### PR TITLE
feat(night): couple the starfield glow to the master output (#268)

### DIFF
--- a/docs/audio-engine-refactor.md
+++ b/docs/audio-engine-refactor.md
@@ -221,6 +221,12 @@ Storage access is fully guarded: private-browsing or storage-denied modes degrad
 To read the counters when reproducing the idle-tab scenario: enable Debug Mode from the floating menu, background the tab for 10+ minutes, return and interact, and check the Resume, Stalls, Rebuild, Timeouts, and Reloads rows in the overlay (Resume and Rebuild show success/attempt pairs).
 The manual Chrome/Safari validation and any threshold tuning remain open on #319 pending the evidence these counters collect.
 
+### Master output level tap (issue #268)
+
+The facade exposes one more read-only tap alongside `getChannelMeter`: `getMasterLevelDb()`, the master output level in dB RMS measured after the limiter on the live bus, so it reads exactly what reaches the destination.
+It is a general surface for audio visualizers (night mode's starfield glow is the first consumer), not a feature-specific hook: consumers poll it from their own animation loops and shape their own attack/release envelopes, which is why the tap is deliberately unsmoothed.
+The meter is created lazily on the first poll (the tap costs nothing until something reads it), survives `rebuild()` by being reattached to the replacement bus in `doInit`, and never touches the offline render path.
+
 ## Expected outcome
 
 `core/audio` stays around its current size (~2,600 lines) but becomes strictly one-directional and testable.

--- a/e2e/night-visualizer.spec.ts
+++ b/e2e/night-visualizer.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, startPlayback, stopPlayback } from "./helpers";
+
+/**
+ * Night-mode starfield visualizer (issue #268).
+ *
+ * The canvas exposes a data-star-glow seam ("silent" | "active") that
+ * follows the engine's master output level, written only on state change.
+ * Loudness itself is deliberately NOT asserted: browser automation
+ * harnesses keep the app's live meters at silence (see the note in
+ * kit-swap-chain.browser.test.ts), so a "glow goes active" assertion
+ * would be flaky by construction. This spec pins what automation can
+ * observe honestly: the starfield mounts with a silent glow, survives a
+ * playback start/stop cycle with the seam always in a valid state, and
+ * ends silent.
+ */
+test.describe("night visualizer", () => {
+  test("starfield mounts silent and stays coherent across playback", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+
+    // Enable night mode from the floating menu.
+    await page.getByRole("button", { name: "Menu" }).click();
+    await page.getByRole("menuitemcheckbox", { name: "Night Mode" }).click();
+
+    // The starfield mounts with the glow seam silent.
+    const sky = page.locator("canvas[data-star-glow]");
+    await expect(sky).toHaveAttribute("data-star-glow", "silent");
+
+    // Across a playback cycle the seam only ever holds a valid state.
+    await startPlayback(page);
+    await expect(sky).toHaveAttribute("data-star-glow", /^(silent|active)$/);
+    await stopPlayback(page);
+
+    // After stopping, the glow settles (or stays) silent.
+    await expect(sky).toHaveAttribute("data-star-glow", "silent");
+
+    // The canvas survives the cycle without remounting artifacts.
+    await expect(sky).toBeAttached();
+  });
+});

