### PR TITLE
fix(audio): pre-roll offline renders past the compressor warm-up

### DIFF
--- a/docs/audio-engine-refactor.md
+++ b/docs/audio-engine-refactor.md
@@ -60,9 +60,9 @@ They must be kept in sync by hand for exports to match live playback.
 - `scheduleVoiceCore` reads `getTransport().bpm` (the live transport) for nudge and ratchet conversion even during offline rendering, because `Offline` restores the global context before the render completes.
   Exports only sound correct because the app happens to keep the live transport bpm in sync with the store.
   Phase 3's pushed snapshots should carry bpm so scheduling never reads the live transport.
-- The first hit of any offline render peaks deterministically about 46% lower than steady state (envelope spin-up at t=0).
-  This plausibly affects the first hit of WAV exports audibly.
-  Not fixed during the behavior-preserving phases; revisit after phase 5.
+- The first hit of any offline render used to peak deterministically about 46% lower than steady state.
+  The original "envelope spin-up at t=0" attribution was wrong: measurement traced it to Chromium's DynamicsCompressorNode startup transient, which slews its internal gain up to unity over the first ~100ms of a fresh context (issue #318).
+  Fixed by renderWav's 200ms pre-roll (`EXPORT_PREROLL_TIME`): the transport starts past the warm-up and the pre-roll is sliced off, so exports begin on the bar line at full amplitude; step-0 flam graces and negative nudges land inside the pre-roll and are trimmed.
 
 ## Target architecture
 
@@ -203,7 +203,7 @@ After phase 5, an adversarial review wave (8 finder angles, one verifier per ded
 The most consequential: negative trigger times crashing WAV export for step-0 flams/nudges, missing supersession on init/rebuild concurrency (duplicate master bus), failed kit loads poisoning retained descriptors, and an unbounded rebuild await ahead of the reload fallback.
 Three refuted candidates validated the architecture: the scheduler's fresh per-step reads make loadKit/rebuild interleavings safe by construction.
 
-Open follow-up: the first-hit attenuation quirk (see above) remains unfixed by design; investigate after the refactor settles.
+The first-hit attenuation quirk (see above) was left unfixed through the behavior-preserving phases by design; issue #318 diagnosed and fixed it afterward via the render pre-roll.
 
 ### Recovery instrumentation (issue #319)
 

--- a/src/core/audio/engine/__tests__/golden-render.browser.test.ts
+++ b/src/core/audio/engine/__tests__/golden-render.browser.test.ts
@@ -8,9 +8,11 @@
  * interface is the stable contract; only its internals change per phase.
  *
  * NOTE on timing: the master chain delays the dry path by 6ms
- * (MASTER_COMP_LATENCY) to match the compressor's lookahead, so absolute
- * onset times include a small constant offset. All assertions therefore use
- * DELTAS between onsets, or compare two renders against each other.
+ * (MASTER_COMP_LATENCY) to match the compressor's lookahead, and the
+ * always-in-line limiter adds its own ~6ms of lookahead, so absolute onset
+ * times include a small constant offset (~12ms measured). All assertions
+ * therefore use DELTAS between onsets, or compare two renders against each
+ * other.
  */
 
 import { beforeAll, describe, expect, it } from "vitest";
@@ -229,56 +231,92 @@ describe("golden render: timing nudge", () => {
   });
 });
 
