### PR TITLE
refactor(audio): consolidate bridge change detection on zustand/shallow

### DIFF
--- a/src/core/audio/bridge/instrument-params.ts
+++ b/src/core/audio/bridge/instrument-params.ts
@@ -8,6 +8,8 @@
  *   by the scheduler on every trigger
  */
 
+import { shallow } from "zustand/shallow";
+
 import type { AudioEngine } from "@/core/audio/engine/audio-engine";
 import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
 import type { InstrumentParams } from "@/features/instrument/types/instrument";
@@ -42,39 +44,28 @@ function subscribeInstrumentParamsToEngine(engine: AudioEngine): () => void {
   const prevPlay: (PlayKnobParams | undefined)[] = [];
 
   const pushIfChanged = (index: number, params: InstrumentParams) => {
-    const continuous = prevContinuous[index];
-    if (
-      !continuous ||
-      continuous.filter !== params.filter ||
-      continuous.pan !== params.pan ||
-      continuous.volume !== params.volume
-    ) {
+    const continuous: ContinuousKnobParams = {
+      filter: params.filter,
+      pan: params.pan,
+      volume: params.volume,
+    };
+    if (!shallow(prevContinuous[index], continuous)) {
       engine.setChannelContinuousParams(
         index,
         instrumentKnobsToContinuousParams(params),
       );
-      prevContinuous[index] = {
-        filter: params.filter,
-        pan: params.pan,
-        volume: params.volume,
-      };
+      prevContinuous[index] = continuous;
     }
 
-    const play = prevPlay[index];
-    if (
-      !play ||
-      play.tune !== params.tune ||
-      play.decay !== params.decay ||
-      play.mute !== params.mute ||
-      play.solo !== params.solo
-    ) {
+    const play: PlayKnobParams = {
+      tune: params.tune,
+      decay: params.decay,
+      mute: params.mute,
+      solo: params.solo,
+    };
+    if (!shallow(prevPlay[index], play)) {
       engine.setChannelPlayParams(index, instrumentKnobsToPlayParams(params));
-      prevPlay[index] = {
-        tune: params.tune,
-        decay: params.decay,
-        mute: params.mute,
-        solo: params.solo,
-      };
+      prevPlay[index] = play;
     }
   };
 

--- a/src/core/audio/bridge/kit-descriptors.test.ts
+++ b/src/core/audio/bridge/kit-descriptors.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the kit descriptor mapping and the early-exit tuple compare
+ * that keys kit reloads in the bridge.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { InstrumentRole } from "@/core/audio/engine/instrument/types";
+import type { InstrumentData } from "@/features/instrument/types/instrument";
+import {
+  kitDescriptorsChanged,
+  toKitSampleDescriptors,
+} from "./kit-descriptors";
+
+function makeInstrument(
+  id: string,
+  path: string,
+  role: InstrumentRole,
+): InstrumentData {
+  return {
+    meta: { id, name: id },
+    role,
+    sample: { meta: { id: `${id}-sample`, name: path }, path },
+    params: {
+      decay: 50,
+      filter: 50,
+      volume: 80,
+      pan: 50,
+      tune: 50,
+      solo: false,
+      mute: false,
+    },
+  };
+}
+
+const instruments = [
+  makeInstrument("kick-a", "kicks/a.wav", "kick"),
+  makeInstrument("hat-a", "hats/a.wav", "hat"),
+];
+
+describe("toKitSampleDescriptors", () => {
+  it("maps instrument id, sample path, and role per slot", () => {
+    expect(toKitSampleDescriptors(instruments)).toEqual([
+      { instrumentId: "kick-a", samplePath: "kicks/a.wav", role: "kick" },
+      { instrumentId: "hat-a", samplePath: "hats/a.wav", role: "hat" },
+    ]);
+  });
+});
+
+describe("kitDescriptorsChanged", () => {
+  const kit = toKitSampleDescriptors(instruments);
+
+  it("reports no change for the same descriptor tuples", () => {
+    expect(kitDescriptorsChanged(kit, instruments)).toBe(false);
+  });
+
+  it("ignores params-only changes (knob drags)", () => {
+    const tweaked = instruments.map((instrument) => ({
+      ...instrument,
+      params: { ...instrument.params, volume: 30 },
+    }));
+    expect(kitDescriptorsChanged(kit, tweaked)).toBe(false);
+  });
+
+  it("detects a role-only change", () => {
+    const rechoked = [
+      instruments[0],
+      { ...instruments[1], role: "ohat" as const },
+    ];
+    expect(kitDescriptorsChanged(kit, rechoked)).toBe(true);
+  });
+
+  it("detects an instrument id change without a path change", () => {
+    const renamed = [
+      { ...instruments[0], meta: { id: "kick-b", name: "kick-b" } },
+      instruments[1],
+    ];
+    expect(kitDescriptorsChanged(kit, renamed)).toBe(true);
+  });
+
+  it("detects a sample path change", () => {
+    const swapped = [
+      instruments[0],
+      makeInstrument("hat-a", "hats/b.wav", "hat"),
+    ];
+    expect(kitDescriptorsChanged(kit, swapped)).toBe(true);
+  });
+
+  it("detects added and removed instruments", () => {
+    expect(kitDescriptorsChanged(kit, instruments.slice(0, 1))).toBe(true);
+    expect(
+      kitDescriptorsChanged(kit, [
+        ...instruments,
+        makeInstrument("perc-a", "percs/a.wav", "perc"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("distinguishes paths a comma-joined string key would conflate", () => {
+    // "a,b" + "c" and "a" + "b,c" both join to "a,b,c"
+    const kitWithComma = toKitSampleDescriptors([
+      makeInstrument("one", "a,b", "kick"),
+      makeInstrument("two", "c", "hat"),
+    ]);
+    const conflated = [
+      makeInstrument("one", "a", "kick"),
+      makeInstrument("two", "b,c", "hat"),
+    ];
+    expect(kitDescriptorsChanged(kitWithComma, conflated)).toBe(true);
+  });
+});

--- a/src/core/audio/bridge/kit-descriptors.ts
+++ b/src/core/audio/bridge/kit-descriptors.ts
@@ -1,0 +1,45 @@
+/**
+ * InstrumentData -> KitSampleDescriptor boundary mapping.
+ *
+ * The engine loads kits from descriptor tuples (instrumentId, samplePath,
+ * role); this is the one place the store-facing instrument model maps to
+ * them, shared by the bridge and the golden-render fixture.
+ */
+
+import type { KitSampleDescriptor } from "@/core/audio/engine";
+import type { InstrumentData } from "@/features/instrument/types/instrument";
+
+/**
+ * Maps instruments to the descriptor tuples engine.loadKit consumes.
+ */
+function toKitSampleDescriptors(
+  instruments: InstrumentData[],
+): KitSampleDescriptor[] {
+  return instruments.map((instrument) => ({
+    instrumentId: instrument.meta.id,
+    samplePath: instrument.sample.path,
+    role: instrument.role,
+  }));
+}
+
+/**
+ * Whether the instruments' descriptor tuples differ from the loaded kit.
+ * Early-exits on the first differing field, so params-only store updates
+ * (knob drags) compare equal without mapping or string building.
+ */
+function kitDescriptorsChanged(
+  kit: KitSampleDescriptor[],
+  instruments: InstrumentData[],
+): boolean {
+  return (
+    kit.length !== instruments.length ||
+    instruments.some(
+      (instrument, index) =>
+        instrument.meta.id !== kit[index].instrumentId ||
+        instrument.sample.path !== kit[index].samplePath ||
+        instrument.role !== kit[index].role,
+    )
+  );
+}
+
+export { kitDescriptorsChanged, toKitSampleDescriptors };

--- a/src/core/audio/bridge/use-engine-bridge.ts
+++ b/src/core/audio/bridge/use-engine-bridge.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { shallow } from "zustand/shallow";
 
 import { getAudioEngine } from "@/core/audio/engine";
 import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
@@ -10,14 +11,11 @@ import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
 import { useAudioContextGuards } from "../hooks/use-audio-context-guards";
 import { subscribeInstrumentParamsToEngine } from "./instrument-params";
+import {
+  kitDescriptorsChanged,
+  toKitSampleDescriptors,
+} from "./kit-descriptors";
 import { mapParamsToSettings, type MasterChainParams } from "./knob-to-domain";
-
-/**
- * Shallow-compares two objects field by field.
- */
-function shallowEqual<T extends object>(a: T, b: T): boolean {
-  return (Object.keys(a) as (keyof T)[]).every((key) => a[key] === b[key]);
-}
 
 /**
  * The bridge between the Zustand stores and the AudioEngine facade.
@@ -31,10 +29,6 @@ function shallowEqual<T extends object>(a: T, b: T): boolean {
 function useEngineBridge(): void {
   // Guard and recover audio context automatically (visibility/gestures/stall)
   useAudioContextGuards();
-
-  const instrumentSamplePaths = useInstrumentsStore((state) =>
-    state.instruments.map((inst) => inst.sample.path).join(","),
-  );
 
   // Engine lifecycle + store wiring (store subscriptions -> engine commands)
   useEffect(() => {
@@ -64,17 +58,14 @@ function useEngineBridge(): void {
     engine.setPlayback(prevPlayback);
     unsubscribers.push(
       usePatternStore.subscribe((state) => {
-        if (
-          state.chain !== prevPlayback.chain ||
-          state.chainEnabled !== prevPlayback.chainEnabled ||
-          state.variation !== prevPlayback.variation
-        ) {
-          prevPlayback = {
-            chain: state.chain,
-            chainEnabled: state.chainEnabled,
-            variation: state.variation,
-          };
-          engine.setPlayback(prevPlayback);
+        const playback = {
+          chain: state.chain,
+          chainEnabled: state.chainEnabled,
+          variation: state.variation,
+        };
+        if (!shallow(prevPlayback, playback)) {
+          prevPlayback = playback;
+          engine.setPlayback(playback);
         }
       }),
     );
@@ -82,12 +73,30 @@ function useEngineBridge(): void {
     // --- Instrument params (continuous + play params, knob -> domain) ---
     unsubscribers.push(subscribeInstrumentParamsToEngine(engine));
 
+    // --- Kit (keyed on the full id / path / role descriptor tuples) ---
+    let prevKit = toKitSampleDescriptors(
+      useInstrumentsStore.getState().instruments,
+    );
+    if (prevKit.length > 0) {
+      void engine.loadKit(prevKit);
+    }
+    unsubscribers.push(
+      useInstrumentsStore.subscribe((state) => {
+        if (kitDescriptorsChanged(prevKit, state.instruments)) {
+          prevKit = toKitSampleDescriptors(state.instruments);
+          if (prevKit.length > 0) {
+            void engine.loadKit(prevKit);
+          }
+        }
+      }),
+    );
+
     // --- Master chain ---
     let prevMasterParams: MasterChainParams | null = null;
     unsubscribers.push(
       useMasterChainStore.subscribe(() => {
         const params = getMasterChainParams();
-        if (prevMasterParams && shallowEqual(prevMasterParams, params)) {
+        if (prevMasterParams && shallow(prevMasterParams, params)) {
           return;
         }
         prevMasterParams = params;
@@ -122,22 +131,6 @@ function useEngineBridge(): void {
       engine.dispose();
     };
   }, []);
-
-  // Load the kit whenever the sample set changes
-  useEffect(() => {
-    if (instrumentSamplePaths.length === 0) {
-      return;
-    }
-
-    const instruments = useInstrumentsStore.getState().instruments;
-    void getAudioEngine().loadKit(
-      instruments.map((instrument) => ({
-        instrumentId: instrument.meta.id,
-        samplePath: instrument.sample.path,
-        role: instrument.role,
-      })),
-    );
-  }, [instrumentSamplePaths]);
 }
 
 export { useEngineBridge };

--- a/src/test/render.ts
+++ b/src/test/render.ts
@@ -15,6 +15,7 @@
 
 import { getContext } from "tone/build/esm/index";
 
+import { toKitSampleDescriptors } from "@/core/audio/bridge/kit-descriptors";
 import {
   instrumentKnobsToContinuousParams,
   instrumentKnobsToPlayParams,
@@ -143,11 +144,7 @@ async function createFixtureEngine(
     engine.setSwing(transportSwingKnobToDomain(swing));
 
     await engine.loadKit(
-      instruments.map((instrument) => ({
-        instrumentId: instrument.meta.id,
-        samplePath: instrument.sample.path,
-        role: instrument.role,
-      })),
+      toKitSampleDescriptors(instruments),
       resolveSampleSource,
     );
 


### PR DESCRIPTION
Closes #321. All three tasks:

- **One change-detection idiom**: the local one-sided `shallowEqual` and the per-field diff lists in `instrument-params.ts` are gone; the bridge compares picked snapshot objects with `zustand/shallow` everywhere (the single-reference pattern compare stays a reference check - wrapping one reference in `shallow` would be noise). `shallow(undefined, next)` is false, so first-push semantics are unchanged.
- **Kit reloads keyed on the full descriptor tuple**: the render-time comma-joined path selector and its separate effect are replaced by a store subscription inside the main wiring effect with an early-exit (id, path, role) tuple compare. Role/id changes without a path change now trigger reloads, comma-containing paths can't conflate keys, knob drags no longer pay map/join churn or re-render the bridge host, and descriptors are only re-mapped when a change is detected.
- **One `InstrumentData -> KitSampleDescriptor` helper**: new `bridge/kit-descriptors.ts`, used by the bridge and by `createFixtureEngine` (which duplicated the mapping verbatim). Type-only imports keep the unit test in the node project.

8 new unit tests cover the compare: mapping correctness, params-only updates staying quiet, role/id/path/length changes triggering, and the comma-conflation case (`["a,b","c"]` vs `["a","b,c"]`) that the joined string got wrong.

One micro-corner documented from review: a single instrument with an empty `sample.path` previously joined to `""` and skipped loading; the guard is now "no instruments". No app state produces empty paths.

Gates: 63/63 tests, lint, build, both engine-purity greps clean.