### PR TITLE
test(e2e): add UI-driving Playwright suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,16 @@ jobs:
 
       - name: Lightshow cold-load smoke check
         run: pnpm smoke:lightshow
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 /coverage
 .vitest-attachments
 __screenshots__
+/playwright-report
+/test-results
 
 # vite
 /dist

--- a/e2e/app-load.spec.ts
+++ b/e2e/app-load.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp } from "./helpers";
+
+test.describe("app load", () => {
+  test("renders the drum machine with the default kit and preset", async ({
+    page,
+  }) => {
+    const consoleErrors: string[] = [];
+    const pageErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    page.on("pageerror", (error) => pageErrors.push(String(error)));
+
+    await gotoApp(page);
+
+    // Default preset and kit are visible on the screen.
+    await expect(page.getByRole("combobox", { name: "Preset" })).toHaveText(
+      "init",
+    );
+    await expect(page.getByRole("combobox", { name: "Kit" })).toHaveText("808");
+
+    // All eight instruments of the 808 kit render.
+    for (const name of [
+      "1 Kick",
+      "2 Kick2",
+      "3 Snare",
+      "4 Clap",
+      "5 Hat",
+      "6 OHat",
+      "7 Tom",
+      "8 Tom2",
+    ]) {
+      await expect(
+        page.getByRole("button", { name, exact: true }),
+      ).toBeVisible();
+    }
+
+    // The 16-step sequencer grid and the transport render.
+    await expect(page.locator("button[data-step-index]")).toHaveCount(16);
+    await expect(
+      page.getByRole("button", { name: "Play", exact: true }),
+    ).toBeVisible();
+
+    // The page loaded without console or uncaught errors.
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,89 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/**
+ * Load the app and wait until it is genuinely interactive:
+ * - the default kit's sample channels are loaded (instrument pads enable
+ *   once their audio channel is ready), and
+ * - the intro lightshow has finished (sequencer step visuals are frozen
+ *   until it completes).
+ */
+async function gotoApp(page: Page): Promise<void> {
+  await page.goto("/");
+  await waitForChannelsReady(page);
+  // The lightshow marks its nodes "done" when the intro wave completes
+  // (safety timeout 3s), after which step/selection visuals are live.
+  await expect(page.locator('[data-light-node="done"]').first()).toBeAttached({
+    timeout: 15_000,
+  });
+}
+
+/** Wait for all eight instrument channels to finish loading samples. */
+async function waitForChannelsReady(page: Page): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await expect(
+      page.locator(`[data-instrument-index="${i}"] button`).first(),
+    ).toBeEnabled({ timeout: 20_000 });
+  }
+}
+
+/** The sequencer pad for a step (0-15) of the currently selected voice. */
+function step(page: Page, index: number): Locator {
+  return page.locator(`button[data-step-index="${index}"]`);
+}
+
+/** Toggle a sequencer step and wait for its visual state to flip. */
+async function toggleStep(
+  page: Page,
+  index: number,
+  expected: "true" | "false",
+): Promise<void> {
+  await step(page, index).click();
+  await expect(step(page, index)).toHaveAttribute("data-active", expected);
+}
+
+/**
+ * Index of the sequencer step indicator (playhead) that is currently lit,
+ * or -1 when the transport is idle.
+ */
+function litIndicatorIndex(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const indicators = document.querySelectorAll(
+      '[data-light-group="sequencer-indicator"]',
+    );
+    return Array.from(indicators).findIndex((el) =>
+      el.classList.contains("bg-primary"),
+    );
+  });
+}
+
+/** Start playback via the transport button and wait for the playhead. */
+async function startPlayback(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Play", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "Pause", exact: true }),
+  ).toBeVisible();
+  // The playhead only lights once the audio context is running and the
+  // transport is actually advancing.
+  await expect
+    .poll(() => litIndicatorIndex(page), { timeout: 15_000 })
+    .toBeGreaterThanOrEqual(0);
+}
+
+/** Stop playback and wait for the transport to return to idle. */
+async function stopPlayback(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Pause", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "Play", exact: true }),
+  ).toBeVisible();
+  await expect.poll(() => litIndicatorIndex(page)).toBe(-1);
+}
+
+export {
+  gotoApp,
+  litIndicatorIndex,
+  startPlayback,
+  step,
+  stopPlayback,
+  toggleStep,
+  waitForChannelsReady,
+};

