### PR TITLE
fix(ci): give the lightshow smoke frame budget headroom above 30fps

### DIFF
--- a/scripts/lightshow-smoke.mjs
+++ b/scripts/lightshow-smoke.mjs
@@ -25,7 +25,11 @@ const NET = {
 // The wave sweeps on and off over ~1.2s; anything much shorter means it was
 // cut off mid-flight.
 const MIN_WAVE_DURATION_MS = 1000;
-const MAX_MEDIAN_FRAME_MS = 33;
+// A steady 30fps cadence quantizes to 33.33ms frames, so the budget must sit
+// clearly above that or a run pacing perfectly at 30fps under the 4x CPU
+// throttle fails by rounding (seen on CI: median 33.3ms vs a 33ms budget).
+// 40ms still fails once the median cadence degrades past ~25fps.
+const MAX_MEDIAN_FRAME_MS = 40;
 
 async function waitForServer(url, timeoutMs = 30000) {
   const deadline = Date.now() + timeoutMs;


### PR DESCRIPTION
Main went red on the first push after #330: the lightshow smoke check failed with `median wave frame 33.3ms <= 33ms` while the identical rebase-merged tree had passed twice on the PR ([failed main run](https://github.com/mxfng/drumhaus/actions/runs/29375443921)).

The budget is mathematically flaky: a page holding a perfectly steady 30fps cadence produces 33.33ms medians - above the 33ms budget by rounding. Under the script's own 4x CPU throttle on shared runners, landing on the 30fps quantization point is a coin flip, not a regression.

Raise the budget to 40ms with a comment explaining the cliff: steady 30fps passes, while genuine jank (median cadence at ~25fps or worse) still fails. Verified locally: build + `pnpm smoke:lightshow` passes (median 8.3ms).