### PR TITLE
chore: extract shared dh-files vite plugin

### DIFF
--- a/dh-files-plugin.ts
+++ b/dh-files-plugin.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import type { Plugin } from "vite";
+
+/**
+ * Loads .dh and .dhkit files (presets/kits stored as JSON) as ES modules.
+ *
+ * Shared by vite.config.ts and vitest.config.ts - vitest intentionally does
+ * not import the app's vite config (its react-compiler babel and tailwind
+ * plugins are unnecessary for tests), so this plugin lives in its own file
+ * to keep the two configs from drifting.
+ */
+function dhFilesPlugin(): Plugin {
+  return {
+    name: "dh-files-loader",
+    transform(_code, id) {
+      if (id.endsWith(".dhkit") || id.endsWith(".dh")) {
+        const content = readFileSync(id, "utf-8");
+        return {
+          code: `export default ${content}`,
+          map: null,
+          moduleType: "js",
+        };
+      }
+    },
+  };
+}
+
+export { dhFilesPlugin };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "vite.config.ts", "dh-files-plugin.ts"],
   "exclude": ["node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { execSync } from "child_process";
-import { readFileSync } from "fs";
 import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
-import { defineConfig, Plugin } from "vite";
+import { defineConfig } from "vite";
+
+import { dhFilesPlugin } from "./dh-files-plugin";
 
 // Build-time metadata helpers
 const getGitHash = () => {
@@ -16,23 +17,6 @@ const getGitHash = () => {
 
 const appVersion = getGitHash();
 const nodeVersion = process.version;
-
-// Custom plugin to handle .dh and .dhkit files as JSON
-function dhFilesPlugin(): Plugin {
-  return {
-    name: "dh-files-loader",
-    transform(_code, id) {
-      if (id.endsWith(".dhkit") || id.endsWith(".dh")) {
-        const content = readFileSync(id, "utf-8");
-        return {
-          code: `export default ${content}`,
-          map: null,
-          moduleType: "js",
-        };
-      }
-    },
-  };
-}
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,27 +1,7 @@
-import { readFileSync } from "node:fs";
 import { playwright } from "@vitest/browser-playwright";
-import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
 
-// Minimal mirror of the dh-files plugin in vite.config.ts so modules that
-// import .dh/.dhkit files (e.g. the instruments store's default kit) can load
-// in tests. We intentionally do not import the app's vite.config.ts because
-// its react-compiler babel and tailwind plugins are unnecessary for tests.
-function dhFilesPlugin(): Plugin {
-  return {
-    name: "dh-files-loader",
-    transform(_code, id) {
-      if (id.endsWith(".dhkit") || id.endsWith(".dh")) {
-        const content = readFileSync(id, "utf-8");
-        return {
-          code: `export default ${content}`,
-          map: null,
-          moduleType: "js",
-        };
-      }
-    },
-  };
-}
+import { dhFilesPlugin } from "./dh-files-plugin";
 
 export default defineConfig({
   plugins: [dhFilesPlugin()],


### PR DESCRIPTION
vite.config.ts and vitest.config.ts each carried an identical copy of `dhFilesPlugin` (the vitest one a deliberate mirror, with a comment explaining why it can't import the app config). The plugin now lives in its own `dh-files-plugin.ts` imported by both configs, with that rationale preserved in its doc comment, so the loader can't drift between app builds and tests.

Also adds the new file to the tsconfig `include` (only `vite.config.ts` was type-checked at the root before).

Gates locally: format, lint, build, 55/55 tests.