--- a/e2e/keybindings.spec.ts
+++ b/e2e/keybindings.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { gotoApp } from "./helpers";
+
+/** The instrument slot that is currently selected (voice mode). */
+function selectedInstrument(page: Page) {
+  return page.locator("[data-instrument-index][data-selected]");
+}
+
+test.describe("instrument keybindings", () => {
+  test("digit keys select voices by physical position (issue #283)", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+
+    // Record what the app actually receives so the layout-mismatch case
+    // below is verifiably real (event.key must not be the digit).
+    await page.evaluate(() => {
+      const keys: { key: string; code: string }[] = [];
+      (window as unknown as Record<string, unknown>).__e2eKeydowns = keys;
+      window.addEventListener("keydown", (event) => {
+        keys.push({ key: event.key, code: event.code });
+      });
+    });
+
+    // Voice 1 is selected by default.
+    await expect(selectedInstrument(page)).toHaveAttribute(
+      "data-instrument-index",
+      "0",
+    );
+
+    // Plain US-layout digit press: "3" selects the third voice.
+    await page.keyboard.press("3");
+    await expect(selectedInstrument(page)).toHaveAttribute(
+      "data-instrument-index",
+      "2",
+    );
+
+    // Layout-mismatched digit (AZERTY-style): the physical Digit1 key
+    // produces key "&", not "1". Playwright's keyboard always emits
+    // US-layout key values, so drive Chromium's input domain directly.
+    const cdp = await page.context().newCDPSession(page);
+    await cdp.send("Input.dispatchKeyEvent", {
+      type: "rawKeyDown",
+      key: "&",
+      code: "Digit1",
+      windowsVirtualKeyCode: 49,
+      nativeVirtualKeyCode: 49,
+    });
+    await cdp.send("Input.dispatchKeyEvent", {
+      type: "keyUp",
+      key: "&",
+      code: "Digit1",
+      windowsVirtualKeyCode: 49,
+      nativeVirtualKeyCode: 49,
+    });
+
+    // The first voice is selected via the physical key position.
+    await expect(selectedInstrument(page)).toHaveAttribute(
+      "data-instrument-index",
+      "0",
+    );
+
+    // Prove the app saw a genuinely layout-mismatched event.
+    const keydowns = await page.evaluate(
+      () =>
+        (window as unknown as Record<string, unknown>).__e2eKeydowns as {
+          key: string;
+          code: string;
+        }[],
+    );
+    expect(keydowns).toContainEqual({ key: "3", code: "Digit3" });
+    expect(keydowns).toContainEqual({ key: "&", code: "Digit1" });
+    expect(keydowns).not.toContainEqual({ key: "1", code: "Digit1" });
+  });
+});

--- a/e2e/kit.spec.ts
+++ b/e2e/kit.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  gotoApp,
+  startPlayback,
+  stopPlayback,
+  waitForChannelsReady,
+} from "./helpers";
+
+test.describe("kit", () => {
+  test("swapping kits updates the instruments and stays playable", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+
+    await expect(page.getByRole("combobox", { name: "Kit" })).toHaveText("808");
+    await expect(
+      page.getByRole("button", { name: "2 Kick2", exact: true }),
+    ).toBeVisible();
+
+    // Swap to the House kit via the kit selector.
+    await page.getByRole("combobox", { name: "Kit" }).click();
+    await page.getByRole("option", { name: "House", exact: true }).click();
+
+    // The screen and the instrument slots reflect the new kit.
+    await expect(page.getByRole("combobox", { name: "Kit" })).toHaveText(
+      "House",
+    );
+    await expect(
+      page.getByRole("button", { name: "2 Bass", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "7 Piano", exact: true }),
+    ).toBeVisible();
+
+    // The new kit's samples finish loading and the app can still play.
+    await waitForChannelsReady(page);
+    await startPlayback(page);
+    await stopPlayback(page);
+  });
+});

