### PR TITLE
feat(audio): instrument rebuild-recovery tiers for idle-tab silence

### DIFF
--- a/docs/audio-engine-refactor.md
+++ b/docs/audio-engine-refactor.md
@@ -205,6 +205,15 @@ Three refuted candidates validated the architecture: the scheduler's fresh per-s
 
 Open follow-up: the first-hit attenuation quirk (see above) remains unfixed by design; investigate after the refactor settles.
 
+### Recovery instrumentation (issue #319)
+
+The rebuild recovery path shipped without real-world evidence of which tier actually fires, so the context guards now count every tier: eager resume attempts and successes, stall detections, rebuild attempts, rebuild successes (clock revived), rebuild timeouts, and reload fallbacks.
+The counters live in `src/core/audio/hooks/recovery-stats.ts` (outside `engine/`, preserving engine purity) and the guards hook records events around its existing branches without touching the recovery logic.
+They persist in localStorage under `drumhaus-audio-recovery-stats` as a small versioned JSON object (`{ version, counters, lastEventAt }`); the reload counter is incremented before the navigation so the otherwise-invisible reload tier survives its own reload.
+Storage access is fully guarded: private-browsing or storage-denied modes degrade counting to a no-op while recovery proceeds unchanged.
+To read the counters when reproducing the idle-tab scenario: enable Debug Mode from the floating menu, background the tab for 10+ minutes, return and interact, and check the Resume, Stalls, Rebuild, Timeouts, and Reloads rows in the overlay (Resume and Rebuild show success/attempt pairs).
+The manual Chrome/Safari validation and any threshold tuning remain open on #319 pending the evidence these counters collect.
+
 ## Expected outcome
 
 `core/audio` stays around its current size (~2,600 lines) but becomes strictly one-directional and testable.

--- a/src/core/audio/hooks/recovery-stats.test.ts
+++ b/src/core/audio/hooks/recovery-stats.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for the recovery-tier counters (issue #319): increments and
+ * persistence shape, versioned resets, and storage-failure tolerance -
+ * counting must fail silent so recovery still runs without storage.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getRecoveryStats,
+  recordRecoveryEvent,
+  RECOVERY_STATS_STORAGE_KEY,
+} from "./recovery-stats";
+
+/** In-memory Web Storage stub; returns the backing map for assertions. */
+function stubStorage(
+  initial: Record<string, string> = {},
+): Map<string, string> {
+  const store = new Map(Object.entries(initial));
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  });
+  return store;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("recovery stats", () => {
+  it("starts zeroed when nothing is persisted", () => {
+    stubStorage();
+
+    const stats = getRecoveryStats();
+
+    expect(Object.values(stats.counters)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+    expect(stats.lastEventAt).toEqual({});
+  });
+
+  it("increments counters and persists a versioned payload", () => {
+    const store = stubStorage();
+
+    recordRecoveryEvent("stallDetected");
+    recordRecoveryEvent("rebuildAttempt");
+    recordRecoveryEvent("rebuildAttempt");
+
+    const stats = getRecoveryStats();
+    expect(stats.counters.stallDetected).toBe(1);
+    expect(stats.counters.rebuildAttempt).toBe(2);
+    expect(stats.lastEventAt.rebuildAttempt).toBeTypeOf("number");
+
+    const persisted = JSON.parse(store.get(RECOVERY_STATS_STORAGE_KEY)!);
+    expect(persisted.version).toBe(1);
+    expect(persisted.counters.rebuildAttempt).toBe(2);
+  });
+
+  it("fills in counters missing from an older same-version payload", () => {
+    stubStorage({
+      [RECOVERY_STATS_STORAGE_KEY]: JSON.stringify({
+        version: 1,
+        counters: { reloadFallback: 3 },
+      }),
+    });
+
+    const stats = getRecoveryStats();
+
+    expect(stats.counters.reloadFallback).toBe(3);
+    expect(stats.counters.rebuildAttempt).toBe(0);
+  });
+
+  it("resets on version mismatch and on corrupt payloads", () => {
+    stubStorage({
+      [RECOVERY_STATS_STORAGE_KEY]: JSON.stringify({
+        version: 0,
+        counters: { reloadFallback: 9 },
+      }),
+    });
+    expect(getRecoveryStats().counters.reloadFallback).toBe(0);
+
+    stubStorage({ [RECOVERY_STATS_STORAGE_KEY]: "not json" });
+    expect(getRecoveryStats().counters.reloadFallback).toBe(0);
+  });
+
+  it("fails silent when storage throws or is missing entirely", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    });
+    expect(() => recordRecoveryEvent("reloadFallback")).not.toThrow();
+    expect(getRecoveryStats().counters.reloadFallback).toBe(0);
+
+    vi.stubGlobal("localStorage", undefined);
+    expect(() => recordRecoveryEvent("reloadFallback")).not.toThrow();
+    expect(getRecoveryStats().counters.reloadFallback).toBe(0);
+  });
+});

