### PR TITLE
feat(export): add MIDI export (#17)

### DIFF
--- a/e2e/midi-export.spec.ts
+++ b/e2e/midi-export.spec.ts
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import { expect, test } from "@playwright/test";
+
+import { gotoApp, toggleStep } from "./helpers";
+
+interface MidiNoteOn {
+  tick: number;
+  channel: number;
+  note: number;
+  velocity: number;
+}
+
+interface MidiTrackInfo {
+  name: string;
+  noteOns: MidiNoteOn[];
+}
+
+interface MidiInfo {
+  format: number;
+  trackCount: number;
+  division: number;
+  bpm: number;
+  tracks: MidiTrackInfo[];
+}
+
+/** Minimal SMF reader: validates the header and walks every track chunk. */
+function parseMidi(buffer: Buffer): MidiInfo {
+  expect(buffer.length).toBeGreaterThan(14);
+  expect(buffer.toString("ascii", 0, 4)).toBe("MThd");
+  expect(buffer.readUInt32BE(4)).toBe(6);
+
+  const format = buffer.readUInt16BE(8);
+  const trackCount = buffer.readUInt16BE(10);
+  const division = buffer.readUInt16BE(12);
+
+  const readVarLen = (offset: number): { value: number; next: number } => {
+    let value = 0;
+    let next = offset;
+    for (;;) {
+      const byte = buffer[next++];
+      value = (value << 7) | (byte & 0x7f);
+      if ((byte & 0x80) === 0) break;
+    }
+    return { value, next };
+  };
+
+  let bpm = 0;
+  const tracks: MidiTrackInfo[] = [];
+  let offset = 14;
+
+  while (offset < buffer.length) {
+    expect(buffer.toString("ascii", offset, offset + 4)).toBe("MTrk");
+    const chunkLength = buffer.readUInt32BE(offset + 4);
+    let cursor = offset + 8;
+    const end = cursor + chunkLength;
+
+    let tick = 0;
+    let name = "";
+    const noteOns: MidiNoteOn[] = [];
+
+    while (cursor < end) {
+      const delta = readVarLen(cursor);
+      cursor = delta.next;
+      tick += delta.value;
+      const status = buffer[cursor++];
+
+      if (status === 0xff) {
+        const metaType = buffer[cursor++];
+        const length = readVarLen(cursor);
+        cursor = length.next;
+        if (metaType === 0x03) {
+          name = buffer.toString("ascii", cursor, cursor + length.value);
+        } else if (metaType === 0x51) {
+          const microsecondsPerBeat =
+            (buffer[cursor] << 16) |
+            (buffer[cursor + 1] << 8) |
+            buffer[cursor + 2];
+          bpm = 60_000_000 / microsecondsPerBeat;
+        }
+        cursor += length.value;
+      } else {
+        const type = status & 0xf0;
+        expect([0x80, 0x90]).toContain(type);
+        const note = buffer[cursor];
+        const velocity = buffer[cursor + 1];
+        cursor += 2;
+        if (type === 0x90 && velocity > 0) {
+          noteOns.push({ tick, channel: status & 0x0f, note, velocity });
+        }
+      }
+    }
+
+    expect(cursor).toBe(end);
+    tracks.push({ name, noteOns });
+    offset = end;
+  }
+
+  expect(tracks).toHaveLength(trackCount);
+  return { format, trackCount, division, bpm, tracks };
+}
+
+test.describe("MIDI export", () => {
+  test("exports the pattern as a valid MIDI download", async ({ page }) => {
+    await gotoApp(page);
+
+    // Put steps 0 and 8 into the kick lane (voice 0 is selected by default).
+    await toggleStep(page, 0, "true");
+    await toggleStep(page, 8, "true");
+
+    await page.getByRole("button", { name: "Export", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "Export" });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("tab", { name: "MIDI" }).click();
+    await dialog.getByLabel("Filename").fill("e2e-midi-export");
+
+    const downloadPromise = page.waitForEvent("download", {
+      timeout: 30_000,
+    });
+    await dialog.getByRole("button", { name: "Export", exact: true }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe("e2e-midi-export.mid");
+
+    const path = await download.path();
+    const midi = parseMidi(fs.readFileSync(path));
+
+    // SMF format 1 at PPQ 480: a conductor track plus one track per voice.
+    expect(midi.format).toBe(1);
+    expect(midi.trackCount).toBe(9);
+    expect(midi.division).toBe(480);
+    expect(midi.tracks[0].name).toBe("e2e-midi-export");
+
+    // The tempo meta event carries the transport BPM.
+    expect(midi.bpm).toBeGreaterThanOrEqual(40);
+    expect(midi.bpm).toBeLessThanOrEqual(300);
+
+    // The kick lane holds the toggled steps: steps 0 and 8 of each of the
+    // two exported bars (one bar is 16 steps * 120 ticks), on GM note 36
+    // (Bass Drum 1), channel 10, at full velocity.
+    const kick = midi.tracks[1];
+    expect(kick.noteOns.map((event) => event.tick)).toEqual([
+      0, 960, 1920, 2880,
+    ]);
+    for (const event of kick.noteOns) {
+      expect(event.channel).toBe(9);
+      expect(event.note).toBe(36);
+      expect(event.velocity).toBe(127);
+    }
+
+    // No other lane picked up notes.
+    for (const track of midi.tracks.slice(2)) {
+      expect(track.noteOns).toHaveLength(0);
+    }
+
+    // The dialog closes and the app confirms the export.
+    await expect(dialog).not.toBeVisible();
+    await expect(
+      page.getByText("Export successful", { exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/src/core/audio/export/index.ts
+++ b/src/core/audio/export/index.ts
@@ -6,3 +6,9 @@ export {
   type ExportProgress,
 } from "./wav-exporter";
 export { downloadWav, encodeWav, generateExportFilename } from "./wav-encoder";
+export {
+  exportToMidi,
+  type MidiExportOptions,
+  type MidiVoiceDescriptor,
+} from "./midi-exporter";
+export { downloadMidi, encodeMidi } from "./midi-encoder";

--- a/src/core/audio/export/midi-encoder.test.ts
+++ b/src/core/audio/export/midi-encoder.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  encodeMidi,
+  encodeVariableLengthQuantity,
+  type MidiFile,
+} from "./midi-encoder";
+
+// -----------------------------------------------------------------------------
+// Minimal SMF reader (covers exactly what the encoder emits)
+// -----------------------------------------------------------------------------
+
+interface ParsedEvent {
+  deltaTicks: number;
+  /** "meta" for FF events, otherwise "on" / "off". */
+  kind: "meta" | "on" | "off";
+  /** Meta type byte for meta events. */
+  metaType?: number;
+  data: number[];
+  channel?: number;
+}
+
+interface ParsedTrack {
+  events: ParsedEvent[];
+}
+
+interface ParsedMidi {
+  format: number;
+  trackCount: number;
+  division: number;
+  tracks: ParsedTrack[];
+}
+
+function readVariableLengthQuantity(
+  bytes: Uint8Array,
+  offset: number,
+): { value: number; next: number } {
+  let value = 0;
+  let next = offset;
+  for (;;) {
+    const byte = bytes[next++];
+    value = (value << 7) | (byte & 0x7f);
+    if ((byte & 0x80) === 0) break;
+  }
+  return { value, next };
+}
+
+function parseMidi(buffer: ArrayBuffer): ParsedMidi {
+  const bytes = new Uint8Array(buffer);
+  const ascii = (start: number, length: number) =>
+    String.fromCharCode(...bytes.slice(start, start + length));
+  const uint32 = (start: number) =>
+    (bytes[start] << 24) |
+    (bytes[start + 1] << 16) |
+    (bytes[start + 2] << 8) |
+    bytes[start + 3];
+  const uint16 = (start: number) => (bytes[start] << 8) | bytes[start + 1];
+
+  expect(ascii(0, 4)).toBe("MThd");
+  expect(uint32(4)).toBe(6);
+  const format = uint16(8);
+  const trackCount = uint16(10);
+  const division = uint16(12);
+
+  const tracks: ParsedTrack[] = [];
+  let offset = 14;
+  while (offset < bytes.length) {
+    expect(ascii(offset, 4)).toBe("MTrk");
+    const chunkLength = uint32(offset + 4);
+    let cursor = offset + 8;
+    const end = cursor + chunkLength;
+    const events: ParsedEvent[] = [];
+
+    while (cursor < end) {
+      const delta = readVariableLengthQuantity(bytes, cursor);
+      cursor = delta.next;
+      const status = bytes[cursor++];
+
+      if (status === 0xff) {
+        const metaType = bytes[cursor++];
+        const length = readVariableLengthQuantity(bytes, cursor);
+        cursor = length.next;
+        events.push({
+          deltaTicks: delta.value,
+          kind: "meta",
+          metaType,
+          data: Array.from(bytes.slice(cursor, cursor + length.value)),
+        });
+        cursor += length.value;
+      } else {
+        const type = status & 0xf0;
+        expect([0x80, 0x90]).toContain(type);
+        events.push({
+          deltaTicks: delta.value,
+          kind: type === 0x90 ? "on" : "off",
+          channel: status & 0x0f,
+          data: [bytes[cursor], bytes[cursor + 1]],
+        });
+        cursor += 2;
+      }
+    }
+
+    expect(cursor).toBe(end);
+    tracks.push({ events });
+    offset = end;
+  }
+
+  expect(tracks).toHaveLength(trackCount);
+  return { format, trackCount, division, tracks };
+}
+
+function noteEvents(track: ParsedTrack): ParsedEvent[] {
+  return track.events.filter((event) => event.kind !== "meta");
+}
+
+// -----------------------------------------------------------------------------
+// Variable-length quantities
+// -----------------------------------------------------------------------------
+
+describe("encodeVariableLengthQuantity", () => {
+  it("encodes the SMF specification's reference vectors", () => {
+    expect(encodeVariableLengthQuantity(0x00)).toEqual([0x00]);
+    expect(encodeVariableLengthQuantity(0x40)).toEqual([0x40]);
+    expect(encodeVariableLengthQuantity(0x7f)).toEqual([0x7f]);
+    expect(encodeVariableLengthQuantity(0x80)).toEqual([0x81, 0x00]);
+    expect(encodeVariableLengthQuantity(0x2000)).toEqual([0xc0, 0x00]);
+    expect(encodeVariableLengthQuantity(0x3fff)).toEqual([0xff, 0x7f]);
+    expect(encodeVariableLengthQuantity(0x4000)).toEqual([0x81, 0x80, 0x00]);
+    expect(encodeVariableLengthQuantity(0xfffffff)).toEqual([
+      0xff, 0xff, 0xff, 0x7f,
+    ]);
+  });
+
+  it("encodes typical tick deltas at PPQ 480", () => {
+    expect(encodeVariableLengthQuantity(120)).toEqual([0x78]); // one 16th
+    expect(encodeVariableLengthQuantity(480)).toEqual([0x83, 0x60]); // one beat
+  });
+
+  it("round-trips through the reader", () => {
+    for (const value of [0, 1, 127, 128, 500, 100_000, 0xfffffff]) {
+      const encoded = Uint8Array.from(encodeVariableLengthQuantity(value));
+      expect(readVariableLengthQuantity(encoded, 0).value).toBe(value);
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// File encoding
+// -----------------------------------------------------------------------------
+
+function makeFile(overrides: Partial<MidiFile> = {}): MidiFile {
+  return {
+    ppq: 480,
+    bpm: 120,
+    name: "test-export",
+    tracks: [],
+    ...overrides,
+  };
+}
+
+describe("encodeMidi", () => {
+  it("writes a format 1 header with PPQ division and conductor track", () => {
+    const parsed = parseMidi(
+      encodeMidi(
+        makeFile({
+          tracks: [
+            { name: "Kick", channel: 9, notes: [] },
+            { name: "Snare", channel: 9, notes: [] },
+          ],
+        }),
+      ),
+    );
+
+    expect(parsed.format).toBe(1);
+    expect(parsed.trackCount).toBe(3); // conductor + 2 voices
+    expect(parsed.division).toBe(480);
+  });
+
+  it("writes tempo, time signature, and names to the conductor track", () => {
+    const parsed = parseMidi(encodeMidi(makeFile({ bpm: 100 })));
+    const conductor = parsed.tracks[0];
+
+    const name = conductor.events.find((event) => event.metaType === 0x03);
+    expect(name?.data.map((c) => String.fromCharCode(c)).join("")).toBe(
+      "test-export",
+    );
+
+    // 100 BPM -> 600,000 microseconds per beat -> 0x09 0x27 0xC0.
+    const tempo = conductor.events.find((event) => event.metaType === 0x51);
+    expect(tempo?.data).toEqual([0x09, 0x27, 0xc0]);
+
+    // 4/4, 24 clocks per click, 8 32nds per quarter.
+    const timeSignature = conductor.events.find(
+      (event) => event.metaType === 0x58,
+    );
+    expect(timeSignature?.data).toEqual([0x04, 0x02, 0x18, 0x08]);
+
+    const endOfTrack = conductor.events[conductor.events.length - 1];
+    expect(endOfTrack?.metaType).toBe(0x2f);
+  });
+
+  it("encodes a note as a delta-timed on/off pair on the track's channel", () => {
+    const parsed = parseMidi(
+      encodeMidi(
+        makeFile({
+          tracks: [
+            {
+              name: "Kick",
+              channel: 9,
+              notes: [
+                { tick: 120, note: 36, velocity: 100, durationTicks: 60 },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+
+    const events = noteEvents(parsed.tracks[1]);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      deltaTicks: 120,
+      kind: "on",
+      channel: 9,
+      data: [36, 100],
+    });
+    expect(events[1]).toMatchObject({
+      deltaTicks: 60,
+      kind: "off",
+      channel: 9,
+      data: [36, 0],
+    });
+  });
+
+  it("orders a note-off before a coinciding note-on so ratchets never merge", () => {
+    const parsed = parseMidi(
+      encodeMidi(
+        makeFile({
+          tracks: [
+            {
+              name: "Snare",
+              channel: 9,
+              notes: [
+                { tick: 0, note: 38, velocity: 90, durationTicks: 60 },
+                { tick: 60, note: 38, velocity: 90, durationTicks: 60 },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+
+    const events = noteEvents(parsed.tracks[1]);
+    expect(events.map((event) => event.kind)).toEqual([
+      "on",
+      "off",
+      "on",
+      "off",
+    ]);
+    expect(events.map((event) => event.deltaTicks)).toEqual([0, 60, 0, 60]);
+  });
+
+  it("names voice tracks after their instruments", () => {
+    const parsed = parseMidi(
+      encodeMidi(
+        makeFile({
+          tracks: [
+            { name: "OHat", channel: 9, notes: [] },
+            { name: "Clap", channel: 9, notes: [] },
+          ],
+        }),
+      ),
+    );
+
+    const names = parsed.tracks.slice(1).map((track) =>
+      track.events
+        .find((event) => event.metaType === 0x03)
+        ?.data.map((c) => String.fromCharCode(c))
+        .join(""),
+    );
+    expect(names).toEqual(["OHat", "Clap"]);
+  });
+});

--- a/src/core/audio/export/midi-encoder.ts
+++ b/src/core/audio/export/midi-encoder.ts
@@ -1,0 +1,210 @@
+// --- Standard MIDI File (SMF) encoding utilities for MIDI export ---
+//
+// Hand-rolled format 1 encoder: one conductor track carrying tempo and time
+// signature metadata, followed by one named track per drum voice. Pure
+// byte-level encoding only - musical decisions (tick math, note mapping,
+// velocities) live in midi-exporter.ts.
+
+/**
+ * One note in absolute ticks. The encoder expands this into a note-on /
+ * note-off pair and handles delta-time conversion and event ordering.
+ */
+interface MidiNote {
+  /** Absolute position in ticks from the start of the file (>= 0). */
+  tick: number;
+  /** MIDI note number (0-127). */
+  note: number;
+  /** Note-on velocity (1-127). */
+  velocity: number;
+  /** Note length in ticks (>= 1). */
+  durationTicks: number;
+}
+
+interface MidiTrack {
+  /** Track name meta event text (e.g. the instrument's display name). */
+  name: string;
+  /** MIDI channel (0-15); drum tracks use 9 (channel 10, 1-based). */
+  channel: number;
+  notes: MidiNote[];
+}
+
+interface MidiFile {
+  /** Pulses (ticks) per quarter note. */
+  ppq: number;
+  /** Tempo for the tempo meta event, in beats per minute. */
+  bpm: number;
+  /** Name written to the conductor track (typically the export filename). */
+  name: string;
+  tracks: MidiTrack[];
+}
+
+// -----------------------------------------------------------------------------
+// Low-level byte helpers
+// -----------------------------------------------------------------------------
+
+/**
+ * Encodes a value as a MIDI variable-length quantity (VLQ): big-endian
+ * 7-bit groups, all but the last byte with the continuation bit set.
+ */
+function encodeVariableLengthQuantity(value: number): number[] {
+  const clamped = Math.max(0, Math.floor(value));
+  const bytes: number[] = [clamped & 0x7f];
+  let remaining = clamped >> 7;
+  while (remaining > 0) {
+    bytes.unshift((remaining & 0x7f) | 0x80);
+    remaining >>= 7;
+  }
+  return bytes;
+}
+
+function pushAscii(bytes: number[], text: string): void {
+  for (let i = 0; i < text.length; i++) {
+    bytes.push(text.charCodeAt(i) & 0x7f);
+  }
+}
+
+function pushUint32(bytes: number[], value: number): void {
+  bytes.push((value >>> 24) & 0xff);
+  bytes.push((value >>> 16) & 0xff);
+  bytes.push((value >>> 8) & 0xff);
+  bytes.push(value & 0xff);
+}
+
+function pushUint16(bytes: number[], value: number): void {
+  bytes.push((value >>> 8) & 0xff);
+  bytes.push(value & 0xff);
+}
+
+/** Track name meta event (FF 03 len text) at delta time 0. */
+function pushTrackNameEvent(bytes: number[], name: string): void {
+  const text = name.slice(0, 127);
+  bytes.push(0x00, 0xff, 0x03, text.length);
+  pushAscii(bytes, text);
+}
+
+/** End-of-track meta event (FF 2F 00) at delta time 0. */
+function pushEndOfTrackEvent(bytes: number[]): void {
+  bytes.push(0x00, 0xff, 0x2f, 0x00);
+}
+
+/** Wraps finished track event bytes in an MTrk chunk. */
+function buildTrackChunk(eventBytes: number[]): number[] {
+  const chunk: number[] = [];
+  pushAscii(chunk, "MTrk");
+  pushUint32(chunk, eventBytes.length);
+  return chunk.concat(eventBytes);
+}
+
+// -----------------------------------------------------------------------------
+// Track encoding
+// -----------------------------------------------------------------------------
+
+/**
+ * Conductor track: track name, tempo (FF 51), and a 4/4 time signature
+ * (FF 58), all at tick 0.
+ */
+function buildConductorTrack(name: string, bpm: number): number[] {
+  const bytes: number[] = [];
+  pushTrackNameEvent(bytes, name);
+
+  // Tempo in microseconds per quarter note.
+  const microsecondsPerBeat = Math.round(60_000_000 / bpm);
+  bytes.push(0x00, 0xff, 0x51, 0x03);
+  bytes.push((microsecondsPerBeat >>> 16) & 0xff);
+  bytes.push((microsecondsPerBeat >>> 8) & 0xff);
+  bytes.push(microsecondsPerBeat & 0xff);
+
+  // Time signature 4/4: numerator 4, denominator 2^2, 24 MIDI clocks per
+  // metronome click, 8 32nd notes per quarter.
+  bytes.push(0x00, 0xff, 0x58, 0x04, 0x04, 0x02, 0x18, 0x08);
+
+  pushEndOfTrackEvent(bytes);
+  return buildTrackChunk(bytes);
+}
+
+/** A note expanded into channel events, before delta conversion. */
+type ChannelEvent = {
+  tick: number;
+  /** Sort key: note-offs precede note-ons at the same tick so back-to-back
+   *  same-pitch notes (e.g. a hit followed by its ratchet) never merge. */
+  kind: "off" | "on";
+  note: number;
+  velocity: number;
+};
+
+function buildVoiceTrack(track: MidiTrack): number[] {
+  const events: ChannelEvent[] = [];
+  for (const note of track.notes) {
+    const tick = Math.max(0, Math.round(note.tick));
+    const durationTicks = Math.max(1, Math.round(note.durationTicks));
+    events.push({ tick, kind: "on", note: note.note, velocity: note.velocity });
+    events.push({
+      tick: tick + durationTicks,
+      kind: "off",
+      note: note.note,
+      velocity: 0,
+    });
+  }
+  events.sort(
+    (a, b) =>
+      a.tick - b.tick || (a.kind === b.kind ? 0 : a.kind === "off" ? -1 : 1),
+  );
+
+  const bytes: number[] = [];
+  pushTrackNameEvent(bytes, track.name);
+
+  const channel = track.channel & 0x0f;
+  let previousTick = 0;
+  for (const event of events) {
+    bytes.push(...encodeVariableLengthQuantity(event.tick - previousTick));
+    previousTick = event.tick;
+    const status = (event.kind === "on" ? 0x90 : 0x80) | channel;
+    bytes.push(status, event.note & 0x7f, event.velocity & 0x7f);
+  }
+
+  pushEndOfTrackEvent(bytes);
+  return buildTrackChunk(bytes);
+}
+
+// -----------------------------------------------------------------------------
+// File encoding
+// -----------------------------------------------------------------------------
+
+/**
+ * Encodes a MidiFile to Standard MIDI File format 1 bytes.
+ */
+function encodeMidi(file: MidiFile): ArrayBuffer {
+  const bytes: number[] = [];
+
+  // Header chunk: MThd, length 6, format 1, ntrks, division (PPQ).
+  pushAscii(bytes, "MThd");
+  pushUint32(bytes, 6);
+  pushUint16(bytes, 1); // format 1
+  pushUint16(bytes, 1 + file.tracks.length); // conductor + voice tracks
+  pushUint16(bytes, file.ppq);
+
+  bytes.push(...buildConductorTrack(file.name, file.bpm));
+  for (const track of file.tracks) {
+    bytes.push(...buildVoiceTrack(track));
+  }
+
+  return Uint8Array.from(bytes).buffer;
+}
+
+/**
+ * Triggers a browser download of the MIDI file
+ */
+function downloadMidi(midiBuffer: ArrayBuffer, filename: string): void {
+  const blob = new Blob([midiBuffer], { type: "audio/midi" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export { downloadMidi, encodeMidi, encodeVariableLengthQuantity };
+export type { MidiFile, MidiNote, MidiTrack };

--- a/src/core/audio/export/midi-exporter.test.ts
+++ b/src/core/audio/export/midi-exporter.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyPattern } from "@/features/sequencer/lib/helpers";
+import {
+  ACCENT_BOOST,
+  ACCENT_DAMPEN,
+  FLAM_GRACE_VELOCITY,
+  FLAM_OFFSET_SECONDS,
+  RATCHET_OFFSET_BEATS,
+  TRANSPORT_SWING_MAX,
+} from "../engine/constants";
+import type { InstrumentRole } from "../engine/instrument/types";
+import {
+  assignDrumNotes,
+  BAKE_SWING_INTO_EXPORT,
+  buildMidiFile,
+  DRUM_CHANNEL,
+  flamOffsetTicks,
+  MIDI_PPQ,
+  NOTE_DURATION_TICKS,
+  RATCHET_OFFSET_TICKS,
+  swingDelayTicks,
+  TICKS_PER_NUDGE_UNIT,
+  TICKS_PER_STEP,
+  toMidiVelocity,
+  type MidiExportOptions,
+} from "./midi-exporter";
+
+const DEFAULT_ROLES: InstrumentRole[] = [
+  "kick",
+  "kick",
+  "snare",
+  "clap",
+  "hat",
+  "ohat",
+  "tom",
+  "crash",
+];
+
+function makeOptions(
+  overrides: Partial<MidiExportOptions> = {},
+): MidiExportOptions {
+  return {
+    filename: "test-export",
+    bars: 1,
+    bpm: 100,
+    swing: 0,
+    pattern: createEmptyPattern(),
+    chain: { steps: [{ variation: 0, repeats: 1 }] },
+    chainEnabled: false,
+    variation: 0,
+    voices: DEFAULT_ROLES.map((role, i) => ({ name: `Voice ${i}`, role })),
+    ...overrides,
+  };
+}
+
+function ticksForSlot(options: MidiExportOptions, slot: number): number[] {
+  return buildMidiFile(options).tracks[slot].notes.map((note) => note.tick);
+}
+
+// -----------------------------------------------------------------------------
+// Tick math helpers
+// -----------------------------------------------------------------------------
+
+describe("tick math", () => {
+  it("uses integer ticks for every app timing unit at PPQ 480", () => {
+    expect(MIDI_PPQ).toBe(480);
+    expect(TICKS_PER_STEP).toBe(120);
+    expect(TICKS_PER_NUDGE_UNIT).toBe(5); // 1/96 beat
+    expect(RATCHET_OFFSET_TICKS).toBe(RATCHET_OFFSET_BEATS * MIDI_PPQ); // 60
+    expect(NOTE_DURATION_TICKS).toBe(60); // a 32nd
+  });
+
+  it("converts the 15ms flam offset to tempo-dependent ticks", () => {
+    // ticks = 0.015s * (bpm / 60) beats/s * 480 ticks/beat
+    expect(flamOffsetTicks(100)).toBe(
+      Math.round(FLAM_OFFSET_SECONDS * (100 / 60) * MIDI_PPQ),
+    );
+    expect(flamOffsetTicks(100)).toBe(12);
+    expect(flamOffsetTicks(200)).toBe(24);
+  });
+
+  it.runIf(BAKE_SWING_INTO_EXPORT)(
+    "delays offbeat 16ths by swing * 2/3 of an 8th, like Tone.js",
+    () => {
+      // Max app swing (knob 100) is Tone swing 0.5 -> 40 ticks.
+      expect(swingDelayTicks(1, TRANSPORT_SWING_MAX)).toBe(40);
+      expect(swingDelayTicks(3, 0.25)).toBe(20);
+      // Even steps sit on 8th boundaries and never swing.
+      expect(swingDelayTicks(0, TRANSPORT_SWING_MAX)).toBe(0);
+      expect(swingDelayTicks(2, TRANSPORT_SWING_MAX)).toBe(0);
+      // No swing, no delay.
+      expect(swingDelayTicks(1, 0)).toBe(0);
+    },
+  );
+
+  it.runIf(!BAKE_SWING_INTO_EXPORT)(
+    "keeps every step on the straight grid when swing baking is disabled",
+    () => {
+      expect(swingDelayTicks(1, TRANSPORT_SWING_MAX)).toBe(0);
+      expect(swingDelayTicks(3, 0.25)).toBe(0);
+    },
+  );
+
+  it("scales velocities to 1-127", () => {
+    expect(toMidiVelocity(1)).toBe(127);
+    expect(toMidiVelocity(0.5)).toBe(64);
+    expect(toMidiVelocity(0)).toBe(1); // velocity 0 would read as a note-off
+    expect(toMidiVelocity(2)).toBe(127);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// General MIDI drum mapping
+// -----------------------------------------------------------------------------
+
+describe("assignDrumNotes", () => {
+  it("maps the default kit layout to the documented GM notes", () => {
+    expect(assignDrumNotes(DEFAULT_ROLES)).toEqual([
+      36, // kick -> Bass Drum 1
+      35, // second kick -> Acoustic Bass Drum
+      38, // snare -> Acoustic Snare
+      39, // clap -> Hand Clap
+      42, // hat -> Closed Hi-Hat
+      46, // ohat -> Open Hi-Hat
+      45, // tom -> Low Tom
+      49, // crash -> Crash Cymbal 1
+    ]);
+  });
+
+  it("walks the tom candidates for multi-tom kits", () => {
+    expect(assignDrumNotes(["tom", "tom", "tom"])).toEqual([45, 47, 50]);
+  });
+
+  it("assigns a distinct note to every slot even without a GM analog", () => {
+    const notes = assignDrumNotes(
+      Array.from({ length: 8 }, (): InstrumentRole => "synth"),
+    );
+    expect(new Set(notes).size).toBe(8);
+    for (const note of notes) {
+      expect(note).toBeGreaterThanOrEqual(35);
+      expect(note).toBeLessThanOrEqual(81);
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Pattern -> MIDI file
+// -----------------------------------------------------------------------------
+
+describe("buildMidiFile", () => {
+  it("places one drum-channel track per voice with steps on the 16th grid", () => {
+    const options = makeOptions();
+    options.pattern.voices[0].variations[0].triggers[0] = true;
+    options.pattern.voices[0].variations[0].triggers[4] = true;
+    options.pattern.voices[2].variations[0].triggers[8] = true;
+
+    const file = buildMidiFile(options);
+    expect(file.ppq).toBe(MIDI_PPQ);
+    expect(file.bpm).toBe(100);
+    expect(file.tracks).toHaveLength(8);
+    for (const track of file.tracks) {
+      expect(track.channel).toBe(DRUM_CHANNEL);
+    }
+    expect(file.tracks[0].name).toBe("Voice 0");
+
+    expect(file.tracks[0].notes.map((note) => note.tick)).toEqual([0, 480]);
+    expect(file.tracks[0].notes[0].note).toBe(36);
+    expect(file.tracks[2].notes.map((note) => note.tick)).toEqual([960]);
+    expect(file.tracks[2].notes[0].note).toBe(38);
+    expect(file.tracks[1].notes).toHaveLength(0);
+  });
+
+  it("applies the precompute accent math to exported velocities", () => {
+    const options = makeOptions();
+    const sequence = options.pattern.voices[0].variations[0];
+    sequence.triggers[0] = true;
+    sequence.velocities[0] = 1.0; // not accented
+    sequence.triggers[4] = true;
+    sequence.velocities[4] = 1.0; // accented
+    sequence.triggers[8] = true;
+    sequence.velocities[8] = 0.5; // accented, below the cap
+    options.pattern.variationMetadata[0].accent[4] = true;
+    options.pattern.variationMetadata[0].accent[8] = true;
+
+    const velocities = buildMidiFile(options).tracks[0].notes.map(
+      (note) => note.velocity,
+    );
+
+    expect(velocities).toEqual([
+      Math.round((1.0 / ACCENT_DAMPEN) * 127), // dampened
+      Math.round(Math.min(1, (1.0 / ACCENT_DAMPEN) * ACCENT_BOOST) * 127), // boosted back to full
+      Math.round(Math.min(1, (0.5 / ACCENT_DAMPEN) * ACCENT_BOOST) * 127), // unchanged
+    ]);
+  });
+
+  it("shifts a lane by its timing nudge in 5-tick units, clamping the file start", () => {
+    const options = makeOptions();
+    options.pattern.voices[0].variations[0].triggers[4] = true;
+    options.pattern.voices[0].variations[0].timingNudge = 1;
+    expect(ticksForSlot(options, 0)).toEqual([480 + TICKS_PER_NUDGE_UNIT]);
+
+    options.pattern.voices[0].variations[0].timingNudge = -2;
+    expect(ticksForSlot(options, 0)).toEqual([480 - 2 * TICKS_PER_NUDGE_UNIT]);
+
+    // A step-0 negative nudge cannot produce a negative tick.
+    options.pattern.voices[0].variations[0].triggers[4] = false;
+    options.pattern.voices[0].variations[0].triggers[0] = true;
+    expect(ticksForSlot(options, 0)).toEqual([0]);
+  });
+
+  it("adds a flam grace note before the main hit at reduced velocity", () => {
+    const options = makeOptions({ bpm: 100 });
+    const sequence = options.pattern.voices[0].variations[0];
+    sequence.triggers[4] = true;
+    sequence.flams[4] = true;
+
+    const notes = buildMidiFile(options).tracks[0].notes;
+    expect(notes).toHaveLength(2);
+    const [grace, main] = notes;
+    expect(main.tick).toBe(480);
+    expect(grace.tick).toBe(480 - flamOffsetTicks(100));
+    expect(grace.velocity).toBe(Math.round(FLAM_GRACE_VELOCITY * 127));
+    // The grace gate never overlaps the main hit.
+    expect(grace.tick + grace.durationTicks).toBeLessThanOrEqual(main.tick);
+  });
+
+  it("clamps a step-0 flam grace note to tick 0", () => {
+    const options = makeOptions();
+    const sequence = options.pattern.voices[0].variations[0];
+    sequence.triggers[0] = true;
+    sequence.flams[0] = true;
+
+    expect(ticksForSlot(options, 0)).toEqual([0, 0]);
+  });
+
+  it("adds a ratchet hit 60 ticks after the main hit at the same velocity", () => {
+    const options = makeOptions();
+    const sequence = options.pattern.voices[0].variations[0];
+    sequence.triggers[4] = true;
+    sequence.velocities[4] = 0.5;
+    sequence.ratchets[4] = true;
+
+    const notes = buildMidiFile(options).tracks[0].notes;
+    expect(notes.map((note) => note.tick)).toEqual([
+      480,
+      480 + RATCHET_OFFSET_TICKS,
+    ]);
+    expect(notes[1].velocity).toBe(notes[0].velocity);
+  });
+
+  it.runIf(BAKE_SWING_INTO_EXPORT)(
+    "bakes swing into offbeat 16ths only",
+    () => {
+      const options = makeOptions({ swing: TRANSPORT_SWING_MAX });
+      const sequence = options.pattern.voices[0].variations[0];
+      sequence.triggers[0] = true;
+      sequence.triggers[1] = true;
+      sequence.triggers[2] = true;
+
+      expect(ticksForSlot(options, 0)).toEqual([0, 120 + 40, 240]);
+    },
+  );
+
+  it("follows the variation chain across bars, like WAV export", () => {
+    const options = makeOptions({
+      bars: 4,
+      chainEnabled: true,
+      chain: {
+        steps: [
+          { variation: 0, repeats: 1 },
+          { variation: 1, repeats: 1 },
+        ],
+      },
+    });
+    // Variation A: step 0. Variation B: step 8.
+    options.pattern.voices[0].variations[0].triggers[0] = true;
+    options.pattern.voices[0].variations[1].triggers[8] = true;
+
+    const barTicks = 16 * TICKS_PER_STEP;
+    expect(ticksForSlot(options, 0)).toEqual([
+      0, // bar 0: A
+      barTicks + 960, // bar 1: B
+      2 * barTicks, // bar 2: A (chain wraps)
+      3 * barTicks + 960, // bar 3: B
+    ]);
+  });
+
+  it("honors chain repeats", () => {
+    const options = makeOptions({
+      bars: 3,
+      chainEnabled: true,
+      chain: {
+        steps: [
+          { variation: 0, repeats: 2 },
+          { variation: 1, repeats: 1 },
+        ],
+      },
+    });
+    options.pattern.voices[0].variations[0].triggers[0] = true;
+    options.pattern.voices[0].variations[1].triggers[8] = true;
+
+    const barTicks = 16 * TICKS_PER_STEP;
+    expect(ticksForSlot(options, 0)).toEqual([
+      0, // bar 0: A
+      barTicks, // bar 1: A (repeat)
+      2 * barTicks + 960, // bar 2: B
+    ]);
+  });
+
+  it("repeats the selected variation when the chain is disabled", () => {
+    const options = makeOptions({ bars: 2, chainEnabled: false, variation: 1 });
+    options.pattern.voices[0].variations[0].triggers[0] = true;
+    options.pattern.voices[0].variations[1].triggers[8] = true;
+
+    const barTicks = 16 * TICKS_PER_STEP;
+    expect(ticksForSlot(options, 0)).toEqual([960, barTicks + 960]);
+  });
+});

--- a/src/core/audio/export/midi-exporter.ts
+++ b/src/core/audio/export/midi-exporter.ts
@@ -1,0 +1,322 @@
+// --- MIDI export: pattern data -> Standard MIDI File, then download ---
+//
+// Store-free like wav-exporter.ts: the feature layer passes pattern, tempo,
+// swing (already in Tone domain units), and voice descriptors in as
+// arguments. Timing and velocity math mirror the live scheduler
+// (engine/sequencer/sequencer.ts) and precompute (accent math) so a DAW
+// plays the exported file back the way the app sounds.
+
+import {
+  FLAM_GRACE_VELOCITY,
+  FLAM_OFFSET_SECONDS,
+  RATCHET_OFFSET_BEATS,
+  STEP_COUNT,
+} from "../engine/constants";
+import type { InstrumentRole } from "../engine/instrument/types";
+import {
+  nudgeToBeatOffset,
+  sanitizeChain,
+  type Pattern,
+  type PatternChain,
+  type VariationId,
+} from "../engine/pattern-types";
+import { buildPrecomputedPattern } from "../engine/sequencer/precompute";
+import {
+  advanceChainAtEndOfBar,
+  variationForBarStart,
+  type ChainPlaybackState,
+} from "../engine/variation/chain";
+import { downloadMidi, encodeMidi, type MidiNote } from "./midi-encoder";
+
+// -----------------------------------------------------------------------------
+// Timing constants (PPQ 480)
+// -----------------------------------------------------------------------------
+
+/**
+ * Pulses per quarter note. 480 makes every app timing unit an integer tick:
+ * a 16th step is 120 ticks, the ratchet offset (1/32 beat... 0.125 beat) is
+ * 60 ticks, and one timing-nudge unit (1/96 beat) is exactly 5 ticks.
+ */
+const MIDI_PPQ = 480;
+
+/** Ticks per 16th-note step. */
+const TICKS_PER_STEP = MIDI_PPQ / 4;
+
+/** Ticks per timing-nudge unit (1/96 of a beat). */
+const TICKS_PER_NUDGE_UNIT = MIDI_PPQ / 96;
+
+/** Ratchet hit offset after the main hit, in ticks (0.125 beat). */
+const RATCHET_OFFSET_TICKS = RATCHET_OFFSET_BEATS * MIDI_PPQ;
+
+/**
+ * Note length for every exported hit: a 32nd (60 ticks). Drum hits are
+ * one-shot triggers, so a short consistent gate reads cleanly in a DAW and
+ * a main hit's note-off lands exactly on its ratchet's note-on (the encoder
+ * orders offs before ons at equal ticks).
+ */
+const NOTE_DURATION_TICKS = MIDI_PPQ / 8;
+
+/** Drum channel: MIDI channel 10, zero-based. */
+const DRUM_CHANNEL = 9;
+
+/**
+ * Whether the transport swing is baked into exported note-on positions
+ * (offbeat 16ths delayed exactly as Tone.js delays them audibly) or the
+ * export stays on the straight 16th grid.
+ *
+ * PENDING MAINTAINER DECISION (see PR discussion): flip this constant to
+ * switch the behavior; nothing else needs to change.
+ */
+const BAKE_SWING_INTO_EXPORT = true;
+
+// -----------------------------------------------------------------------------
+// Tick math (exported for tests)
+// -----------------------------------------------------------------------------
+
+/**
+ * Swing delay in ticks for a step, replicating Tone.js Transport swing with
+ * a 16n swingSubdivision: offbeat 16ths (odd steps) are delayed by
+ * swing * 2/3 of an 8th note, i.e. swing * (2 * TICKS_PER_STEP) / 3. Even
+ * steps sit on 8th-note boundaries and are never swung.
+ *
+ * Returns 0 for every step when swing baking is disabled.
+ */
+function swingDelayTicks(step: number, swing: number): number {
+  if (!BAKE_SWING_INTO_EXPORT) return 0;
+  if (step % 2 === 0) return 0;
+  return Math.round(swing * ((2 * TICKS_PER_STEP) / 3));
+}
+
+/**
+ * Flam grace-note offset in ticks. The scheduler places the grace note a
+ * fixed 15ms before the main hit, so the tick distance depends on tempo.
+ */
+function flamOffsetTicks(bpm: number): number {
+  const ticksPerSecond = (bpm / 60) * MIDI_PPQ;
+  return Math.round(FLAM_OFFSET_SECONDS * ticksPerSecond);
+}
+
+/**
+ * Scales a precomputed [0..1] velocity (accent math already applied) to
+ * MIDI 1-127. Never 0: velocity 0 is a note-off in MIDI running status.
+ */
+function toMidiVelocity(velocity: number): number {
+  return Math.min(127, Math.max(1, Math.round(velocity * 127)));
+}
+
+// -----------------------------------------------------------------------------
+// General MIDI drum mapping
+// -----------------------------------------------------------------------------
+
+/**
+ * GM percussion note candidates per instrument role, in preference order.
+ * When a kit repeats a role (e.g. two kicks), later slots take the next
+ * candidate so every lane keeps a distinct note in the DAW.
+ */
+const GM_ROLE_NOTES: Record<InstrumentRole, number[]> = {
+  kick: [36, 35], // Bass Drum 1, Acoustic Bass Drum
+  snare: [38, 40], // Acoustic Snare, Electric Snare
+  clap: [39], // Hand Clap
+  hat: [42, 44], // Closed Hi-Hat, Pedal Hi-Hat
+  ohat: [46], // Open Hi-Hat
+  tom: [45, 47, 50, 48, 43, 41], // Low, Low-Mid, High, Hi-Mid, Floor toms
+  perc: [37, 56, 54, 70], // Side Stick, Cowbell, Tambourine, Maracas
+  crash: [49, 57, 55], // Crash 1, Crash 2, Splash
+  bass: [35, 36], // Acoustic Bass Drum (no GM drum slot for bass synths)
+  synth: [], // No GM percussion analog; falls back below
+  other: [], // No GM percussion analog; falls back below
+};
+
+/**
+ * Fallback pool for roles without a GM analog or with exhausted candidates,
+ * kept inside the GM percussion range so channel 10 always makes a sound.
+ */
+const GM_FALLBACK_NOTES = [51, 53, 56, 54, 37, 75, 76, 69, 70];
+
+/**
+ * Assigns one distinct GM percussion note per slot: role candidates first
+ * (in slot order), then the fallback pool, then the first unused note in
+ * the GM percussion range (35-81) as a last resort.
+ */
+function assignDrumNotes(roles: InstrumentRole[]): number[] {
+  const used = new Set<number>();
+
+  return roles.map((role) => {
+    const candidates = [...GM_ROLE_NOTES[role], ...GM_FALLBACK_NOTES];
+    let note = candidates.find((candidate) => !used.has(candidate));
+    if (note === undefined) {
+      for (let fallback = 35; fallback <= 81; fallback++) {
+        if (!used.has(fallback)) {
+          note = fallback;
+          break;
+        }
+      }
+    }
+    note ??= 35;
+    used.add(note);
+    return note;
+  });
+}
+
+// -----------------------------------------------------------------------------
+// Pattern -> MIDI file
+// -----------------------------------------------------------------------------
+
+/** A drum voice's identity for track naming and GM note mapping. */
+interface MidiVoiceDescriptor {
+  name: string;
+  role: InstrumentRole;
+}
+
+interface MidiExportOptions {
+  /** Filename without extension; also written as the conductor track name. */
+  filename: string;
+  /** Number of bars to export; the chain arrangement advances per bar. */
+  bars: number;
+  bpm: number;
+  /** Transport swing in Tone domain units (0-0.5), converted at the boundary. */
+  swing: number;
+  pattern: Pattern;
+  chain: PatternChain;
+  chainEnabled: boolean;
+  /** Variation played for every bar when the chain is disabled. */
+  variation: VariationId;
+  /** Per-slot voice descriptors, in slot order. */
+  voices: MidiVoiceDescriptor[];
+}
+
+/**
+ * Builds the MIDI file data for a pattern export. Bar arrangement follows
+ * the same chain semantics as WAV export: with the chain enabled each bar
+ * advances through the chain (wrapping), otherwise every bar plays the
+ * given variation.
+ */
+function buildMidiFile(options: MidiExportOptions) {
+  const { pattern, bars, bpm, swing, chainEnabled, variation } = options;
+
+  const precomputed = buildPrecomputedPattern(pattern);
+  const chain = sanitizeChain(options.chain);
+  const chainState: ChainPlaybackState = {
+    stepIndex: 0,
+    repeatsRemaining: chain.steps[0]?.repeats ?? 1,
+  };
+
+  const flamTicks = flamOffsetTicks(bpm);
+  const notesBySlot: MidiNote[][] = options.voices.map(() => []);
+
+  for (let bar = 0; bar < bars; bar++) {
+    const barVariation = variationForBarStart(
+      chainEnabled,
+      chain,
+      chainState,
+      variation,
+    );
+    const barStartTick = bar * STEP_COUNT * TICKS_PER_STEP;
+
+    for (let step = 0; step < STEP_COUNT; step++) {
+      const hits = precomputed.stepsByVariation[barVariation][step];
+
+      for (const hit of hits) {
+        const slot = hit.voice.instrumentIndex;
+        const lane = notesBySlot[slot];
+        if (!lane) continue;
+
+        const sequence = hit.voice.variations[barVariation];
+        // Same nudge math as the scheduler, in ticks: nudge units are 1/96
+        // of a beat, exactly TICKS_PER_NUDGE_UNIT ticks each at PPQ 480.
+        const nudgeTicks =
+          nudgeToBeatOffset(sequence.timingNudge ?? 0) * MIDI_PPQ;
+        // Clamped to >= 0 like the scheduler's Math.max(0, ...): a step-0
+        // negative nudge in the first bar cannot land before tick 0.
+        const mainTick = Math.max(
+          0,
+          Math.round(
+            barStartTick +
+              step * TICKS_PER_STEP +
+              swingDelayTicks(step, swing) +
+              nudgeTicks,
+          ),
+        );
+        const velocity = toMidiVelocity(hit.velocity);
+
+        // Flam: grace note before the main hit at reduced velocity, clamped
+        // to tick 0 at the very start of the file (mirroring the scheduler).
+        if (sequence.flams?.[step]) {
+          const graceTick = Math.max(0, mainTick - flamTicks);
+          lane.push({
+            tick: graceTick,
+            note: 0, // assigned below
+            velocity: toMidiVelocity(hit.velocity * FLAM_GRACE_VELOCITY),
+            durationTicks: Math.min(
+              NOTE_DURATION_TICKS,
+              Math.max(1, mainTick - graceTick),
+            ),
+          });
+        }
+
+        lane.push({
+          tick: mainTick,
+          note: 0,
+          velocity,
+          durationTicks: NOTE_DURATION_TICKS,
+        });
+
+        // Ratchet: second hit a 32nd after the main hit at the same velocity.
+        if (sequence.ratchets?.[step]) {
+          lane.push({
+            tick: mainTick + RATCHET_OFFSET_TICKS,
+            note: 0,
+            velocity,
+            durationTicks: NOTE_DURATION_TICKS,
+          });
+        }
+      }
+    }
+
+    advanceChainAtEndOfBar(chainEnabled, chain, chainState);
+  }
+
+  const drumNotes = assignDrumNotes(options.voices.map((voice) => voice.role));
+
+  return {
+    ppq: MIDI_PPQ,
+    bpm,
+    name: options.filename,
+    tracks: options.voices.map((voice, slot) => ({
+      name: voice.name,
+      channel: DRUM_CHANNEL,
+      notes: notesBySlot[slot].map((note) => ({
+        ...note,
+        note: drumNotes[slot],
+      })),
+    })),
+  };
+}
+
+/**
+ * Exports the pattern to a Standard MIDI File download.
+ */
+function exportToMidi(options: MidiExportOptions): void {
+  const midiBuffer = encodeMidi(buildMidiFile(options));
+  downloadMidi(midiBuffer, `${options.filename}.mid`);
+}
+
+// Bar-count suggestion is shared with WAV export so both formats follow the
+// same arrangement semantics.
+export { getSuggestedBars } from "./wav-exporter";
+export {
+  assignDrumNotes,
+  BAKE_SWING_INTO_EXPORT,
+  buildMidiFile,
+  DRUM_CHANNEL,
+  exportToMidi,
+  flamOffsetTicks,
+  MIDI_PPQ,
+  NOTE_DURATION_TICKS,
+  RATCHET_OFFSET_TICKS,
+  swingDelayTicks,
+  TICKS_PER_NUDGE_UNIT,
+  TICKS_PER_STEP,
+  toMidiVelocity,
+};
+export type { MidiExportOptions, MidiVoiceDescriptor };

--- a/src/features/preset/dialogs/export-dialog.tsx
+++ b/src/features/preset/dialogs/export-dialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { MidiExportForm } from "@/features/preset/forms/midi-export-form";
 import { PresetFileExportForm } from "@/features/preset/forms/preset-file-export-form";
 import { WavExportForm } from "@/features/preset/forms/wav-export-form";
 import {
@@ -19,11 +20,10 @@ interface ExportDialogProps {
   onClose: () => void;
 }
 
-type ExportTab = "file" | "wav";
-// Future: "midi" | etc.
+type ExportTab = "file" | "wav" | "midi";
 
 function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
-  const [activeTab, setActiveTab] = useState<"file" | "wav">("file");
+  const [activeTab, setActiveTab] = useState<ExportTab>("file");
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
@@ -39,10 +39,10 @@ function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as ExportTab)}
         >
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="file">Preset File</TabsTrigger>
             <TabsTrigger value="wav">WAV</TabsTrigger>
-            {/* Future: <TabsTrigger value="midi">MIDI</TabsTrigger> */}
+            <TabsTrigger value="midi">MIDI</TabsTrigger>
           </TabsList>
 
           <TabsContent value="file">
@@ -53,11 +53,9 @@ function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
             <WavExportForm onClose={onClose} />
           </TabsContent>
 
-          {/* Future:
           <TabsContent value="midi">
             <MidiExportForm onClose={onClose} />
           </TabsContent>
-          */}
         </Tabs>
       </DialogContent>
     </Dialog>

--- a/src/features/preset/forms/midi-export-form.tsx
+++ b/src/features/preset/forms/midi-export-form.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+
+import { transportSwingKnobToDomain } from "@/core/audio/bridge/knob-to-domain";
+import {
+  exportToMidi,
+  getSuggestedBars,
+} from "@/core/audio/export/midi-exporter";
+import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
+import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
+import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
+import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import {
+  Button,
+  DialogDescription,
+  DialogFooter,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  Input,
+  Slider,
+  useToast,
+} from "@/shared/ui";
+
+interface MidiExportFormProps {
+  onClose: () => void;
+}
+
+const midiExportSchema = z.object({
+  filename: z.string().trim().min(1, "Filename is required"),
+  bars: z.number().int().min(1, "At least 1 bar").max(8, "Maximum 8 bars"),
+});
+
+type MidiExportFormValues = z.infer<typeof midiExportSchema>;
+
+function MidiExportForm({ onClose }: MidiExportFormProps) {
+  const pattern = usePatternStore((state) => state.pattern);
+  const chain = usePatternStore((state) => state.chain);
+  const chainEnabled = usePatternStore((state) => state.chainEnabled);
+  const variation = usePatternStore((state) => state.variation);
+  const bpm = useTransportStore((state) => state.bpm);
+  const swing = useTransportStore((state) => state.swing);
+  const instruments = useInstrumentsStore((state) => state.instruments);
+  const presetName = usePresetMetaStore(
+    (state) => state.currentPresetMeta.name,
+  );
+
+  const { toast } = useToast();
+  const recommendedBars = getSuggestedBars(chain, chainEnabled);
+
+  const defaultValues = useMemo(
+    () => ({
+      filename: presetName,
+      bars: recommendedBars,
+    }),
+    [presetName, recommendedBars],
+  );
+
+  const form = useForm<MidiExportFormValues>({
+    resolver: zodResolver(midiExportSchema),
+    defaultValues,
+    mode: "onChange",
+  });
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    control,
+    formState: { errors, isSubmitting, isValid },
+  } = form;
+
+  useEffect(() => {
+    setValue("filename", presetName, { shouldValidate: true });
+  }, [presetName, setValue]);
+
+  useEffect(() => {
+    setValue("bars", recommendedBars, { shouldValidate: true });
+  }, [recommendedBars, setValue]);
+
+  const bars = useWatch({ control, name: "bars" });
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      exportToMidi({
+        filename: values.filename.trim() || "drumhaus-export",
+        bars: values.bars,
+        bpm,
+        swing: transportSwingKnobToDomain(swing),
+        pattern,
+        chain,
+        chainEnabled,
+        variation,
+        voices: instruments.map((instrument) => ({
+          name: instrument.meta.name,
+          role: instrument.role,
+        })),
+      });
+
+      toast({
+        title: "Export successful",
+        description: "Your MIDI file has been exported.",
+        duration: 8000,
+      });
+      onClose();
+    } catch (error) {
+      console.error("Export failed:", error);
+      toast({
+        title: "Something went wrong",
+        description: "Couldn't export MIDI. Please try again.",
+        status: "error",
+        duration: 8000,
+      });
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <div className="space-y-4">
+        <DialogDescription>
+          Export your pattern as a MIDI file for use in a DAW.
+        </DialogDescription>
+
+        <FieldGroup>
+          <Field data-invalid={Boolean(errors.filename)}>
+            <FieldLabel htmlFor="midi-filename">Filename</FieldLabel>
+            <Input
+              id="midi-filename"
+              autoFocus
+              aria-invalid={Boolean(errors.filename)}
+              disabled={isSubmitting}
+              {...register("filename")}
+            />
+            <FieldError errors={[errors.filename]} />
+          </Field>
+
+          <FieldSeparator />
+
+          <FieldSet>
+            <FieldLegend>Export options</FieldLegend>
+            <FieldGroup>
+              <Field data-invalid={Boolean(errors.bars)}>
+                <FieldLabel htmlFor="midi-bars">Length</FieldLabel>
+
+                <div className="flex items-center justify-between">
+                  <FieldDescription>
+                    Recommended: {recommendedBars}{" "}
+                    {recommendedBars === 1 ? "bar" : "bars"}
+                  </FieldDescription>
+                  <span className="text-sm">
+                    {bars} {bars === 1 ? "bar" : "bars"}
+                  </span>
+                </div>
+                <div>
+                  <Slider
+                    id="midi-bars"
+                    value={[bars ?? recommendedBars]}
+                    onValueChange={([value]) =>
+                      setValue("bars", value, { shouldValidate: true })
+                    }
+                    min={1}
+                    max={8}
+                    step={1}
+                    disabled={isSubmitting}
+                  />
+                  <div className="flex justify-between px-[8px]">
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
+                      <div key={n} className="flex flex-col items-center">
+                        <div className="h-1 w-px" />
+                        <span
+                          className={`mt-0.5 text-[10px] ${[1, 2, 4, 8].includes(n) ? "text-foreground-emphasis" : "text-foreground-muted"}`}
+                        >
+                          {n}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <FieldError errors={[errors.bars]} />
+              </Field>
+
+              <FieldDescription>
+                Notes follow the General MIDI drum map on channel 10, with
+                tempo, accents, flams, ratchets, timing nudge, and swing baked
+                in.
+              </FieldDescription>
+            </FieldGroup>
+          </FieldSet>
+        </FieldGroup>
+        <FieldSeparator />
+      </div>
+
+      <DialogFooter className="pt-6">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!isValid || isSubmitting}>
+          Export
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export { MidiExportForm };


### PR DESCRIPTION
Adds MIDI export to the export suite: a hand-rolled Standard MIDI File encoder plus a store-free exporter under `src/core/audio/export/`, and a MIDI tab in the Export dialog mirroring the WAV form.
No new dependencies.

## Mapping proposal

| App concept | MIDI representation | Rationale |
| --- | --- | --- |
| File format | SMF format 1, PPQ 480, conductor track + 8 voice tracks | Format 1 keeps per-voice lanes separate in DAWs; PPQ 480 makes every app timing unit an integer tick (16th = 120, ratchet offset = 60, nudge unit = 5) |
| Tempo / meter | Tempo meta event from the current BPM, 4/4 time signature meta | DAW grid lines up with the app immediately on import |
| Tracks | One track per voice, named after the instrument, all on MIDI channel 10 | Channel 10 is the GM percussion channel, so files make sound on anything GM-aware |
| Note numbers | GM drum map chosen per slot role: kick 36, snare 38, clap 39, closed hat 42, open hat 46, tom 45 (then 47/50/48/43/41), perc 37/56/54/70, crash 49 (then 57/55), bass 35 | Role-appropriate GM notes; duplicate roles walk the role's candidate list so every lane keeps a distinct note |
| Note fallback | Roles without a GM analog (synth, other) or with exhausted candidates take the first unused note from a fixed pool (51, 53, 56, 54, 37, 75, 76, 69, 70), then the first unused note in the GM percussion range 35-81 | Deterministic, collision-free, and always audible on channel 10 |
| Steps | 16th-note grid, 120 ticks per step, bar = 1920 ticks | Direct translation of the sequencer grid |
| Velocity + accents | Precomputed velocity via the engine's own `buildPrecomputedPattern` (dampen by 1.3 when the variation has accents, boost accented steps by 1.3, clamp at 1.0), scaled to MIDI 1-127 | Reusing the shipped precompute function guarantees the DAW plays back the dynamics the app actually produces |
| Flams | Grace note before the main hit at 0.6x velocity, offset = 15ms converted to ticks at the export tempo, clamped at tick 0 for the file start | Matches the scheduler's `FLAM_OFFSET_SECONDS` behavior, which is wall-clock (tempo-dependent in ticks) |
| Ratchets | Second note at +60 ticks (0.125 beat, a 32nd) at the main hit's velocity | Matches `RATCHET_OFFSET_BEATS` exactly |
| Timing nudge | Whole lane shifted by nudge x 5 ticks (1/96 beat per unit), step-0 negative shifts clamped to tick 0 | Mirrors `nudgeToBeatOffset` and the scheduler's `Math.max(0, ...)` clamp |
| Swing | Baked into note-on positions by default: offbeat 16ths delayed by swing x 2/3 of an 8th (40 ticks at max swing), replicating Tone.js Transport swing math exactly | Exported MIDI plays back in a DAW the way the app audibly plays it |
| Note gate | Fixed 60-tick (32nd) duration; note-offs are ordered before coinciding note-ons so a hit and its ratchet never merge | Drum hits are one-shot triggers; a short consistent gate reads cleanly |
| Arrangement | Bars follow the same variation-chain semantics as WAV export (chain advance per bar with wrap, or the selected variation when the chain is off), with the same suggested bar count | MIDI and WAV exports of the same state describe the same performance |

Mute and solo are deliberately not applied: MIDI export captures the pattern data, and muting is treated as a mix decision that the WAV render owns.

## Open question: bake swing or export a straight grid? (awaiting maintainer decision)

The current default bakes swing into note positions, so the DAW playback matches what the app sounds like, but the notes land off the DAW grid and re-quantizing loses the feel toggle.
The alternative is exporting the straight 16th grid and letting users apply their DAW's swing.
This audibly changes DAW playback, so it is the maintainer's call.
The behavior is isolated behind a single constant, `BAKE_SWING_INTO_EXPORT` in `src/core/audio/export/midi-exporter.ts`; flipping it to `false` is the entire change, and the swing unit tests are gated on the flag so both settings keep the suite green.

## Layering

The encoder (`midi-encoder.ts`) is pure byte-level SMF encoding, and the exporter (`midi-exporter.ts`) takes pattern, BPM, domain swing, chain, and voice descriptors as arguments, matching `wav-exporter.ts`'s store-free layering.
The feature-layer form passes store data in and converts the swing knob at the boundary via the existing bridge helper.
Timing and velocity math import the engine's own constants and precompute function, so the export cannot drift from live playback.

## Test coverage

- `midi-encoder.test.ts`: VLQ reference vectors and round-trips, format 1 header bytes, PPQ division, tempo/time-signature/track-name meta bytes, delta-timed note on/off pairs, and off-before-on ordering at coinciding ticks.
- `midi-exporter.test.ts`: integer tick constants, tempo-dependent flam ticks, swing delay math (flag-gated both ways), 1-127 velocity scaling, accent parity against `ACCENT_DAMPEN`/`ACCENT_BOOST`, GM note assignment (defaults, multi-tom, no-analog distinctness), nudge shifts with the step-0 clamp, flam grace placement and clamp, ratchet offset, and chain arrangement across bars (enabled, repeats, disabled).
- `e2e/midi-export.spec.ts`: drives the real UI (toggles steps, opens Export, MIDI tab, downloads) and parses the `.mid` bytes: MThd header, format 1, 9 tracks, division 480, tempo in range, and the exact kick-lane note-ons (ticks 0/960/1920/2880, note 36, channel 10, velocity 127) with all other lanes empty.

All gates pass locally: `pnpm prettier . --check`, `pnpm lint`, `pnpm test` (108 passed, 1 flag-gated skip), `pnpm build`, `pnpm smoke:lightshow`, and `pnpm test:e2e` (8/8 including the new spec).

Closes #17