### PR TITLE
chore(audio): small engine cleanups deferred from the refactor review

### DIFF
--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -32,7 +32,11 @@ import {
   STEP_COUNT,
   TRANSPORT_SWING_MAX,
 } from "./constants";
-import { ensureAudioContextIsRunning } from "./context/manager";
+import {
+  ensureAudioContextIsRunning,
+  getAudioContextHealth,
+  type AudioContextHealth,
+} from "./context/manager";
 import {
   InstrumentChannel,
   triggerAllInstrumentsReleaseAtTime,
@@ -92,12 +96,15 @@ interface PlaybackConfig {
 }
 
 /**
- * Read-only transport/context diagnostics for debug displays.
+ * Read-only transport/context diagnostics for debug displays and the
+ * context guards: transport state, the context clock, and the resume
+ * guard's context health, in one snapshot.
  */
 interface EngineDiagnostics {
   transportState: string;
   transportPosition: string;
   contextTime: number;
+  contextHealth: AudioContextHealth;
 }
 
 /**
@@ -379,8 +386,7 @@ class AudioEngine {
     const ohatIndex = roles.indexOf("ohat");
     const anySolos = playParams.some((params) => params?.solo);
 
-    const stepDuration = 60 / bpm / 4; // Duration of one 16th note in seconds
-    const barDuration = options.bars * STEP_COUNT * stepDuration;
+    const barDuration = calculateExportDuration(options.bars, bpm);
     // Add tail for reverb/release decay if requested, otherwise end on the
     // bar line for DAW looping.
     const tailTime = options.includeTail ? EXPORT_TAIL_TIME : 0;
@@ -746,7 +752,8 @@ class AudioEngine {
   }
 
   /**
-   * Read-only transport/context diagnostics for debug displays. Not a
+   * Read-only transport/context diagnostics for debug displays and the
+   * context guards. The engine's single observability surface; not a
    * mutation surface - values are snapshots.
    */
   getDiagnostics(): EngineDiagnostics {
@@ -755,6 +762,7 @@ class AudioEngine {
       transportState: transport.state,
       transportPosition: transport.position.toString(),
       contextTime: getContext().currentTime,
+      contextHealth: getAudioContextHealth(),
     };
   }
 
@@ -851,6 +859,21 @@ class AudioEngine {
 }
 
 // -----------------------------------------------------------------------------
+// Export duration
+// -----------------------------------------------------------------------------
+
+/**
+ * Duration in seconds of a whole-bar render: bars of STEP_COUNT 16th-note
+ * steps at the given bpm. Re-exported through export/wav-exporter so the
+ * export form's duration estimate can never drift from what renderWav
+ * actually renders.
+ */
+function calculateExportDuration(bars: number, bpm: number): number {
+  const stepDuration = 60 / bpm / 4; // Duration of one 16th note in seconds
+  return bars * STEP_COUNT * stepDuration;
+}
+
+// -----------------------------------------------------------------------------
 // Kit channel construction (shared by loadKit and renderWav)
 // -----------------------------------------------------------------------------
 
@@ -923,7 +946,7 @@ function getAudioEngine(): AudioEngine {
   return audioEngine;
 }
 
-export { AudioEngine, getAudioEngine };
+export { AudioEngine, calculateExportDuration, getAudioEngine };
 export type {
   EngineDiagnostics,
   KitSampleDescriptor,

--- a/src/core/audio/engine/context/manager.ts
+++ b/src/core/audio/engine/context/manager.ts
@@ -64,9 +64,14 @@ async function ensureAudioContextIsRunning(
   return health.state === "running";
 }
 
+/**
+ * Read-only snapshot of the resume guard's context health. Folded into the
+ * engine's unified diagnostics surface (AudioEngine.getDiagnostics).
+ */
 function getAudioContextHealth(): AudioContextHealth {
   // Return a shallow copy to avoid accidental mutation
   return { ...health };
 }
 
 export { ensureAudioContextIsRunning, getAudioContextHealth };
+export type { AudioContextHealth };

--- a/src/core/audio/engine/index.ts
+++ b/src/core/audio/engine/index.ts
@@ -10,6 +10,7 @@
 // Facade (live playback, offline rendering, and recovery all go through it)
 export {
   AudioEngine,
+  calculateExportDuration,
   getAudioEngine,
   type EngineDiagnostics,
   type KitSampleDescriptor,
@@ -23,8 +24,8 @@ export type { MasterChainSettings } from "./master-bus";
 // Playback data model
 export type { Pattern, PatternChain, VariationId } from "./pattern-types";
 
-// Audio Context
+// Audio Context (health snapshots are folded into engine.getDiagnostics())
 export {
   ensureAudioContextIsRunning,
-  getAudioContextHealth,
+  type AudioContextHealth,
 } from "./context/manager";

--- a/src/core/audio/engine/master-bus.ts
+++ b/src/core/audio/engine/master-bus.ts
@@ -69,7 +69,7 @@ type MasterChainSettings = {
 interface MasterBusNodes {
   // Compressor section (front of chain with parallel compression)
   compressor: Compressor;
-  compMakeupGain: Gain; // Fixed makeup gain after compressor
+  compMakeupGain: Gain<"decibels">; // Fixed makeup gain after compressor
   compWetGain: Gain; // Controls wet (compressed) signal level
   compDryDelay: Delay; // Compensates for compressor latency
   compDryGain: Gain; // Controls dry (uncompressed) signal level
@@ -302,7 +302,7 @@ function createCompressorSection(settings: MasterChainSettings) {
   });
 
   // Fixed makeup gain compensates for gain reduction (+1.5dB)
-  const compMakeupGain = new Gain(Math.pow(10, MASTER_COMP_MAKEUP_GAIN / 20));
+  const compMakeupGain = new Gain(MASTER_COMP_MAKEUP_GAIN, "decibels");
 
   // Parallel compression wet/dry mix
   const compWetGain = new Gain(settings.compMix);

--- a/src/core/audio/engine/transport/transport.ts
+++ b/src/core/audio/engine/transport/transport.ts
@@ -22,41 +22,39 @@ const liveTransport = getTransport();
 
 /**
  * Start the live transport and all sources synced to it.
- * @param time The time when the transport should start.
- * @param offset The timeline offset to start the transport.
  */
-function startTransport(time?: number, offset?: number): void {
-  liveTransport.start(time, offset);
+function startTransport(): void {
+  liveTransport.start();
 }
 
 /**
  * Stop the live transport and all sources synced to it.
- * @param time The time when the transport should stop.
  */
-function stopTransport(time?: number): void {
-  liveTransport.stop(time);
+function stopTransport(): void {
+  liveTransport.stop();
 }
 
 /**
- * Set the live transport BPM
+ * Set the live transport BPM, preserving the current swing.
  */
 function setTransportBpm(bpm: number): void {
-  liveTransport.bpm.value = bpm;
+  configureTransportTiming(liveTransport, bpm, liveTransport.swing);
 }
 
 /**
- * Set the live transport swing in domain units (0-0.5 Tone swing).
- * Knob-value conversion happens at the boundary in
- * bridge/knob-to-domain.ts (transportSwingKnobToDomain).
+ * Set the live transport swing in domain units (0-0.5 Tone swing),
+ * preserving the current bpm. Knob-value conversion happens at the
+ * boundary in bridge/knob-to-domain.ts (transportSwingKnobToDomain).
  */
 function setTransportSwing(swing: number): void {
-  liveTransport.swingSubdivision = SEQUENCE_SUBDIVISION;
-  liveTransport.swing = swing;
+  configureTransportTiming(liveTransport, liveTransport.bpm.value, swing);
 }
 
 /**
  * Configures transport timing settings from domain values (bpm, 0-0.5 swing).
- * Works with both online (getTransport) and offline transport objects.
+ * Works with both online (getTransport) and offline transport objects, and
+ * is the single assignment point for transport timing - the live setters
+ * above route through it.
  */
 function configureTransportTiming(
   transport: {

--- a/src/core/audio/export/wav-exporter.ts
+++ b/src/core/audio/export/wav-exporter.ts
@@ -1,7 +1,6 @@
 // --- WAV export: offline render via the engine, then encode + download ---
 
 import { getAudioEngine, type PatternChain } from "../engine";
-import { STEP_COUNT } from "../engine/constants";
 import { downloadWav, encodeWav } from "./wav-encoder";
 
 interface ExportOptions {
@@ -60,13 +59,8 @@ function getSuggestedBars(chain: PatternChain, chainEnabled: boolean): number {
   return Math.min(8, recommended);
 }
 
-/**
- * Calculate export duration in seconds
- */
-function calculateExportDuration(bars: number, bpm: number): number {
-  const stepDuration = 60 / bpm / 4;
-  return bars * STEP_COUNT * stepDuration;
-}
-
-export { exportToWav, getSuggestedBars, calculateExportDuration };
+// Duration math lives in the engine next to renderWav; re-exported here so
+// the export form's estimate can never drift from what actually renders.
+export { calculateExportDuration } from "../engine";
+export { exportToWav, getSuggestedBars };
 export type { ExportOptions, ExportProgress };

--- a/src/core/audio/hooks/use-audio-context-guards.ts
+++ b/src/core/audio/hooks/use-audio-context-guards.ts
@@ -1,9 +1,16 @@
 import { useEffect, useRef } from "react";
-import { getContext } from "tone/build/esm/index";
 
 import { getAudioEngine } from "@/core/audio/engine";
 import { useToast } from "@/shared/ui";
 import { ensureAudioContextIsRunning } from "../engine/context/manager";
+
+/**
+ * The guards observe the audio clock through the engine's read-only
+ * diagnostics snapshot instead of reaching into Tone directly.
+ */
+function getContextTime(): number {
+  return getAudioEngine().getDiagnostics().contextTime;
+}
 
 /**
  * Centralized audio context guard:
@@ -35,11 +42,11 @@ function useAudioContextGuards() {
 
     const scheduleChecks = (reason: string) => {
       clearScheduled();
-      const baseline = getContext().currentTime;
+      const baseline = getContextTime();
 
       CHECK_DELAY_MS.forEach((delay, index) => {
         const id = window.setTimeout(async () => {
-          const currentTime = getContext().currentTime;
+          const currentTime = getContextTime();
           const delta = currentTime - baseline;
           const stalled = delta < CTX_DELTA_THRESHOLD;
 
@@ -89,11 +96,11 @@ function useAudioContextGuards() {
           }
           await ensureAudioContextIsRunning(`guards:${reason}:rebuild`);
 
-          const rebuildBaseline = getContext().currentTime;
+          const rebuildBaseline = getContextTime();
           await new Promise((resolve) =>
             window.setTimeout(resolve, REBUILD_RECHECK_DELAY_MS),
           );
-          const rebuildDelta = getContext().currentTime - rebuildBaseline;
+          const rebuildDelta = getContextTime() - rebuildBaseline;
 
           if (rebuildDelta >= CTX_DELTA_THRESHOLD) {
             // The rebuild revived the clock - recovered without a reload.

--- a/src/features/debug/components/debug-overlay.tsx
+++ b/src/features/debug/components/debug-overlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { getAudioContextHealth, getAudioEngine } from "@/core/audio/engine";
+import { getAudioEngine } from "@/core/audio/engine";
 import { useDebugStore } from "@/features/debug/store/use-debug-store";
 
 interface DebugStats {
@@ -66,7 +66,7 @@ const DebugOverlay = () => {
       const position = diagnostics.transportPosition.split(".")[0];
       const audioTime = Math.round(diagnostics.contextTime * 10) / 10;
 
-      const health = getAudioContextHealth();
+      const health = diagnostics.contextHealth;
       const resumedAgoSeconds =
         health.lastResume !== null
           ? Math.max((performance.now() - health.lastResume) / 1000, 0)

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -18,6 +18,11 @@ const FIXTURE_SAMPLE_RATE = 44100;
 /**
  * Neutral instrument knob values: tune centered, full decay, filter centered,
  * unity volume, centered pan.
+ *
+ * Deliberately hand-pinned rather than derived from init(): these are
+ * golden-stability snapshots, so golden renders cannot silently shift when
+ * the app's default preset changes. Any edit here invalidates the golden
+ * baselines - change these values only on purpose.
  */
 const DEFAULT_INSTRUMENT_PARAMS: InstrumentParams = {
   tune: 50,

--- a/src/test/render.ts
+++ b/src/test/render.ts
@@ -40,6 +40,13 @@ const RENDER_TAIL_SECONDS = 0.3;
 /**
  * Neutral master chain knob values: filter centered, all sends off,
  * compressor threshold fully open (minimal compression), unity volume.
+ *
+ * Deliberately hand-pinned rather than derived from init(): these are
+ * golden-stability snapshots, so golden renders cannot silently shift when
+ * the app's default preset changes. compRatio deliberately differs from the
+ * app default (50 here vs init()'s ~57.14) - the golden baselines were
+ * captured against this value. Any edit here invalidates them, so change
+ * these values only on purpose.
  */
 const DEFAULT_MASTER_PARAMS: MasterChainParams = {
   filter: 50,


### PR DESCRIPTION
Closes #322. All five items from the grab bag:

- **transport**: drop the never-used `time`/`offset` params on `startTransport`/`stopTransport`; the live bpm/swing setters now route through `configureTransportTiming`, making it the single assignment point for transport timing
- **export duration**: `calculateExportDuration` moves into the engine next to `renderWav` (the source of truth it must match) and is re-exported through `export/wav-exporter`, removing the duplicated math
- **master bus**: build the makeup gain as `new Gain(dB, "decibels")` instead of hand-rolling `Math.pow(10, dB / 20)` - verified bit-identical in tone 15.5.25 (`Param._fromType` applies the same `dbToGain` formula); the node's gain param is never written after construction, so the unit change has no other observers
- **observability**: `getAudioContextHealth` folds into `engine.getDiagnostics()` as one read-only snapshot surface; the debug overlay and the context guards consume it, and the guards drop their direct Tone import
- **test defaults**: document the fixture/render params as deliberately pinned golden-stability snapshots (compRatio intentionally differs from the app default; the golden baselines were captured against it)

No behavior changes intended anywhere. Gates: 55/55 tests (node + Chromium golden renders), lint, build, and both engine-purity greps clean.