--- a/src/core/audio/engine/__tests__/master-level.browser.test.ts
+++ b/src/core/audio/engine/__tests__/master-level.browser.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Browser tests for the master output level tap (issue #268).
+ *
+ * Live meters read silence in this headless harness (see the note in
+ * kit-swap-chain.browser.test.ts), so loudness itself is not asserted.
+ * These tests pin the tap's contract instead: silence reporting, lazy
+ * creation before init, and staying functional across rebuild(), which
+ * exercises the doInit reattachment path.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { AudioEngine } from "@/core/audio/engine";
+import {
+  makeClickSampleUrl,
+  makeInstrument,
+  makePattern,
+} from "@/test/fixtures";
+import { createFixtureEngine } from "@/test/render";
+
+/** Anything at or below this reads as silence for the tap's consumers. */
+const SILENCE_DB = -60;
+
+function makeEngine() {
+  return createFixtureEngine({
+    pattern: makePattern({ steps: [{ voice: 0, step: 0 }] }),
+    instruments: [makeInstrument(0, "kick")],
+    sampleUrls: [makeClickSampleUrl()],
+    bpm: 120,
+  });
+}
+
+describe("master output level tap", () => {
+  it("reports silence before the engine is initialized", () => {
+    const engine = new AudioEngine();
+    try {
+      // Lazy meter creation with no master bus yet: silence, no throw.
+      expect(engine.getMasterLevelDb()).toBeLessThanOrEqual(SILENCE_DB);
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("reports silence when the engine is idle", async () => {
+    const engine = await makeEngine();
+    try {
+      expect(engine.getMasterLevelDb()).toBeLessThanOrEqual(SILENCE_DB);
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("stays functional across rebuild()", async () => {
+    const engine = await makeEngine();
+    try {
+      // First poll creates the meter against the original bus.
+      expect(engine.getMasterLevelDb()).toBeLessThanOrEqual(SILENCE_DB);
+
+      await engine.rebuild();
+
+      // The retained meter was reconnected to the replacement bus and
+      // still reports a valid level.
+      expect(engine.getMasterLevelDb()).toBeLessThanOrEqual(SILENCE_DB);
+    } finally {
+      engine.dispose();
+    }
+  });
+});

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -140,6 +140,14 @@ interface RenderWavOptions {
  */
 const CHANNEL_METER_SMOOTHING = 0.8;
 
+/**
+ * Smoothing for the master output level tap. Deliberately 0: the tap
+ * reports the raw per-window RMS so each consumer can shape its own
+ * attack/release envelope (the night-sky glow does its smoothing in
+ * feature land).
+ */
+const MASTER_METER_SMOOTHING = 0;
+
 // -----------------------------------------------------------------------------
 // AudioEngine
 // -----------------------------------------------------------------------------
@@ -155,6 +163,12 @@ class AudioEngine {
    * consumers survive kit loads.
    */
   private meters: (Meter | null)[] = [];
+  /**
+   * Engine-owned master output level tap, created lazily by
+   * getMasterLevelDb and reconnected to each new master bus (init and
+   * rebuild) so polling consumers survive graph reconstruction.
+   */
+  private masterMeter: Meter | null = null;
 
   // --- Kit metadata (derived at loadKit time) ---
   private roles: InstrumentRole[] = [];
@@ -253,6 +267,12 @@ class AudioEngine {
 
     this.masterBus = bus;
 
+    // Reattach the master level tap to the new bus (init after dispose,
+    // or a rebuild's re-init) so polling consumers keep reading levels.
+    if (this.masterMeter) {
+      bus.connectOutputTap(this.masterMeter);
+    }
+
     // Settings may have been pushed while the bus was being built.
     if (this.masterSettings !== masterSettings) {
       bus.applySettings(this.masterSettings ?? masterSettings);
@@ -283,6 +303,9 @@ class AudioEngine {
 
     this.meters.forEach((meter) => meter?.dispose());
     this.meters = [];
+
+    this.masterMeter?.dispose();
+    this.masterMeter = null;
 
     this.masterBus?.dispose();
     this.masterBus = null;
@@ -808,6 +831,27 @@ class AudioEngine {
       this.channels[index]?.output.connect(meter);
     }
     return meter;
+  }
+
+  /**
+   * Current master output level in dB RMS, tapped AFTER the limiter on the
+   * live master bus, so it reads exactly what reaches the speakers (the
+   * offline renderWav path is untouched). Returns -Infinity while silent
+   * or before the bus exists.
+   *
+   * The meter is created lazily on the first call, so the tap costs
+   * nothing until something polls it, and it survives rebuild(): doInit
+   * reconnects the retained meter to each replacement bus. Unsmoothed by
+   * design (see MASTER_METER_SMOOTHING); consumers shape their own
+   * attack/release. Safe to poll from requestAnimationFrame loops.
+   */
+  getMasterLevelDb(): number {
+    if (!this.masterMeter) {
+      this.masterMeter = new Meter({ smoothing: MASTER_METER_SMOOTHING });
+      this.masterBus?.connectOutputTap(this.masterMeter);
+    }
+    const value = this.masterMeter.getValue();
+    return typeof value === "number" ? value : value[0];
   }
 
   /**

--- a/src/core/audio/engine/master-bus.ts
+++ b/src/core/audio/engine/master-bus.ts
@@ -225,6 +225,17 @@ class MasterBus {
   }
 
   /**
+   * Connects a read-only tap (e.g. a meter) to the bus output, AFTER the
+   * limiter, so the tap observes exactly the signal that reaches the
+   * destination. Disposing the bus disconnects the tap along with the
+   * limiter; callers that keep tap nodes alive across rebuilds must
+   * reconnect them to the replacement bus.
+   */
+  connectOutputTap(tap: ToneAudioNode): void {
+    this.nodes.limiter.connect(tap);
+  }
+
+  /**
    * Disposes all master bus nodes.
    * Handles errors gracefully to prevent crashes during cleanup.
    */

--- a/src/features/night/components/night-sky.tsx
+++ b/src/features/night/components/night-sky.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from "react";
 
+import { nearPlaneFade, nearScaleCap } from "@/features/night/lib/star-field";
+
 interface Star {
   x: number;
   y: number;
@@ -87,28 +89,36 @@ function NightSky() {
       const baseOpacity = 0.7 + Math.sin(time * 0.5) * 0.1;
 
       // Draw stars
+      const fov = 2;
+      const scaleCap = nearScaleCap(fov);
+
       stars.forEach((star) => {
         // Apply rotation, need to reassign z and not double compute
         let { x, z } = rotateY(star.x, star.z, rotationRef.current.y);
         let { y } = rotateX(star.y, z, rotationRef.current.x);
         ({ y, z } = rotateX(y, z, rotationRef.current.x));
 
+        // Near-plane dissolve: stars approaching the camera fade out over
+        // a z-band (and their projection scale is capped) instead of
+        // ballooning and vanishing in a single frame.
+        const fade = nearPlaneFade(z, fov);
+        if (fade === 0) return;
+
         // Simple perspective projection
-        const fov = 2;
-        const scale = fov / (fov + z);
+        const scale = Math.min(fov / (fov + z), scaleCap);
         const x2d = x * scale * width * 0.15 + width / 2;
         const y2d = y * scale * height * 0.15 + height / 2;
 
         // Size with perspective
         const size = star.size * scale * 2;
 
-        // Skip if behind camera or off-screen
-        if (z < -fov || size < 0.1) return;
+        // Skip if too small or off-screen
+        if (size < 0.1) return;
         if (x2d < -50 || x2d > width + 50 || y2d < -50 || y2d > height + 50)
           return;
 
         // Draw star with glow effect (Minecraft-style squares)
-        const opacity = baseOpacity * (0.6 + scale * 0.4);
+        const opacity = baseOpacity * (0.6 + scale * 0.4) * fade;
         ctx.globalCompositeOperation = "lighter"; // Additive blending
 
         // Glow (larger square)

--- a/src/features/night/components/night-sky.tsx
+++ b/src/features/night/components/night-sky.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef } from "react";
 
+import { getAudioEngine } from "@/core/audio/engine";
 import { nearPlaneFade, nearScaleCap } from "@/features/night/lib/star-field";
+import {
+  GLOW_ACTIVE_THRESHOLD,
+  GLOW_BRIGHTNESS_GAIN,
+  GLOW_SILENT_THRESHOLD,
+  GLOW_SIZE_GAIN,
+  glowTargetFromDb,
+  smoothGlowLevel,
+} from "@/features/night/lib/star-glow";
 
 interface Star {
   x: number;
@@ -71,6 +80,10 @@ function NightSky() {
     };
 
     // Animation loop
+    let lastFrameAt: number | null = null;
+    let glowLevel = 0;
+    let glowSeamActive = false;
+
     const animate = () => {
       animationFrameRef.current = requestAnimationFrame(animate);
 
@@ -87,6 +100,32 @@ function NightSky() {
       // Twinkling effect
       const time = Date.now() * 0.001;
       const baseOpacity = 0.7 + Math.sin(time * 0.5) * 0.1;
+
+      const now = performance.now();
+      const deltaMs = lastFrameAt === null ? 0 : now - lastFrameAt;
+      lastFrameAt = now;
+
+      // Audio-coupled glow: the glow squares breathe with the
+      // engine's actual master output level (post-limiter dB RMS), polled
+      // imperatively each frame like an audio visualizer. Silence decays
+      // to exactly 0, restoring the baseline idle look.
+      glowLevel = smoothGlowLevel(
+        glowLevel,
+        glowTargetFromDb(getAudioEngine().getMasterLevelDb()),
+        deltaMs,
+      );
+      const glowSizeBoost = 1 + GLOW_SIZE_GAIN * glowLevel;
+      const glowAlphaBoost = 1 + GLOW_BRIGHTNESS_GAIN * glowLevel;
+
+      // Test seam for the audio layer, written only on state change
+      // (hysteresis keeps it from flapping at the threshold).
+      if (!glowSeamActive && glowLevel > GLOW_ACTIVE_THRESHOLD) {
+        glowSeamActive = true;
+        canvas.dataset.starGlow = "active";
+      } else if (glowSeamActive && glowLevel < GLOW_SILENT_THRESHOLD) {
+        glowSeamActive = false;
+        canvas.dataset.starGlow = "silent";
+      }
 
       // Draw stars
       const fov = 2;
@@ -121,9 +160,9 @@ function NightSky() {
         const opacity = baseOpacity * (0.6 + scale * 0.4) * fade;
         ctx.globalCompositeOperation = "lighter"; // Additive blending
 
-        // Glow (larger square)
-        const glowSize = size * 1.5;
-        ctx.fillStyle = `rgba(${star.r * 255}, ${star.g * 255}, ${star.b * 255}, ${opacity * 0.3})`;
+        // Glow (larger square); size and opacity ride the audio level
+        const glowSize = size * 1.5 * glowSizeBoost;
+        ctx.fillStyle = `rgba(${star.r * 255}, ${star.g * 255}, ${star.b * 255}, ${opacity * 0.3 * glowAlphaBoost})`;
         ctx.fillRect(
           x2d - glowSize,
           y2d - glowSize,
@@ -159,6 +198,7 @@ function NightSky() {
   return (
     <canvas
       ref={canvasRef}
+      data-star-glow="silent"
       className="fixed inset-0 z-0"
       style={{
         width: "100vw",

--- a/src/features/night/lib/star-field.test.ts
+++ b/src/features/night/lib/star-field.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { NEAR_FADE_BAND, nearPlaneFade, nearScaleCap } from "./star-field";
+
+const FOV = 2;
+
+describe("nearPlaneFade", () => {
+  it("is fully opaque at and beyond the fade band", () => {
+    expect(nearPlaneFade(-FOV + NEAR_FADE_BAND, FOV)).toBe(1);
+    expect(nearPlaneFade(0, FOV)).toBe(1);
+    expect(nearPlaneFade(5, FOV)).toBe(1);
+  });
+
+  it("is fully transparent at and behind the near plane", () => {
+    expect(nearPlaneFade(-FOV, FOV)).toBe(0);
+    expect(nearPlaneFade(-FOV - 1, FOV)).toBe(0);
+  });
+
+  it("passes the midpoint at half opacity (smoothstep symmetry)", () => {
+    expect(nearPlaneFade(-FOV + NEAR_FADE_BAND / 2, FOV)).toBeCloseTo(0.5, 5);
+  });
+
+  it("decreases monotonically toward the plane with no visible corner", () => {
+    let previous = 1;
+    for (let i = 1; i <= 20; i++) {
+      const z = -FOV + NEAR_FADE_BAND * (1 - i / 20);
+      const fade = nearPlaneFade(z, FOV);
+      expect(fade).toBeLessThan(previous);
+      previous = fade;
+    }
+    expect(previous).toBe(0);
+  });
+
+  it("eases at the band edges (smoothstep, near-zero slope)", () => {
+    const step = NEAR_FADE_BAND / 1000;
+    const nearEdge = nearPlaneFade(-FOV + step, FOV);
+    const farEdge = 1 - nearPlaneFade(-FOV + NEAR_FADE_BAND - step, FOV);
+    // A linear ramp would move 0.001 per step; smoothstep moves ~0.
+    expect(nearEdge).toBeLessThan(0.0001);
+    expect(farEdge).toBeLessThan(0.0001);
+  });
+});
+
+describe("nearScaleCap", () => {
+  it("equals the projection scale at the near edge of the band", () => {
+    // scale(z) = fov / (fov + z) evaluated at z = band - fov.
+    expect(nearScaleCap(FOV)).toBeCloseTo(FOV / NEAR_FADE_BAND, 10);
+  });
+
+  it("caps the otherwise unbounded near-plane blowup", () => {
+    const zNearPlane = -FOV + 0.001;
+    const rawScale = FOV / (FOV + zNearPlane);
+    expect(rawScale).toBeGreaterThan(nearScaleCap(FOV) * 100);
+  });
+});

--- a/src/features/night/lib/star-field.ts
+++ b/src/features/night/lib/star-field.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure geometry for the night sky's near-plane dissolve. Kept free of
+ * canvas/React so the fade curve is unit-testable.
+ */
+
+/**
+ * Width of the near-plane dissolve band, in z units. Stars fade out as z
+ * falls from (band - fov) to -fov instead of being hard-culled: the old
+ * cut let scale = fov / (fov + z) balloon a star right up to the plane and
+ * then drop it in a single frame - a visible pop during rotation. The band
+ * also caps the projection scale (fov / band at the band edge), so a
+ * dissolving star stops growing while it fades.
+ */
+const NEAR_FADE_BAND = 0.5;
+
+/**
+ * Near-plane fade factor (0..1) for a star at depth z under the given
+ * projection fov: 1 at and beyond the band, easing smoothly to 0 at the
+ * near plane (smoothstep, so the dissolve has no visible corner). Returns
+ * 0 for anything at or behind the plane.
+ */
+function nearPlaneFade(z: number, fov: number): number {
+  const t = (z + fov) / NEAR_FADE_BAND;
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  return t * t * (3 - 2 * t);
+}
+
+/**
+ * The maximum projection scale, reached at the near edge of the fade band.
+ * Clamping to this keeps dissolving stars from ballooning: beyond the band
+ * they only fade.
+ */
+function nearScaleCap(fov: number): number {
+  return fov / NEAR_FADE_BAND;
+}
+
+export { NEAR_FADE_BAND, nearPlaneFade, nearScaleCap };

--- a/src/features/night/lib/star-glow.test.ts
+++ b/src/features/night/lib/star-glow.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GLOW_ACTIVE_THRESHOLD,
+  GLOW_ATTACK_TAU_MS,
+  GLOW_DB_FLOOR,
+  GLOW_RELEASE_TAU_MS,
+  GLOW_SILENT_THRESHOLD,
+  glowTargetFromDb,
+  smoothGlowLevel,
+} from "./star-glow";
+
+describe("glowTargetFromDb", () => {
+  it("maps silence (-Infinity dB) to 0", () => {
+    expect(glowTargetFromDb(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+
+  it("maps NaN defensively to 0", () => {
+    expect(glowTargetFromDb(Number.NaN)).toBe(0);
+  });
+
+  it("clamps at and below the dB floor to 0", () => {
+    expect(glowTargetFromDb(GLOW_DB_FLOOR)).toBe(0);
+    expect(glowTargetFromDb(GLOW_DB_FLOOR - 20)).toBe(0);
+  });
+
+  it("clamps at and above 0 dB to 1", () => {
+    expect(glowTargetFromDb(0)).toBe(1);
+    expect(glowTargetFromDb(6)).toBe(1);
+  });
+
+  it("is linear in dB between the floor and 0 dB", () => {
+    expect(glowTargetFromDb(GLOW_DB_FLOOR / 2)).toBeCloseTo(0.5, 5);
+    expect(glowTargetFromDb(GLOW_DB_FLOOR * 0.75)).toBeCloseTo(0.25, 5);
+    expect(glowTargetFromDb(GLOW_DB_FLOOR * 0.25)).toBeCloseTo(0.75, 5);
+  });
+});
+
+describe("smoothGlowLevel", () => {
+  it("attacks fast: one attack tau covers ~63% of a rise", () => {
+    const level = smoothGlowLevel(0, 1, GLOW_ATTACK_TAU_MS);
+    expect(level).toBeCloseTo(1 - Math.exp(-1), 5);
+  });
+
+  it("releases slowly: a 16ms frame barely moves a fall", () => {
+    const level = smoothGlowLevel(1, 0, 16);
+    expect(level).toBeCloseTo(Math.exp(-16 / GLOW_RELEASE_TAU_MS), 5);
+    expect(level).toBeGreaterThan(0.9);
+  });
+
+  it("rises much faster than it falls for the same time step", () => {
+    const rise = smoothGlowLevel(0, 1, 16);
+    const fall = 1 - smoothGlowLevel(1, 0, 16);
+    expect(rise).toBeGreaterThan(fall * 5);
+  });
+
+  it("is frame-rate independent for a held target", () => {
+    const oneStep = smoothGlowLevel(0.2, 1, 16);
+    const twoSteps = smoothGlowLevel(smoothGlowLevel(0.2, 1, 8), 1, 8);
+    expect(twoSteps).toBeCloseTo(oneStep, 10);
+  });
+
+  it("does not move on a zero time step", () => {
+    expect(smoothGlowLevel(0.4, 1, 0)).toBe(0.4);
+  });
+
+  it("clamps negative time steps instead of overshooting", () => {
+    expect(smoothGlowLevel(0.4, 1, -50)).toBe(0.4);
+  });
+
+  it("snaps the silent tail to exactly 0", () => {
+    // Decay from a low level toward silence crosses the epsilon and must
+    // land on a true 0 so idle rendering is bit-identical to baseline.
+    let level = 0.01;
+    for (let i = 0; i < 200 && level !== 0; i++) {
+      level = smoothGlowLevel(level, 0, 16);
+    }
+    expect(level).toBe(0);
+  });
+
+  it("never snaps while the target itself is audible", () => {
+    expect(smoothGlowLevel(0.0005, 0.5, 16)).toBeGreaterThan(0);
+  });
+});
+
+describe("test-seam thresholds", () => {
+  it("keeps hysteresis: active threshold sits above the silent one", () => {
+    expect(GLOW_ACTIVE_THRESHOLD).toBeGreaterThan(GLOW_SILENT_THRESHOLD);
+  });
+});

--- a/src/features/night/lib/star-glow.ts
+++ b/src/features/night/lib/star-glow.ts
@@ -1,0 +1,102 @@
+/**
+ * Audio-coupled glow math for the night sky.
+ *
+ * The starfield's glow tracks the engine's ACTUAL master output level
+ * (post-limiter dB RMS from getMasterLevelDb) like an audio visualizer,
+ * breathing with the loudness of the mix. Pure functions so the curve is
+ * unit-testable; the canvas rAF loop polls the level imperatively each
+ * frame and never touches React state.
+ *
+ * The curve, visualizer-style:
+ * 1. dB -> target: linear-in-dB normalization over [GLOW_DB_FLOOR, 0].
+ *    Equal dB steps read as equal visual steps, which tracks loudness
+ *    perception far better than linear amplitude. Silence (-Infinity, or
+ *    anything at/below the floor) maps to 0; 0 dB and above map to 1.
+ * 2. target -> level: exponential attack/release smoothing. Fast attack
+ *    so hits register on their transient; slower release so the glow
+ *    falls away musically instead of flickering per RMS window.
+ * 3. Levels below GLOW_LEVEL_EPSILON with a silent target snap to exactly
+ *    0, so idle rendering is bit-identical to the baseline look.
+ */
+
+/** Master levels at/below this dB read as silence (target 0). */
+const GLOW_DB_FLOOR = -60;
+
+/** Attack time constant: ~63% of the way to a louder target in this long. */
+const GLOW_ATTACK_TAU_MS = 20;
+
+/** Release time constant: ~63% of the way to a quieter target in this long. */
+const GLOW_RELEASE_TAU_MS = 180;
+
+/** Below this (with a silent target) the level snaps to exactly 0. */
+const GLOW_LEVEL_EPSILON = 0.001;
+
+/**
+ * Cap on the smoothing time step, so a backgrounded tab (throttled rAF)
+ * eases back in instead of jumping on return.
+ */
+const GLOW_MAX_FRAME_DELTA_MS = 100;
+
+/**
+ * Tuning constants for how strongly the glow reacts. Both are peak
+ * fractional boosts at a 0 dB master level; typical playback sits well
+ * below that, so the working range is a fraction of these. Tuned ambient:
+ * the sky is a background visualizer and must never pull focus.
+ */
+
+/** Peak fractional glow-size boost. */
+const GLOW_SIZE_GAIN = 0.2;
+
+/** Peak fractional glow-opacity boost. */
+const GLOW_BRIGHTNESS_GAIN = 0.1;
+
+/**
+ * Test-seam hysteresis for the data-star-glow attribute: "active" above
+ * the high threshold, back to "silent" below the low one, so the seam
+ * does not flap on the boundary.
+ */
+const GLOW_ACTIVE_THRESHOLD = 0.05;
+const GLOW_SILENT_THRESHOLD = 0.02;
+
+/**
+ * Maps a master output level in dB (RMS, -Infinity for silence) to the
+ * glow target in 0..1, linear in dB between GLOW_DB_FLOOR and 0.
+ */
+function glowTargetFromDb(db: number): number {
+  if (Number.isNaN(db)) return 0;
+  const normalized = (db - GLOW_DB_FLOOR) / -GLOW_DB_FLOOR;
+  return Math.min(1, Math.max(0, normalized));
+}
+
+/**
+ * One frame of visualizer smoothing: exponential approach to the target
+ * with a fast attack and slower release. Frame-rate independent for a
+ * held target (two 8ms steps land exactly where one 16ms step does);
+ * deltaMs is clamped to [0, GLOW_MAX_FRAME_DELTA_MS].
+ */
+function smoothGlowLevel(
+  previous: number,
+  target: number,
+  deltaMs: number,
+): number {
+  const clampedDelta = Math.min(Math.max(deltaMs, 0), GLOW_MAX_FRAME_DELTA_MS);
+  const tau = target > previous ? GLOW_ATTACK_TAU_MS : GLOW_RELEASE_TAU_MS;
+  const alpha = 1 - Math.exp(-clampedDelta / tau);
+  const next = previous + (target - previous) * alpha;
+
+  // Snap the tail to a true 0 so silence renders the exact baseline.
+  if (next < GLOW_LEVEL_EPSILON && target < GLOW_LEVEL_EPSILON) return 0;
+  return next;
+}
+
+export {
+  GLOW_ACTIVE_THRESHOLD,
+  GLOW_ATTACK_TAU_MS,
+  GLOW_BRIGHTNESS_GAIN,
+  GLOW_DB_FLOOR,
+  GLOW_RELEASE_TAU_MS,
+  GLOW_SILENT_THRESHOLD,
+  GLOW_SIZE_GAIN,
+  glowTargetFromDb,
+  smoothGlowLevel,
+};

--- a/src/layout/floating-menu.tsx
+++ b/src/layout/floating-menu.tsx
@@ -65,7 +65,10 @@ function FloatingMenu() {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button className="text-primary border-primary hover:bg-accent/20 focus-ring fixed top-2 left-2 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 bg-transparent backdrop-blur-xl transition-all duration-500">
+          <button
+            aria-label="Menu"
+            className="text-primary border-primary hover:bg-accent/20 focus-ring fixed top-2 left-2 z-50 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border-2 bg-transparent backdrop-blur-xl transition-all duration-500"
+          >
             <DrumhausLogo size={20} fill="currentColor" />
           </button>
         </DropdownMenuTrigger>


### PR DESCRIPTION
## Preview

**Preview (final shape): https://249c70b8.drumhaus.pages.dev**
Branch alias: https://feat-268-stars-transport-pul.drumhaus.pages.dev
Enable Night Mode from the floating menu, press play, and let it sit in your peripheral vision.

## Summary

Night mode becomes a background audio visualizer: the star glow breathes with the actual loudness of the mix.
The reaction is deliberately ambient - the user is making beats in the foreground and the sky must never pull focus.

- **Loudness-coupled glow.** The glow squares follow the engine's master output level: post-limiter dB RMS, mapped linear-in-dB from a -60dB floor (tracking loudness perception), through a fast-attack (20ms) slow-release (180ms) visualizer envelope. Silence decays to a snapped zero, so the idle look is bit-identical to the baseline twinkle. Polled imperatively inside the canvas rAF loop; no per-frame allocations, nothing engine-related read during React render.
- **Near-plane dissolve fix (pre-existing artifact).** Stars were hard-culled at the near plane while the projection scale blew up unbounded on approach, so near stars ballooned and vanished in one frame during the slow orbit. They now dissolve over a smoothstep z-band with the scale capped at the band edge.

## Dropped by design

A transport-synced positional beat pulse (a per-quarter-note projection "breath") was prototyped and reviewed on this PR's earlier previews, and dropped by maintainer decision: positional expansion cannot be dialed subtle enough for a background visualizer - it grabs attention no matter the gain - while luminosity coupled to the engine level tap reads as subtle.
The audio-coupled glow is the resolution of #268's intent.

## Engine surface

`getMasterLevelDb()` on the AudioEngine facade: a reusable read-only tap for audio visualizers (documented in docs/audio-engine-refactor.md), mirroring `getChannelMeter`.
Tapped after the limiter on the live bus; unsmoothed by design so each consumer shapes its own envelope; created lazily so it costs nothing until polled; survives `rebuild()` via reattachment in doInit; the offline render path is untouched.
Engine purity greps stay at zero hits.

## Tunables (all named constants)

- `src/features/night/lib/star-glow.ts`: `GLOW_SIZE_GAIN`, `GLOW_BRIGHTNESS_GAIN`, `GLOW_DB_FLOOR`, `GLOW_ATTACK_TAU_MS`, `GLOW_RELEASE_TAU_MS`
- `src/features/night/lib/star-field.ts`: `NEAR_FADE_BAND`

## Tests

- Unit tests for all pure math: glow dB mapping and attack/release smoothing (frame-rate independence, silent-tail snap) and the near-plane fade curve.
- Engine browser tests pin the tap's contract: silence when idle, lazy creation before init, functional across `rebuild()`. Loudness itself is not asserted - live meters read silence under automation harnesses (documented in kit-swap-chain.browser.test.ts), so that would be flaky by construction.
- E2E (`e2e/night-visualizer.spec.ts`): enables night mode from the menu, asserts the `data-star-glow` seam mounts silent, stays a valid state across a playback cycle, and settles silent after stop. The floating-menu trigger gained an `aria-label` for reachability.
- Full gates green locally: prettier, oxlint, vitest (1052), build, smoke:lightshow, Playwright suite 11/11.

Closes #268
