### PR TITLE
Fix: preserve chain position across mid-playback kit swaps

### DIFF
--- a/src/core/audio/engine/__tests__/kit-swap-chain.browser.test.ts
+++ b/src/core/audio/engine/__tests__/kit-swap-chain.browser.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Live-playback regression test for issue #241: hot swapping kits must not
+ * reset the variation chain position.
+ *
+ * Offline rendering cannot exercise this (every render builds a fresh
+ * sequence), so this test drives a LIVE engine: real transport, real
+ * AudioContext (unlocked via a trusted click, as headless Chromium's
+ * autoplay policy makes context.resume() hang without user activation),
+ * and a mid-playback loadKit exactly like the bridge issues when the
+ * sample set changes.
+ *
+ * Assertions read the engine's onPlaybackVariationChange emissions, which
+ * fire at sequence creation and at every bar start. Live meters read
+ * silence in this headless harness, so audio levels are not asserted.
+ */
+
+import { getContext } from "tone/build/esm/index";
+import { describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import {
+  makeClickSampleUrl,
+  makeInstrument,
+  makePattern,
+} from "@/test/fixtures";
+import { createFixtureEngine } from "@/test/render";
+
+/** High tempo so bars pass quickly: one bar = 16 * (60/480/4)s = 500ms. */
+const BPM = 480;
+/** Wall-clock duration of one bar at BPM, in milliseconds. */
+const BAR_MS = (60_000 / BPM) * 4;
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const start = performance.now();
+  while (!predicate()) {
+    if (performance.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+describe("kit hot swap during chain playback (issue #241)", () => {
+  it("preserves the chain position across a mid-playback loadKit", async () => {
+    const clickUrl = makeClickSampleUrl();
+    const instruments = [makeInstrument(0, "kick"), makeInstrument(1, "snare")];
+
+    // Chain: one bar of variation A, then sixteen bars of variation B (8s
+    // at 480 bpm, generous slack for slow CI). The kit swap lands inside
+    // the B window; a chain reset would jump back to A immediately, which
+    // was the pre-fix behavior (loadKit recreated the live sequence, whose
+    // chain cursor lives for exactly one sequence lifetime).
+    const engine = await createFixtureEngine({
+      pattern: makePattern({
+        steps: [
+          { voice: 0, step: 0 },
+          ...[0, 4, 8, 12].map((step) => ({
+            voice: 0,
+            step,
+            variation: 1 as const,
+          })),
+        ],
+      }),
+      instruments,
+      sampleUrls: [clickUrl, clickUrl],
+      bpm: BPM,
+      chain: {
+        steps: [
+          { variation: 0, repeats: 1 },
+          { variation: 1, repeats: 8 },
+          { variation: 1, repeats: 8 },
+        ],
+      },
+      chainEnabled: true,
+    });
+
+    const emissions: number[] = [];
+    engine.onPlaybackVariationChange((variation) => emissions.push(variation));
+
+    try {
+      // Trusted user gesture so the AudioContext is allowed to start.
+      await userEvent.click(document.body);
+      await engine.play();
+      expect(getContext().state).toBe("running");
+
+      // Let the chain advance into its variation-B window.
+      await waitFor(
+        () => emissions.includes(1),
+        8000,
+        "the chain to reach variation B",
+      );
+
+      // Hot swap the kit mid-playback (fresh descriptor array, same
+      // samples), exactly like the bridge does when the sample set changes.
+      const emissionCountBeforeSwap = emissions.length;
+      const pathToUrl = new Map(
+        instruments.map((instrument) => [instrument.sample.path, clickUrl]),
+      );
+      await engine.loadKit(
+        instruments.map((instrument) => ({
+          instrumentId: instrument.meta.id,
+          samplePath: instrument.sample.path,
+          role: instrument.role,
+        })),
+        async (path: string) => ({ url: pathToUrl.get(path) ?? path }),
+      );
+
+      // The swap landed: replacement channels are loaded.
+      expect(engine.isChannelReady(0)).toBe(true);
+      expect(engine.isChannelReady(1)).toBe(true);
+
+      // Observe a few more bars, comfortably inside the B window.
+      await new Promise((resolve) => setTimeout(resolve, 2.5 * BAR_MS));
+
+      // Playback must have continued across the swap (bar starts still
+      // fire)...
+      const appended = emissions.slice(emissionCountBeforeSwap);
+      expect(appended.length).toBeGreaterThan(0);
+
+      // ...and every emission from the swap call onward must still be
+      // variation B: no synchronous variation-A emission at swap time (the
+      // reset chain cursor re-announcing chain step 0) and no restarted
+      // chain in the following bars.
+      expect(appended).toEqual(Array(appended.length).fill(1));
+    } finally {
+      engine.stop();
+      engine.dispose();
+    }
+  }, 20000);
+});

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -274,6 +274,11 @@ class AudioEngine {
    * per-channel params. If another loadKit (or dispose) supersedes this call
    * while it is in flight, the orphaned new channels are disposed and the
    * active ones are left untouched.
+   *
+   * During playback the live sequence is deliberately left untouched: the
+   * scheduler reads channels fresh on every step, so it picks up the new
+   * kit on its next step, and recreating the sequence here would reset the
+   * variation chain position (issue #241).
    */
   async loadKit(
     kit: KitSampleDescriptor[],
@@ -325,10 +330,6 @@ class AudioEngine {
         this.continuousParams,
         this.meters,
       );
-
-      if (this.isPlaying) {
-        this.createLiveSequence();
-      }
 
       this.kitLoadedListeners.forEach((listener) => listener());
     } catch (error) {

--- a/src/core/audio/engine/sequencer/sequencer.ts
+++ b/src/core/audio/engine/sequencer/sequencer.ts
@@ -113,7 +113,8 @@ function createPatternSequence(options: PatternSequenceOptions): Sequence {
 
   // Chain playback state lives for exactly one sequence lifetime; live
   // playback recreates the sequence (restarting from the chain's first
-  // step) whenever a new chain is pushed.
+  // step) whenever a new chain is pushed. Kit swaps deliberately do NOT
+  // recreate the sequence, so the chain position survives them (issue #241).
   const chainState: ChainPlaybackState = {
     stepIndex: 0,
     repeatsRemaining: chain.steps[0]?.repeats ?? 1,


### PR DESCRIPTION
Fixes #241.

`loadKit` no longer recreates the live sequence during playback. Post-refactor (#317), the scheduler reads channels, roles, and per-note params fresh on every step, so the recreation was vestigial - its only observable effect was resetting the variation chain to its first step and emitting a spurious variation change mid-bar.

Empirically reproduced before the fix (chain [A x1, B x8]: a mid-playback kit swap emitted A and restarted the chain) and covered by a new live-playback regression test (`kit-swap-chain.browser.test.ts`) asserting chain position and variation emissions survive a hot swap. Full suite: 55/55.