--- a/src/core/audio/hooks/recovery-stats.ts
+++ b/src/core/audio/hooks/recovery-stats.ts
@@ -1,0 +1,110 @@
+/**
+ * Recovery-tier instrumentation for the idle-tab silence bug (issue #319).
+ *
+ * The context guards escalate resume -> rebuild -> reload; these counters
+ * record which tier actually fires in the wild. They persist in
+ * localStorage so the reload fallback (which would otherwise erase its own
+ * evidence) survives, and the debug overlay is the read surface - there is
+ * no analytics backend.
+ *
+ * Counting must never break recovery: every storage access is guarded, so
+ * private-browsing/storage-denied modes degrade counting to a no-op.
+ */
+
+const RECOVERY_STATS_STORAGE_KEY = "drumhaus-audio-recovery-stats";
+const RECOVERY_STATS_VERSION = 1;
+
+/** One countable step of the guards' recovery escalation. */
+type RecoveryEvent =
+  | "resumeAttempt" // eager ensure ran (visibility/focus/gesture, throttled)
+  | "resumeSuccess" // eager ensure left the context running
+  | "stallDetected" // a scheduled check found the context clock stalled
+  | "rebuildAttempt" // still stalled after resume; in-place rebuild started
+  | "rebuildSuccess" // the rebuild revived the clock
+  | "rebuildTimeout" // the rebuild hit its timeout bound
+  | "reloadFallback"; // last resort: page reload triggered
+
+type RecoveryCounters = Record<RecoveryEvent, number>;
+
+interface RecoveryStats {
+  version: number;
+  counters: RecoveryCounters;
+  /** Epoch ms of the most recent occurrence of each event. */
+  lastEventAt: Partial<Record<RecoveryEvent, number>>;
+}
+
+function emptyRecoveryCounters(): RecoveryCounters {
+  return {
+    resumeAttempt: 0,
+    resumeSuccess: 0,
+    stallDetected: 0,
+    rebuildAttempt: 0,
+    rebuildSuccess: 0,
+    rebuildTimeout: 0,
+    reloadFallback: 0,
+  };
+}
+
+function emptyRecoveryStats(): RecoveryStats {
+  return {
+    version: RECOVERY_STATS_VERSION,
+    counters: emptyRecoveryCounters(),
+    lastEventAt: {},
+  };
+}
+
+/**
+ * Reads the persisted stats. Missing, corrupt, or version-mismatched
+ * payloads fall back to zeroed counters; unknown keys are dropped and
+ * missing ones read as zero.
+ */
+function getRecoveryStats(): RecoveryStats {
+  try {
+    const raw = globalThis.localStorage.getItem(RECOVERY_STATS_STORAGE_KEY);
+    if (!raw) return emptyRecoveryStats();
+
+    const parsed = JSON.parse(raw) as Partial<RecoveryStats> | null;
+    if (!parsed || parsed.version !== RECOVERY_STATS_VERSION) {
+      return emptyRecoveryStats();
+    }
+
+    const stats = emptyRecoveryStats();
+    for (const event of Object.keys(stats.counters) as RecoveryEvent[]) {
+      const count = parsed.counters?.[event];
+      if (typeof count === "number") stats.counters[event] = count;
+      const at = parsed.lastEventAt?.[event];
+      if (typeof at === "number") stats.lastEventAt[event] = at;
+    }
+    return stats;
+  } catch {
+    return emptyRecoveryStats();
+  }
+}
+
+/**
+ * Increments one counter and stamps its last-occurrence time, writing
+ * through to localStorage synchronously - the reloadFallback increment must
+ * land before the navigation that immediately follows it. Fail-silent:
+ * counting is best-effort and recovery proceeds even without storage.
+ */
+function recordRecoveryEvent(event: RecoveryEvent): void {
+  try {
+    const stats = getRecoveryStats();
+    stats.counters[event] += 1;
+    stats.lastEventAt[event] = Date.now();
+    globalThis.localStorage.setItem(
+      RECOVERY_STATS_STORAGE_KEY,
+      JSON.stringify(stats),
+    );
+  } catch {
+    // Storage unavailable; drop the count rather than disturb recovery.
+  }
+}
+
+export {
+  emptyRecoveryCounters,
+  getRecoveryStats,
+  RECOVERY_STATS_STORAGE_KEY,
+  recordRecoveryEvent,
+};
+export type { RecoveryCounters, RecoveryEvent, RecoveryStats };