--- a/e2e/preset.spec.ts
+++ b/e2e/preset.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, step, toggleStep } from "./helpers";
+
+test.describe("preset save and load", () => {
+  test("loading a saved preset reverts later edits", async ({ page }) => {
+    await gotoApp(page);
+
+    // Make a change worth saving: turn step 1 on.
+    await toggleStep(page, 0, "true");
+
+    // Saving from a factory preset opens the Save As dialog.
+    await page.getByRole("button", { name: "Save preset" }).click();
+    const saveDialog = page.getByRole("dialog", { name: "Save Preset" });
+    await expect(saveDialog).toBeVisible();
+    await saveDialog.getByLabel("Preset name").fill("E2E Preset");
+    await saveDialog.getByRole("button", { name: "Save" }).click();
+    await expect(saveDialog).not.toBeVisible();
+
+    // The saved preset becomes the current one.
+    await expect(page.getByRole("combobox", { name: "Preset" })).toHaveText(
+      "E2E Preset",
+    );
+
+    // Modify the pattern after saving.
+    await toggleStep(page, 8, "true");
+
+    // Switching away with unsaved changes prompts for confirmation.
+    await page.getByRole("combobox", { name: "Preset" }).click();
+    await page.getByRole("option", { name: "init", exact: true }).click();
+    const confirmDialog = page.getByRole("dialog", { name: "Switch Preset?" });
+    await expect(confirmDialog).toBeVisible();
+    await confirmDialog.getByRole("button", { name: "Switch Anyway" }).click();
+
+    // init's empty pattern is back.
+    await expect(page.getByRole("combobox", { name: "Preset" })).toHaveText(
+      "init",
+    );
+    await expect(step(page, 0)).toHaveAttribute("data-active", "false");
+
+    // Load the saved preset again: the saved step is restored and the
+    // post-save modification is gone.
+    await page.getByRole("combobox", { name: "Preset" }).click();
+    await page.getByRole("option", { name: "E2E Preset", exact: true }).click();
+    await expect(page.getByRole("combobox", { name: "Preset" })).toHaveText(
+      "E2E Preset",
+    );
+    await expect(step(page, 0)).toHaveAttribute("data-active", "true");
+    await expect(step(page, 8)).toHaveAttribute("data-active", "false");
+  });
+});

--- a/e2e/sequencer.spec.ts
+++ b/e2e/sequencer.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, step, toggleStep } from "./helpers";
+
+test.describe("sequencer", () => {
+  test("steps toggle on and off in the grid", async ({ page }) => {
+    await gotoApp(page);
+
+    // The init preset starts with an empty pattern.
+    await expect(step(page, 0)).toHaveAttribute("data-active", "false");
+
+    // Toggle a few steps on.
+    await toggleStep(page, 0, "true");
+    await toggleStep(page, 4, "true");
+    await toggleStep(page, 15, "true");
+
+    // Untouched neighbours stay off.
+    await expect(step(page, 1)).toHaveAttribute("data-active", "false");
+    await expect(step(page, 14)).toHaveAttribute("data-active", "false");
+
+    // Toggling again turns a step back off.
+    await toggleStep(page, 4, "false");
+    await expect(step(page, 0)).toHaveAttribute("data-active", "true");
+    await expect(step(page, 15)).toHaveAttribute("data-active", "true");
+  });
+});

--- a/e2e/transport.spec.ts
+++ b/e2e/transport.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  gotoApp,
+  litIndicatorIndex,
+  startPlayback,
+  stopPlayback,
+} from "./helpers";
+
+test.describe("transport", () => {
+  test("play starts the playhead and stop returns to idle", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+
+    // Clicking play is the user gesture that starts the audio context.
+    await startPlayback(page);
+
+    // The playhead advances: the lit step indicator moves to another step.
+    const initial = await litIndicatorIndex(page);
+    await expect
+      .poll(() => litIndicatorIndex(page), { timeout: 10_000 })
+      .not.toBe(initial);
+
+    // Stopping returns the transport to idle: play affordance is back and
+    // no step indicator stays lit.
+    await stopPlayback(page);
+  });
+});