-describe("golden render: step-0 time clamping", () => {
-  it("renders a step-0 flam plus a negatively nudged step-0 hit", async () => {
-    // Voice 0 flams step 0 (grace note would land at -15ms) and plays a
-    // plain hit on step 4. Voice 1 has timing nudge -2 (step 0 would land
-    // at ~-10ms) with hits on steps 0 and 8. Offline renders start at t=0,
-    // so all step-0 trigger times must clamp to 0 instead of throwing a
-    // RangeError inside the offline context.
+describe("golden render: step-0 pre-bar trimming", () => {
+  // BASELINE CHANGE (#318): renderWav pre-rolls the offline transport past
+  // the compressor warm-up and slices the pre-roll off, so the export
+  // starts exactly on the bar line. Step-0 events pulled ahead of the bar
+  // line - flam grace notes and negative timing nudges - now land inside
+  // the pre-roll and are trimmed at the bar line, replacing the previous
+  // "step-0 time clamping" golden, which asserted the old clamp-to-t=0
+  // behavior (all pre-bar events stacked ON the bar line).
+  it("trims a step-0 flam grace note, keeping the main hit on the bar line", async () => {
     const buffer = await renderFixture({
       pattern: makePattern({
         steps: [
           { voice: 0, step: 0, flam: true },
           { voice: 0, step: 4 },
-          { voice: 1, step: 0 },
-          { voice: 1, step: 8 },
         ],
-        nudges: [{ voice: 1, nudge: -2 }],
       }),
-      instruments: [makeInstrument(0, "kick"), makeInstrument(1, "snare")],
-      sampleUrls: [clickUrl, clickUrl],
+      instruments: [makeInstrument(0, "kick")],
+      sampleUrls: [clickUrl],
+      bpm: BPM,
+    });
+
+    // The grace note (bar line - 15ms) is cut at the bar line; only its
+    // sub-peak decay tail bleeds into the export through the master
+    // chain's ~12ms latency. The raised threshold ignores that residual
+    // (measured ~0.11; an untrimmed grace would peak near 0.6) while
+    // still catching every full hit.
+    const onsets = findOnsets(buffer, { threshold: 0.2 });
+    // Two onsets, not three: contrast with the step-4 flam test above,
+    // which keeps its grace note and resolves two onsets 15ms apart.
+    expect(onsets).toHaveLength(2);
+    // The main hit stays on the bar line (offset only by master chain
+    // latency).
+    expect(onsets[0]).toBeLessThan(0.02);
+    // The step-4 hit stays on the grid relative to it.
+    expect(onsets[1] - onsets[0]).toBeGreaterThan(4 * STEP - TOL);
+    expect(onsets[1] - onsets[0]).toBeLessThan(4 * STEP + TOL);
+    // The trimmed grace leaves at most a quiet residual ahead of the main
+    // hit's onset.
+    expect(peakInWindow(buffer, 0, 0.008)).toBeLessThan(0.2);
+  });
+
+  it("keeps a step-0 negative nudge early instead of clamping it to the bar line", async () => {
+    // Nudge -2 pulls hits ~10.4ms early at 120 BPM. Pre-#318, the step-0
+    // trigger clamped to t=0 (losing its nudge), so the step-0 -> step-8
+    // gap measured 8 steps MINUS the nudge; now the whole voice keeps its
+    // timing and the gap is exactly 8 steps. The step-0 hit is trimmed at
+    // the bar line, but the master chain's ~12ms latency exceeds the
+    // 10.4ms nudge, so its audio still lands intact just inside the
+    // export - matching how the nudge sounds in live playback.
+    const buffer = await renderFixture({
+      pattern: makePattern({
+        steps: [
+          { voice: 0, step: 0 },
+          { voice: 0, step: 8 },
+        ],
+        nudges: [{ voice: 0, nudge: -2 }],
+      }),
+      instruments: [makeInstrument(0, "kick")],
+      sampleUrls: [clickUrl],
       bpm: BPM,
     });
 
     const onsets = findOnsets(buffer);
-    // Step 0 collapses into ONE onset: the flam grace note, the flammed
-    // main hit, and voice 1's nudged hit all clamp to t=0.
-    expect(onsets).toHaveLength(3);
-    // The clamped hits land right at the start of the buffer (offset only
-    // by the master chain's ~6ms compressor latency).
-    expect(onsets[0]).toBeLessThan(0.02);
-    // Voice 0's plain step-4 hit stays on the grid relative to step 0.
-    expect(onsets[1] - onsets[0]).toBeGreaterThan(4 * STEP - TOL);
-    expect(onsets[1] - onsets[0]).toBeLessThan(4 * STEP + TOL);
-    // Voice 1's step-8 hit keeps its -2 nudge (no clamping needed there),
-    // so the gap from step 4 is 4 steps minus the nudge magnitude.
-    const expectedGap = 4 * STEP - NUDGE_PLUS_2_OFFSET;
-    expect(onsets[2] - onsets[1]).toBeGreaterThan(expectedGap - TOL);
-    expect(onsets[2] - onsets[1]).toBeLessThan(expectedGap + TOL);
+    expect(onsets).toHaveLength(2);
+    // The nudged step-0 hit sounds ahead of where a bar-line hit lands
+    // (~12ms), not clamped onto it.
+    expect(onsets[0]).toBeLessThan(0.01);
+    // Both hits carry the same -2 nudge, so their gap is exactly 8 steps
+    // (the old clamp made this 8 * STEP - NUDGE_PLUS_2_OFFSET).
+    expect(onsets[1] - onsets[0]).toBeGreaterThan(8 * STEP - TOL);
+    expect(onsets[1] - onsets[0]).toBeLessThan(8 * STEP + TOL);
   });
 });
 
 describe("golden render: accent and velocity", () => {
-  // Peak comparisons avoid step 0: the current engine renders the very
-  // first hit of an offline render (t=0) ~46% quieter than steady state
-  // (verified empirically: hits on all 16 steps peak at 0.4709 then 0.8739
-  // for every later step). Timing tests are unaffected; peaks are measured
-  // from step 4 onward where amplitude is stable.
+  // Peak comparisons INCLUDE step 0 (baseline change, #318): renderWav's
+  // pre-roll removed the compressor warm-up that used to render the first
+  // hit of an export ~59% quieter than steady state, so first-hit peaks
+  // now match every later step (locked in by the first-hit amplitude test
+  // below). Steps 0 and 8 sit exactly 1s apart at 120 BPM, so both hits
+  // share the same sub-sample trigger phase and their peaks compare
+  // cleanly.
   it("boosts accented steps relative to non-accented steps", async () => {
     const instruments = [makeInstrument(0, "snare")];
     const steps = [
-      { voice: 0, step: 4 },
+      { voice: 0, step: 0 },
       { voice: 0, step: 8 },
     ];
 
@@ -322,11 +360,39 @@ describe("golden render: accent and velocity", () => {
     expect(Math.abs(plainPeak2 - plainPeak1)).toBeLessThan(plainPeak1 * 0.1);
   });
 
+  // Locks out #318: Chromium's DynamicsCompressorNode initializes its
+  // internal gain low and slews to unity over the first ~100ms of a fresh
+  // context, so un-pre-rolled renders played a step-0 hit at ~41% of
+  // steady-state amplitude (measured 0.4039 vs 0.9888 through the full
+  // master chain). renderWav's pre-roll moves the warm-up out of the
+  // export; the cured first/steady ratio measures 1.0000.
+  it("renders the first hit at steady-state amplitude", async () => {
+    const buffer = await renderFixture({
+      pattern: makePattern({
+        steps: Array.from({ length: 16 }, (_, step) => ({ voice: 0, step })),
+      }),
+      instruments: [makeInstrument(0, "hat")],
+      sampleUrls: [clickUrl],
+      bpm: BPM,
+    });
+
+    const onsets = findOnsets(buffer);
+    expect(onsets).toHaveLength(16);
+
+    const firstPeak = peakInWindow(buffer, onsets[0], onsets[0] + 0.015);
+    // Onset 8 lies exactly 1s after the first hit (8 steps at 120 BPM),
+    // so it shares the first hit's sub-sample trigger phase; peaks vary
+    // ~2% with sub-sample alignment and this pairing cancels that out.
+    const steadyPeak = peakInWindow(buffer, onsets[8], onsets[8] + 0.015);
+    expect(firstPeak).toBeGreaterThan(steadyPeak * 0.98);
+    expect(firstPeak).toBeLessThan(steadyPeak * 1.02);
+  });
+
   it("scales hit amplitude by step velocity", async () => {
     const buffer = await renderFixture({
       pattern: makePattern({
         steps: [
-          { voice: 0, step: 4, velocity: 1.0 },
+          { voice: 0, step: 0, velocity: 1.0 },
           { voice: 0, step: 8, velocity: 0.25 },
         ],
       }),

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -28,6 +28,7 @@ import {
 } from "../cache/sample";
 import {
   EXPORT_CHANNEL_COUNT,
+  EXPORT_PREROLL_TIME,
   EXPORT_TAIL_TIME,
   STEP_COUNT,
   TRANSPORT_SWING_MAX,
@@ -390,7 +391,27 @@ class AudioEngine {
     // Add tail for reverb/release decay if requested, otherwise end on the
     // bar line for DAW looping.
     const tailTime = options.includeTail ? EXPORT_TAIL_TIME : 0;
-    const duration = barDuration + tailTime;
+    // Output length in samples, exactly as a render without pre-roll would
+    // size it (OfflineAudioContext truncates duration * sampleRate), so the
+    // pre-roll below can never change the export's duration.
+    const outputSamples = Math.floor(
+      (barDuration + tailTime) * options.sampleRate,
+    );
+
+    // Pre-roll past the DynamicsCompressorNode warm-up (#318): a fresh
+    // offline context starts both compressor instances (parallel comp and
+    // limiter) at low internal gain, leaving the first ~100ms of output
+    // attenuated. Start the transport a whole-sample pre-roll in and slice
+    // those samples back off after rendering, so the export still begins
+    // exactly on the bar line at full amplitude. Step-0 events pulled ahead
+    // of the bar line (flam grace notes, negative timing nudges) land
+    // inside the pre-roll and are trimmed from the export.
+    const prerollSamples = Math.ceil(EXPORT_PREROLL_TIME * options.sampleRate);
+    const prerollSeconds = prerollSamples / options.sampleRate;
+    // One sample of margin so seconds -> samples truncation inside Offline
+    // can never leave the render shorter than the slice window below.
+    const renderDuration =
+      (prerollSamples + outputSamples + 1) / options.sampleRate;
 
     const toneBuffer = await Offline(
       async ({ transport, destination }) => {
@@ -423,9 +444,9 @@ class AudioEngine {
           barBudget: options.bars,
         });
 
-        transport.start(0);
+        transport.start(prerollSeconds);
       },
-      duration,
+      renderDuration,
       EXPORT_CHANNEL_COUNT,
       options.sampleRate,
     );
@@ -434,7 +455,7 @@ class AudioEngine {
     if (!nativeBuffer) {
       throw new Error("Failed to render audio buffer");
     }
-    return nativeBuffer;
+    return sliceRenderedBuffer(nativeBuffer, prerollSamples, outputSamples);
   }
 
   // ---------------------------------------------------------------------------
@@ -871,6 +892,32 @@ class AudioEngine {
 function calculateExportDuration(bars: number, bpm: number): number {
   const stepDuration = 60 / bpm / 4; // Duration of one 16th note in seconds
   return bars * STEP_COUNT * stepDuration;
+}
+
+/**
+ * Copies a window of a rendered buffer into a fresh AudioBuffer, dropping
+ * the first offsetSamples samples. renderWav renders a warm-up pre-roll
+ * ahead of the first bar and cuts it off here, so exports start exactly on
+ * the bar line.
+ */
+function sliceRenderedBuffer(
+  buffer: AudioBuffer,
+  offsetSamples: number,
+  lengthSamples: number,
+): AudioBuffer {
+  const sliced = new AudioBuffer({
+    numberOfChannels: buffer.numberOfChannels,
+    length: lengthSamples,
+    sampleRate: buffer.sampleRate,
+  });
+  for (let channel = 0; channel < buffer.numberOfChannels; channel++) {
+    const data = buffer.getChannelData(channel);
+    sliced.copyToChannel(
+      data.subarray(offsetSamples, offsetSamples + lengthSamples),
+      channel,
+    );
+  }
+  return sliced;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/core/audio/engine/constants.ts
+++ b/src/core/audio/engine/constants.ts
@@ -168,6 +168,16 @@ const SPLIT_FILTER_BYPASS_FLOOR_HZ = 10; // Avoid clamping HP to 0 Hz
 const EXPORT_TAIL_TIME = 2; // Seconds
 const EXPORT_CHANNEL_COUNT = 2;
 
+/**
+ * Warm-up pre-roll rendered ahead of the first bar of an offline render and
+ * sliced off before the buffer is returned (see renderWav). Chromium's
+ * DynamicsCompressorNode initializes its internal gain low and slews up to
+ * unity over the first ~100ms of a fresh context, so anything scheduled
+ * near t=0 renders quiet (#318); 200ms is a 2x margin over the worst
+ * measured warm-up.
+ */
+const EXPORT_PREROLL_TIME = 0.2; // Seconds
+
 // ============================================================================
 // Audio context
 // ============================================================================
@@ -272,6 +282,7 @@ export {
   SPLIT_FILTER_BYPASS_FLOOR_HZ,
   EXPORT_TAIL_TIME,
   EXPORT_CHANNEL_COUNT,
+  EXPORT_PREROLL_TIME,
   AUDIO_CONTEXT_CHECK_THROTTLE_MS,
   RATCHET_OFFSET_BEATS,
   FLAM_OFFSET_SECONDS,

--- a/src/core/audio/engine/sequencer/sequencer.ts
+++ b/src/core/audio/engine/sequencer/sequencer.ts
@@ -232,9 +232,11 @@ function scheduleVoice(
   const beatOffset = nudgeToBeatOffset(timingNudge);
   const secondsPerBeat = 60 / ctx.bpm;
   const nudgeSeconds = beatOffset * secondsPerBeat;
-  // Clamped to >= 0: offline renders start at t=0, so a negative nudge on
-  // step 0 would otherwise produce a negative absolute time and throw a
-  // RangeError inside the offline context.
+  // Clamped to >= 0: a negative absolute time would throw a RangeError.
+  // Only live playback can get near the floor (the live transport starts
+  // near context time 0); offline renders start past renderWav's pre-roll,
+  // so a step-0 negative nudge stays positive there and simply lands ahead
+  // of the bar line, where the export trims it.
   const adjustedTime = Math.max(0, timeSeconds + nudgeSeconds);
 
   // Closed hat mutes open hat (TR-909 style)
@@ -253,8 +255,9 @@ function scheduleVoice(
   // array on this hot path.
   const hasFlam = variation.flams?.[step] ?? false;
   if (hasFlam) {
-    // Clamped for the same reason as adjustedTime: a flam on step 0 places
-    // its grace note before t=0 in an offline render.
+    // Clamped for the same reason as adjustedTime: live playback near
+    // context time 0. Offline, a step-0 grace note lands inside renderWav's
+    // pre-roll (before the bar line) and is trimmed from the export.
     const flamGraceTime = Math.max(0, adjustedTime - FLAM_OFFSET_SECONDS);
     const flamGraceVelocity = velocity * FLAM_GRACE_VELOCITY;
     channel.trigger(flamGraceTime, {


### PR DESCRIPTION
Fixes #318. Diagnosis and fix approach per the investigation on the issue; step-0 trim semantics as decided there.

Chromium's DynamicsCompressorNode initializes its internal gain low and slews to unity over the first ~100ms of a fresh context - independent of parameters (reproduces with threshold 0 / ratio 1 / knee 0). Two DCN instances sit in the render path (parallel compressor + the always-in-line limiter), so every WAV export with a step-0 hit played its first transient at ~41% of steady state. Live playback was never affected.

**The fix**: `renderWav` renders a 200ms whole-sample pre-roll (`EXPORT_PREROLL_TIME`, 2x margin over the worst measured warm-up) ahead of the first bar, starts the offline transport at the pre-roll offset, and slices the pre-roll off the returned buffer. Output duration is computed in samples exactly as the un-pre-rolled render sized it, so export length is unchanged to the sample (verified: 96000/192000 samples before and after, tail logic included).

**Measured**: first/steady peak ratio 0.4084 before, 1.0000 after, on the production renderWav path through the full master chain. Onset grid and cross-render deltas unchanged.

**Step-0 semantics (decided on the issue)**: flam graces and negative nudges on step 0 now land ahead of the bar line inside the pre-roll and are trimmed, instead of clamping to t=0 and stacking on the bar line. The sequencer's `>= 0` clamps stay for live playback near context start (comments updated; zero code changes there - live is bit-identical).

**Goldens**: the step-0 clamping golden is replaced by two trim-semantics tests (each baseline change documented in-test), peak comparisons include step 0 again, the step-4 workaround comment is gone, and a new first-hit amplitude assertion (within 2% of steady state) locks the bug out. Golden file stable across 3 consecutive runs.

Also updates the design doc's quirks section: the old "envelope spin-up" attribution was refuted by measurement.

Gates: 70/70 tests, lint, build, both engine-purity greps clean.