### PR TITLE
fix(instrument): select voices by physical digit key position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # testing
 /coverage
+.vitest-attachments
+__screenshots__
 
 # vite
 /dist

--- a/src/features/instrument/hooks/use-instrument-grid-shortcuts.browser.test.ts
+++ b/src/features/instrument/hooks/use-instrument-grid-shortcuts.browser.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Browser tests for useInstrumentGridShortcuts.
+ *
+ * Mounts the real hook in Chromium and dispatches real KeyboardEvents on
+ * window. Number-key voice selection must be keyed off the physical digit
+ * row (event.code), because non-US and custom layouts produce different
+ * event.key values for those keys (e.g. French AZERTY gives key "&" for
+ * code "Digit1"). Regression test for issue #283.
+ */
+
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useInstrumentGridShortcuts } from "@/features/instrument/hooks/use-instrument-grid-shortcuts";
+
+declare global {
+  // Required by React so act() can flush effects in tests.
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+type HarnessOptions = {
+  initialVoiceIndex?: number;
+  isAnyDialogOpen?: () => boolean;
+};
+
+type Harness = {
+  selected: number[];
+};
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+/** Mounts the real hook and records every voice selection it makes. */
+async function mountShortcuts({
+  initialVoiceIndex = 0,
+  isAnyDialogOpen = () => false,
+}: HarnessOptions = {}): Promise<Harness> {
+  const selected: number[] = [];
+
+  function Host() {
+    const [voiceIndex, setVoiceIndex] = useState(initialVoiceIndex);
+    useInstrumentGridShortcuts({
+      voiceIndex,
+      onSelectVoice: (voice) => {
+        selected.push(voice);
+        setVoiceIndex(voice);
+      },
+      isAnyDialogOpen,
+    });
+    return null;
+  }
+
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // act() flushes the effect that attaches the window listener.
+  await act(async () => {
+    root?.render(createElement(Host));
+  });
+
+  return { selected };
+}
+
+/** Dispatches a real keydown and flushes the re-render it may cause. */
+async function pressKey(init: KeyboardEventInit): Promise<void> {
+  await act(async () => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { ...init }));
+  });
+}
+
+describe("useInstrumentGridShortcuts", () => {
+  it("selects voices from digit keys on a US layout", async () => {
+    const { selected } = await mountShortcuts();
+
+    await pressKey({ key: "1", code: "Digit1" });
+    await pressKey({ key: "8", code: "Digit8" });
+
+    expect(selected).toEqual([0, 7]);
+  });
+
+  it("selects voices from the physical digit row on non-US layouts", async () => {
+    const { selected } = await mountShortcuts();
+
+    // French AZERTY: unshifted digit row produces symbols, not digits.
+    await pressKey({ key: "&", code: "Digit1" });
+    await pressKey({ key: "é", code: "Digit2" });
+    // Czech: unshifted digit row produces accented letters.
+    await pressKey({ key: "ř", code: "Digit5" });
+
+    expect(selected).toEqual([0, 1, 4]);
+  });
+
+  it("selects voices from the numpad", async () => {
+    const { selected } = await mountShortcuts();
+
+    await pressKey({ key: "3", code: "Numpad3" });
+
+    expect(selected).toEqual([2]);
+  });
+
+  it("falls back to event.key when the event carries no code", async () => {
+    const { selected } = await mountShortcuts();
+
+    await pressKey({ key: "4", code: "" });
+
+    expect(selected).toEqual([3]);
+  });
+
+  it("ignores digit keys outside the 1-8 range", async () => {
+    const { selected } = await mountShortcuts();
+
+    await pressKey({ key: "9", code: "Digit9" });
+    await pressKey({ key: "0", code: "Digit0" });
+
+    expect(selected).toEqual([]);
+  });
+
+  it("navigates with arrow keys regardless of layout", async () => {
+    const { selected } = await mountShortcuts({ initialVoiceIndex: 3 });
+
+    await pressKey({ key: "ArrowRight", code: "ArrowRight" });
+    await pressKey({ key: "ArrowLeft", code: "ArrowLeft" });
+
+    expect(selected).toEqual([4, 3]);
+  });
+
+  it("does nothing while a dialog is open", async () => {
+    const { selected } = await mountShortcuts({
+      isAnyDialogOpen: () => true,
+    });
+
+    await pressKey({ key: "1", code: "Digit1" });
+    await pressKey({ key: "ArrowRight", code: "ArrowRight" });
+
+    expect(selected).toEqual([]);
+  });
+});

--- a/src/features/instrument/hooks/use-instrument-grid-shortcuts.ts
+++ b/src/features/instrument/hooks/use-instrument-grid-shortcuts.ts
@@ -40,9 +40,17 @@ function useInstrumentGridShortcuts({
         selectVoice(newVoiceDown(voiceIndex));
       } else if (event.key === "k") {
         selectVoice(newVoiceUp(voiceIndex));
-      } else if (event.key >= "1" && event.key <= "8") {
-        const number = Number(event.key) - 1; // 0-based
-        selectVoice(number);
+      } else {
+        // Digits are matched by physical position (event.code) so layouts
+        // whose digit row produces other characters (AZERTY, custom xkb
+        // configs, ...) still work. event.key is a fallback for events
+        // without a code, e.g. synthetic or IME-composed ones.
+        const digit =
+          /^(?:Digit|Numpad)([1-8])$/.exec(event.code)?.[1] ??
+          (event.key >= "1" && event.key <= "8" ? event.key : undefined);
+        if (digit !== undefined) {
+          selectVoice(Number(digit) - 1); // 0-based
+        }
       }
     };
 


### PR DESCRIPTION
Fixes #283.

## Problem

Number keys didn't swap the active voice on Linux setups with non-US or custom keyboard layouts (reported on Helium browser, CachyOS/Hyprland, custom config). The shortcut handler in `use-instrument-grid-shortcuts.ts` matched `event.key >= "1" && event.key <= "8"`, and `event.key` is layout-dependent: the physical digit row produces `"&"`, `"é"`, accented letters, etc. on AZERTY, Czech, and custom xkb layouts, so the comparison never matched.

## Fix

Match physical position first via `event.code` (`Digit1`-`Digit8`, `Numpad1`-`Numpad8`), keeping the `event.key` range check as a fallback for events that carry no code (synthetic/IME). All existing guards and the arrow/vim-key branches are unchanged. Audited every other key handler in `src/` - they match named keys or letters, not the digit row, so this was the only instance of the defect class.

## Testing

- New browser-mode regression test mounts the real hook in Chromium and dispatches real `KeyboardEvent`s, including layout-mismatched ones (`key: "&", code: "Digit1"`). Verified it fails against the pre-fix code (non-US layout case only) and passes after.
- Full suite: 77 tests pass (was 70). `pnpm lint` and `pnpm build` clean. Engine purity greps clean (no engine files touched).
- Also gitignores vitest browser failure artifacts (`.vitest-attachments`, `__screenshots__`), which any failing browser test leaves behind.