--- a/e2e/wav-export.spec.ts
+++ b/e2e/wav-export.spec.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, toggleStep } from "./helpers";
+
+interface WavInfo {
+  sampleRate: number;
+  channels: number;
+  duration: number;
+}
+
+/** Minimal RIFF/WAVE reader: validates the header and walks the chunks. */
+function parseWav(buffer: Buffer): WavInfo {
+  expect(buffer.length).toBeGreaterThan(44);
+  expect(buffer.toString("ascii", 0, 4)).toBe("RIFF");
+  expect(buffer.toString("ascii", 8, 12)).toBe("WAVE");
+
+  let sampleRate = 0;
+  let channels = 0;
+  let byteRate = 0;
+  let dataSize = 0;
+
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    if (chunkId === "fmt ") {
+      channels = buffer.readUInt16LE(offset + 10);
+      sampleRate = buffer.readUInt32LE(offset + 12);
+      byteRate = buffer.readUInt32LE(offset + 16);
+    } else if (chunkId === "data") {
+      dataSize = chunkSize;
+    }
+    offset += 8 + chunkSize + (chunkSize % 2);
+  }
+
+  expect(sampleRate).toBeGreaterThan(0);
+  expect(channels).toBeGreaterThan(0);
+  expect(byteRate).toBeGreaterThan(0);
+  expect(dataSize).toBeGreaterThan(0);
+
+  return { sampleRate, channels, duration: dataSize / byteRate };
+}
+
+test.describe("WAV export", () => {
+  test("exports the pattern as a valid WAV download", async ({ page }) => {
+    await gotoApp(page);
+
+    // Put something in the pattern so the render isn't trivially empty.
+    await toggleStep(page, 0, "true");
+    await toggleStep(page, 8, "true");
+
+    await page.getByRole("button", { name: "Export", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "Export" });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("tab", { name: "WAV" }).click();
+    await dialog.getByLabel("Filename").fill("e2e-export");
+
+    // The form displays the expected render duration, e.g. "4.0s".
+    const durationText = await dialog
+      .getByText(/^\d+\.\ds$/)
+      .first()
+      .innerText();
+    const expectedDuration = Number.parseFloat(durationText);
+    expect(expectedDuration).toBeGreaterThan(0);
+
+    // Submitting renders offline and triggers a browser download.
+    const downloadPromise = page.waitForEvent("download", {
+      timeout: 45_000,
+    });
+    await dialog.getByRole("button", { name: "Export", exact: true }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe("e2e-export.wav");
+
+    const path = await download.path();
+    const wav = fs.readFileSync(path);
+
+    // Non-trivial payload with a valid RIFF/WAVE header.
+    expect(wav.length).toBeGreaterThan(100_000);
+    const info = parseWav(wav);
+
+    // The rendered duration matches what the export form promised.
+    expect(Math.abs(info.duration - expectedDuration)).toBeLessThan(0.25);
+
+    // The dialog closes and the app confirms the export.
+    await expect(dialog).not.toBeVisible();
+    // exact: true dodges the duplicate text inside the toast's aria-live
+    // announcement span.
+    await expect(
+      page.getByText("Export successful", { exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "smoke:lightshow": "node scripts/lightshow-smoke.mjs",
+    "test:e2e": "playwright test",
     "prepare": "husky",
     "kit:new": "tsx scripts/new-kit.ts",
     "waveforms:build": "tsx scripts/generate-waveforms.ts"
@@ -53,6 +54,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+    "@playwright/test": "1.61.1",
     "@rolldown/plugin-babel": "^0.2.3",
     "@tailwindcss/vite": "^4.3.1",
     "@types/babel__core": "^7.20.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * UI-driving end-to-end suite (issue #271).
+ *
+ * Runs against a production build served by `vite preview` on port 4444 for
+ * CI fidelity. In CI the build step has already produced `dist/`, so the web
+ * server only needs to serve it; locally the suite rebuilds first so it
+ * always exercises the current source.
+ *
+ * Kept fully separate from vitest: vitest only picks up `.test.ts` files
+ * under `src`, and this runner only picks up `.spec.ts` files under `e2e`.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  // Audio engine boot + offline WAV renders need generous headroom on CI.
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: "http://localhost:4444",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: process.env.CI ? "pnpm preview" : "pnpm build && pnpm preview",
+    port: 4444,
+    reuseExistingServer: false,
+    timeout: 180_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.7.1
         version: 4.7.1(prettier@3.8.4)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -626,6 +629,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2499,6 +2507,10 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.71.0':
     optional: true
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@polka/url@1.0.0-next.29': {}
 

--- a/src/features/instrument/components/instrument-control.tsx
+++ b/src/features/instrument/components/instrument-control.tsx
@@ -65,6 +65,8 @@ function InstrumentControl({
 
   return (
     <div
+      data-instrument-index={index}
+      data-selected={showSelectedState || undefined}
       className={cn(
         "group flex h-full w-full flex-col rounded-2xl border border-transparent",
         {

--- a/src/features/kit/components/kit-navigator.tsx
+++ b/src/features/kit/components/kit-navigator.tsx
@@ -12,7 +12,12 @@ function KitNavigator({ onPrevious, onNext }: KitNavigatorProps) {
     <div className="text-screen grid h-full w-full grid-cols-4">
       <Tooltip delayDuration={0}>
         <TooltipTrigger asChild>
-          <Button onClick={onPrevious} variant="screen" size="screen">
+          <Button
+            onClick={onPrevious}
+            variant="screen"
+            size="screen"
+            aria-label="Previous kit"
+          >
             <ChevronLeft
               className="group-hover:text-accent transition-all duration-200"
               size={20}
@@ -27,7 +32,12 @@ function KitNavigator({ onPrevious, onNext }: KitNavigatorProps) {
 
       <Tooltip delayDuration={0}>
         <TooltipTrigger asChild>
-          <Button onClick={onNext} variant="screen" size="screen">
+          <Button
+            onClick={onNext}
+            variant="screen"
+            size="screen"
+            aria-label="Next kit"
+          >
             <ChevronRight
               className="group-hover:text-accent transition-all duration-200"
               size={20}

--- a/src/features/kit/components/kit-select.tsx
+++ b/src/features/kit/components/kit-select.tsx
@@ -19,6 +19,7 @@ function KitSelect({ selectedKitId, kits, onSelect }: KitSelectProps) {
       <Select value={selectedKitId} onValueChange={onSelect}>
         <SelectTrigger
           size="screen"
+          aria-label="Kit"
           className="text-screen-foreground w-full cursor-pointer rounded-none border-transparent bg-transparent px-1 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
         >
           <SelectValue />

--- a/src/features/preset/components/preset-actions.tsx
+++ b/src/features/preset/components/preset-actions.tsx
@@ -46,7 +46,12 @@ function PresetActions({ onOpenFromFile }: PresetActionsProps) {
     <div className="text-screen grid h-full w-full grid-cols-4">
       <Tooltip delayDuration={0}>
         <TooltipTrigger asChild>
-          <Button onClick={handleSave} variant="screen" size="screen">
+          <Button
+            onClick={handleSave}
+            variant="screen"
+            size="screen"
+            aria-label={isCustom ? "Update preset" : "Save preset"}
+          >
             <Save
               className="group-hover:text-accent transition-all duration-200"
               size={20}
@@ -60,7 +65,12 @@ function PresetActions({ onOpenFromFile }: PresetActionsProps) {
 
       <Tooltip delayDuration={0}>
         <TooltipTrigger asChild>
-          <Button onClick={onOpenFromFile} variant="screen" size="screen">
+          <Button
+            onClick={onOpenFromFile}
+            variant="screen"
+            size="screen"
+            aria-label="Import preset from file"
+          >
             <FolderOpen
               className="group-hover:text-accent transition-all duration-200"
               size={20}
@@ -76,6 +86,7 @@ function PresetActions({ onOpenFromFile }: PresetActionsProps) {
             onClick={() => openDialog("export")}
             variant="screen"
             size="screen"
+            aria-label="Export"
           >
             <AudioLines
               className="group-hover:text-accent transition-all duration-200"
@@ -92,6 +103,7 @@ function PresetActions({ onOpenFromFile }: PresetActionsProps) {
             onClick={() => openDialog("share")}
             variant="screen"
             size="screen"
+            aria-label="Share preset"
           >
             <Share2
               className="group-hover:text-accent transition-all duration-200"

--- a/src/features/preset/components/preset-select.tsx
+++ b/src/features/preset/components/preset-select.tsx
@@ -47,6 +47,7 @@ function PresetSelect({
       <Select value={selectedPresetId} onValueChange={onSelect}>
         <SelectTrigger
           size="screen"
+          aria-label="Preset"
           className="text-screen-foreground w-full cursor-pointer rounded-none border-transparent bg-transparent px-1 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
         >
           <SelectValue />

--- a/src/features/transport/components/play-pause-button.tsx
+++ b/src/features/transport/components/play-pause-button.tsx
@@ -13,6 +13,7 @@ const PlayPauseButton = () => {
         <TooltipTrigger asChild>
           <Button
             variant="hardware"
+            aria-label={isPlaying ? "Pause" : "Play"}
             className="h-(--app-play-button) w-(--app-play-button) rounded-xl p-1 [&_svg]:size-[50px]!"
             onClick={() => togglePlay()}
             onKeyDown={(ev) => {


### PR DESCRIPTION
Closes #271.

## What

The vitest suites (node + Chromium browser mode) cover logic and real-audio rendering below the React layer; this adds the remaining gap from #271 - a real browser driving the real UI. Seven specs under `e2e/` with a separate `@playwright/test` runner (`pnpm test:e2e`):

- **App load**: default kit/preset renders, 8 instruments, 16 steps, zero console/page errors
- **Play/stop**: clicking Play (the audio-unlock gesture) starts the playhead, indicators advance, stop returns to idle
- **Sequencer**: steps toggle on/off, neighbours unaffected
- **Kit swap**: instruments update, channels reload, app stays playable
- **Preset save/load**: save-as dialog round-trip; loading the preset reverts later edits
- **WAV export**: captures the download, validates RIFF/WAVE chunks, size, and duration against the dialog
- **Keybindings (#283 regression)**: a CDP-dispatched AZERTY-style event (`key: "&", code: "Digit1"`) must select voice 1 by physical position - exactly the class of layout bug this suite exists to catch; a page-side recorder proves the app received a genuinely layout-mismatched event

## How

- `playwright.config.ts`: Chromium only, `webServer` runs `vite preview` on 4444 against the production build (CI reuses the `dist/` from the build step; locally it rebuilds first). Traces retained on failure.
- CI: E2E step after build in the existing job, reusing the cached Playwright Chromium; Playwright report uploaded as an artifact on failure.
- Runners stay disjoint: vitest only matches `src/**/*.test.ts`, Playwright only `e2e/**/*.spec.ts`.
- Icon-only controls gained aria-labels and instrument slots expose `data-instrument-index`/`data-selected`, so specs use role/label selectors - also a straight accessibility improvement.

## Testing

- `pnpm test:e2e`: 7/7 green across five consecutive runs (~13s each; one strict-mode locator issue found and fixed during development)
- `pnpm test`: 77 passed, unchanged; `pnpm lint`, `pnpm build`, prettier check clean
- Engine purity greps clean (nothing under `src/core/audio` touched)

Not covered (flows exist, beyond the critical paths): share dialog, .dh file import/export, preset rename/duplicate/delete, tempo/swing controls, parameter knobs.