--- a/src/core/audio/hooks/use-audio-context-guards.ts
+++ b/src/core/audio/hooks/use-audio-context-guards.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { getAudioEngine } from "@/core/audio/engine";
 import { useToast } from "@/shared/ui";
 import { ensureAudioContextIsRunning } from "../engine/context/manager";
+import { recordRecoveryEvent } from "./recovery-stats";
 
 /**
  * The guards observe the audio clock through the engine's read-only
@@ -18,6 +19,8 @@ function getContextTime(): number {
  * - detects stalled clocks, rebuilds the audio graph in place, and only
  *   reloads the page if the in-place rebuild fails to revive the clock
  * - notifies user when a reload was triggered due to recovery failure
+ * - counts each recovery tier (recovery-stats) so real sessions reveal
+ *   which path fires; the debug overlay surfaces the counters
  */
 function useAudioContextGuards() {
   const { toast } = useToast();
@@ -55,8 +58,11 @@ function useAudioContextGuards() {
             return;
           }
 
-          // First check: try to resume
+          // First check: try to resume. Counted once per stall episode -
+          // a stall at the second check implies one here (same baseline,
+          // monotonic clock), so this never undercounts escalations.
           if (index === 0) {
+            recordRecoveryEvent("stallDetected");
             recoveryAttemptsRef.current += 1;
             await ensureAudioContextIsRunning(`guards:${reason}`);
             return;
@@ -74,6 +80,7 @@ function useAudioContextGuards() {
             return;
           }
 
+          recordRecoveryEvent("rebuildAttempt");
           try {
             // Bound the rebuild attempt: a rebuild that hangs (e.g. on a
             // sample fetch that never settles) must not block the
@@ -87,6 +94,7 @@ function useAudioContextGuards() {
               ),
             ]);
             if (timedOut) {
+              recordRecoveryEvent("rebuildTimeout");
               console.warn(
                 "[audio-guards] In-place rebuild timed out; falling back to re-measure",
               );
@@ -104,6 +112,7 @@ function useAudioContextGuards() {
 
           if (rebuildDelta >= CTX_DELTA_THRESHOLD) {
             // The rebuild revived the clock - recovered without a reload.
+            recordRecoveryEvent("rebuildSuccess");
             recoveryAttemptsRef.current = 0;
             return;
           }
@@ -114,7 +123,9 @@ function useAudioContextGuards() {
             return;
           }
 
-          // Still stalled: reload as last resort
+          // Still stalled: reload as last resort. Counted BEFORE the
+          // navigation so the otherwise-invisible reload tier survives it.
+          recordRecoveryEvent("reloadFallback");
           reloadTriggeredRef.current = true;
           // Add URL parameter to notify user after reload
           const url = new URL(window.location.href);
@@ -132,8 +143,10 @@ function useAudioContextGuards() {
         return;
       }
       ensureThrottleRef.current = now;
+      recordRecoveryEvent("resumeAttempt");
       void ensureAudioContextIsRunning(reason).then((running) => {
         if (running) {
+          recordRecoveryEvent("resumeSuccess");
           hasStartedOnce = true;
           recoveryAttemptsRef.current = 0;
         }

--- a/src/features/debug/components/debug-overlay.tsx
+++ b/src/features/debug/components/debug-overlay.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 
 import { getAudioEngine } from "@/core/audio/engine";
+import {
+  emptyRecoveryCounters,
+  getRecoveryStats,
+  type RecoveryCounters,
+} from "@/core/audio/hooks/recovery-stats";
 import { useDebugStore } from "@/features/debug/store/use-debug-store";
 
 interface DebugStats {
@@ -11,6 +16,7 @@ interface DebugStats {
   audioTime: number;
   audioState: string;
   resumedAgoSeconds: number | null;
+  recovery: RecoveryCounters;
 }
 
 const DebugOverlay = () => {
@@ -23,6 +29,7 @@ const DebugOverlay = () => {
     audioTime: 0,
     audioState: "unknown",
     resumedAgoSeconds: null,
+    recovery: emptyRecoveryCounters(),
   });
 
   const frameTimesRef = useRef<number[]>([]);
@@ -72,6 +79,9 @@ const DebugOverlay = () => {
           ? Math.max((performance.now() - health.lastResume) / 1000, 0)
           : null;
 
+      // Recovery-tier counters persisted by the context guards (issue #319)
+      const recovery = getRecoveryStats().counters;
+
       setStats({
         fps,
         heapMB,
@@ -80,6 +90,7 @@ const DebugOverlay = () => {
         audioTime,
         audioState: health.state,
         resumedAgoSeconds,
+        recovery,
       });
       animationId = requestAnimationFrame(updateStats);
     };
@@ -129,6 +140,31 @@ const DebugOverlay = () => {
             <span>{stats.resumedAgoSeconds.toFixed(1)}s ago</span>
           </div>
         )}
+        {/* Recovery tiers: success/attempt pairs, then escalation counts */}
+        <div className="flex justify-between gap-4">
+          <span className="opacity-70">Resume</span>
+          <span>
+            {stats.recovery.resumeSuccess}/{stats.recovery.resumeAttempt}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="opacity-70">Stalls</span>
+          <span>{stats.recovery.stallDetected}</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="opacity-70">Rebuild</span>
+          <span>
+            {stats.recovery.rebuildSuccess}/{stats.recovery.rebuildAttempt}
+          </span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="opacity-70">Timeouts</span>
+          <span>{stats.recovery.rebuildTimeout}</span>
+        </div>
+        <div className="flex justify-between gap-4">
+          <span className="opacity-70">Reloads</span>
+          <span>{stats.recovery.reloadFallback}</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Refs #319 (instrumentation half; the manual Chrome/Safari idle-tab validation and any threshold tuning stay open on the issue pending the evidence this collects).

The context guards now count every recovery tier so real sessions reveal which path fires in the wild:

- **resume** attempts/successes (the eager, throttled `ensureAudioContextIsRunning` path)
- **stall detections** (once per stall episode)
- **rebuild** attempts, successes (clock revived), and timeout escalations
- **reload fallbacks** - counted BEFORE the navigation, and persisted in localStorage, so the tier that erases its own evidence still shows up afterward

Counters live in `src/core/audio/hooks/recovery-stats.ts` (outside `engine/`, purity preserved) under one versioned localStorage key (`drumhaus-audio-recovery-stats`); corrupt/missing/version-mismatched payloads zero out, and every storage access is guarded so private-browsing modes degrade counting to a silent no-op while recovery runs unchanged. The debug overlay surfaces the five rows in its existing poll loop. The recovery logic itself is untouched - the guards diff is counting calls around existing branches only.

Docs: new "Recovery instrumentation" subsection in the execution notes with the schema and the repro read-out procedure.

Gates: 60/60 tests (5 new unit tests: persistence shape, corrupt-payload reset, storage-failure tolerance), lint, build, both purity greps clean.