### PR TITLE
feat(export): add WAV stem export (#308)

### DIFF
--- a/docs/audio-engine-refactor.md
+++ b/docs/audio-engine-refactor.md
@@ -205,6 +205,13 @@ Three refuted candidates validated the architecture: the scheduler's fresh per-s
 
 The first-hit attenuation quirk (see above) was left unfixed through the behavior-preserving phases by design; issue #318 diagnosed and fixed it afterward via the render pre-roll.
 
+### Stem rendering options (issue #308)
+
+`renderWav` remains the single offline render path; stem export extends its options instead of adding a parallel renderer.
+`soloChannelIndex` isolates one channel by transforming the render's snapshot (the target becomes the only soloed channel and the solo flag is forced on) - retained engine state is never mutated, so live playback is unaffected and a muted channel honestly renders a silent stem.
+`masterTap` selects the tap point: `"master"` (default) renders through the full master chain exactly like a mix export, while `"preMaster"` connects the channel chains straight to the offline destination, carrying channel-level processing only (the compressor, saturation, EQ, limiter, and the phaser/reverb sends are master-bus-level and drop out, and master volume stays at unity).
+The #318 warm-up pre-roll applies in both modes: the pre-master tap has no compressors to warm up, but one uniform code path keeps every render scheduled, sliced, and sized identically, including step-0 pre-bar trimming.
+
 ### Recovery instrumentation (issue #319)
 
 The rebuild recovery path shipped without real-world evidence of which tier actually fires, so the context guards now count every tier: eager resume attempts and successes, stall detections, rebuild attempts, rebuild successes (clock revived), rebuild timeouts, and reload fallbacks.

--- a/e2e/stem-export.spec.ts
+++ b/e2e/stem-export.spec.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import { expect, test } from "@playwright/test";
+import { unzipSync } from "fflate";
+
+import { gotoApp, toggleStep } from "./helpers";
+
+interface WavInfo {
+  sampleRate: number;
+  channels: number;
+  duration: number;
+  /** Peak |sample| of the 16-bit PCM payload, normalized to 0..1. */
+  peak: number;
+}
+
+/** Minimal RIFF/WAVE reader: validates the header and walks the chunks. */
+function parseWav(buffer: Buffer): WavInfo {
+  expect(buffer.length).toBeGreaterThan(44);
+  expect(buffer.toString("ascii", 0, 4)).toBe("RIFF");
+  expect(buffer.toString("ascii", 8, 12)).toBe("WAVE");
+
+  let sampleRate = 0;
+  let channels = 0;
+  let byteRate = 0;
+  let dataSize = 0;
+  let dataOffset = 0;
+
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    if (chunkId === "fmt ") {
+      channels = buffer.readUInt16LE(offset + 10);
+      sampleRate = buffer.readUInt32LE(offset + 12);
+      byteRate = buffer.readUInt32LE(offset + 16);
+    } else if (chunkId === "data") {
+      dataSize = chunkSize;
+      dataOffset = offset + 8;
+    }
+    offset += 8 + chunkSize + (chunkSize % 2);
+  }
+
+  expect(sampleRate).toBeGreaterThan(0);
+  expect(channels).toBeGreaterThan(0);
+  expect(byteRate).toBeGreaterThan(0);
+  expect(dataSize).toBeGreaterThan(0);
+
+  let peak = 0;
+  const end = Math.min(dataOffset + dataSize, buffer.length);
+  for (let i = dataOffset; i + 1 < end; i += 2) {
+    peak = Math.max(peak, Math.abs(buffer.readInt16LE(i)));
+  }
+
+  return {
+    sampleRate,
+    channels,
+    duration: dataSize / byteRate,
+    peak: peak / 0x8000,
+  };
+}
+
+test.describe("stem export", () => {
+  test("exports pre-master stems as a valid zip download", async ({ page }) => {
+    await gotoApp(page);
+
+    // Put steps into two lanes: kick (voice 0, selected by default) and
+    // snare (voice 3 on the default kit, selected via its digit key).
+    await toggleStep(page, 0, "true");
+    await toggleStep(page, 8, "true");
+    await page.keyboard.press("3");
+    await expect(
+      page.locator("[data-instrument-index][data-selected]"),
+    ).toHaveAttribute("data-instrument-index", "2");
+    await toggleStep(page, 4, "true");
+
+    await page.getByRole("button", { name: "Export", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "Export" });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole("tab", { name: "Stems" }).click();
+    await dialog.getByLabel("Filename").fill("e2e-stems");
+
+    // The form displays the expected per-file render duration, e.g. "4.8s".
+    const durationText = await dialog
+      .getByText(/^\d+\.\ds$/)
+      .first()
+      .innerText();
+    const expectedDuration = Number.parseFloat(durationText);
+    expect(expectedDuration).toBeGreaterThan(0);
+
+    // Submitting renders each stem offline and downloads one zip.
+    const downloadPromise = page.waitForEvent("download", {
+      timeout: 45_000,
+    });
+    await dialog.getByRole("button", { name: "Export", exact: true }).click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe("e2e-stems-stems.zip");
+
+    const path = await download.path();
+    const entries = unzipSync(new Uint8Array(fs.readFileSync(path)));
+
+    // Empty-lane policy: lanes without triggers are skipped, so the pack
+    // holds exactly the README, the full mix, and the two played stems
+    // (default kit slot names: Kick, Kick2, Snare, Clap, Hat, OHat, Tom,
+    // Tom2; slot numbering is 1-based in slot order).
+    expect(Object.keys(entries).sort()).toEqual([
+      "00-full-mix.wav",
+      "01-kick.wav",
+      "03-snare.wav",
+      "README.txt",
+    ]);
+
+    // The README states the pre-master contract and lists skipped lanes.
+    const readme = Buffer.from(entries["README.txt"]).toString("utf-8");
+    expect(readme).toContain("PRE-MASTER");
+    expect(readme).toContain("Skipped (would have rendered silence):");
+    for (const skipped of [
+      "02-kick2.wav",
+      "04-clap.wav",
+      "05-hat.wav",
+      "06-ohat.wav",
+      "07-tom.wav",
+      "08-tom2.wav",
+    ]) {
+      expect(readme).toContain(`${skipped} (no triggers in the exported bars)`);
+    }
+
+    // Every WAV parses, matches the promised duration, and the toggled
+    // lanes carry real audio.
+    for (const name of ["00-full-mix.wav", "01-kick.wav", "03-snare.wav"]) {
+      const info = parseWav(Buffer.from(entries[name]));
+      expect(Math.abs(info.duration - expectedDuration)).toBeLessThan(0.25);
+      expect(info.peak).toBeGreaterThan(0.05);
+    }
+
+    // The dialog closes and the app confirms the export, naming the
+    // skipped lanes.
+    await expect(dialog).not.toBeVisible();
+    await expect(
+      page.getByText("Export successful", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Skipped silent lanes: .*Kick2/).first(),
+    ).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-tooltip": "^1.2.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.3",
     "framer-motion": "^12.40.0",
     "immer": "^11.1.8",
     "lucide-react": "^1.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       framer-motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1516,6 +1519,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   framer-motion@12.40.0:
     resolution: {integrity: sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==}
@@ -3365,6 +3371,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   framer-motion@12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/src/core/audio/engine/__tests__/stem-render.browser.test.ts
+++ b/src/core/audio/engine/__tests__/stem-render.browser.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Regression tests for renderWav's stem options (issue #308):
+ * soloChannelIndex (single-channel isolation) and masterTap
+ * ("master" through the full master chain vs "preMaster" straight to the
+ * offline destination).
+ *
+ * These follow the golden-render patterns: fixture state is pushed through
+ * the real engine command API (createFixtureEngine) and rendered via the
+ * production renderWav path; assertions use onset deltas or compare two
+ * renders against each other. See golden-render.browser.test.ts for the
+ * note on master-chain latency (~12ms constant onset offset) - the
+ * pre-master tap has none, which one test below locks in.
+ */
+
+import { getContext } from "tone/build/esm/index";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { RenderWavOptions } from "@/core/audio/engine/audio-engine";
+import { findOnsets, peakInWindow, rmsInWindow } from "@/test/analysis";
+import {
+  makeClickSampleUrl,
+  makeInstrument,
+  makePattern,
+} from "@/test/fixtures";
+import { createFixtureEngine, type RenderFixtureOptions } from "@/test/render";
+
+const BPM = 120;
+/** Duration of one 16th note at 120 BPM. */
+const STEP = 60 / BPM / 4; // 0.125s
+/** Tolerance for onset-delta assertions. */
+const TOL = 0.005;
+
+let clickUrl: string;
+
+beforeAll(() => {
+  clickUrl = makeClickSampleUrl();
+});
+
+/**
+ * Renders fixture state through the production path with explicit
+ * renderWav option overrides (renderFixture itself stays options-free).
+ */
+async function renderWithOptions(
+  fixtureOpts: RenderFixtureOptions,
+  renderOpts: Partial<RenderWavOptions> = {},
+): Promise<AudioBuffer> {
+  const engine = await createFixtureEngine(fixtureOpts);
+  try {
+    return await engine.renderWav({
+      bars: fixtureOpts.bars ?? 1,
+      sampleRate: getContext().sampleRate,
+      includeTail: false,
+      ...renderOpts,
+    });
+  } finally {
+    engine.dispose();
+  }
+}
+
+describe("stem render: soloChannelIndex", () => {
+  // Kick on steps 0/8, snare on steps 4/12: each channel's onsets are
+  // distinguishable by position, so isolation shows up as both a count
+  // and a timing signature.
+  const fixture = (): RenderFixtureOptions => ({
+    pattern: makePattern({
+      steps: [
+        { voice: 0, step: 0 },
+        { voice: 0, step: 8 },
+        { voice: 1, step: 4 },
+        { voice: 1, step: 12 },
+      ],
+    }),
+    instruments: [makeInstrument(0, "kick"), makeInstrument(1, "snare")],
+    sampleUrls: [clickUrl, clickUrl],
+    bpm: BPM,
+  });
+
+  it("renders only the isolated channel's onsets", async () => {
+    const fullBuffer = await renderWithOptions(fixture());
+    expect(findOnsets(fullBuffer)).toHaveLength(4);
+
+    const kickStem = await renderWithOptions(fixture(), {
+      soloChannelIndex: 0,
+    });
+    const kickOnsets = findOnsets(kickStem);
+    expect(kickOnsets).toHaveLength(2);
+    // Steps 0 and 8 are 8 steps apart.
+    expect(kickOnsets[1] - kickOnsets[0]).toBeGreaterThan(8 * STEP - TOL);
+    expect(kickOnsets[1] - kickOnsets[0]).toBeLessThan(8 * STEP + TOL);
+    // The first kick sits on the bar line (plus master-chain latency only).
+    expect(kickOnsets[0]).toBeLessThan(0.02);
+
+    const snareStem = await renderWithOptions(fixture(), {
+      soloChannelIndex: 1,
+    });
+    const snareOnsets = findOnsets(snareStem);
+    expect(snareOnsets).toHaveLength(2);
+    // The first snare sits on step 4, not step 0.
+    expect(snareOnsets[0]).toBeGreaterThan(4 * STEP - TOL);
+    expect(snareOnsets[0]).toBeLessThan(4 * STEP + 0.02);
+  });
+
+  it("overrides a retained solo on another channel without mutating it", async () => {
+    // The snare is soloed in the pushed state; isolating the kick must win
+    // for this render only.
+    const opts: RenderFixtureOptions = {
+      pattern: makePattern({
+        steps: [
+          { voice: 0, step: 0 },
+          { voice: 1, step: 8 },
+        ],
+      }),
+      instruments: [
+        makeInstrument(0, "kick"),
+        makeInstrument(1, "snare", { solo: true }),
+      ],
+      sampleUrls: [clickUrl, clickUrl],
+      bpm: BPM,
+    };
+
+    const engine = await createFixtureEngine(opts);
+    try {
+      const renderOpts = {
+        bars: 1,
+        sampleRate: getContext().sampleRate,
+        includeTail: false,
+      };
+
+      const kickStem = await engine.renderWav({
+        ...renderOpts,
+        soloChannelIndex: 0,
+      });
+      const kickOnsets = findOnsets(kickStem);
+      expect(kickOnsets).toHaveLength(1);
+      expect(kickOnsets[0]).toBeLessThan(0.1); // step 0, not step 8
+
+      // The retained snare solo is untouched: a plain render on the SAME
+      // engine still honors it.
+      const plainBuffer = await engine.renderWav(renderOpts);
+      const plainOnsets = findOnsets(plainBuffer);
+      expect(plainOnsets).toHaveLength(1);
+      expect(plainOnsets[0]).toBeGreaterThan(8 * STEP - TOL); // step 8
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("renders a muted channel's stem silent, matching the mix", async () => {
+    const buffer = await renderWithOptions(
+      {
+        pattern: makePattern({
+          steps: [
+            { voice: 0, step: 0 },
+            { voice: 1, step: 8 },
+          ],
+        }),
+        instruments: [
+          makeInstrument(0, "kick"),
+          makeInstrument(1, "snare", { mute: true }),
+        ],
+        sampleUrls: [clickUrl, clickUrl],
+        bpm: BPM,
+      },
+      { soloChannelIndex: 1 },
+    );
+
+    expect(findOnsets(buffer)).toHaveLength(0);
+  });
+});
+
+describe("stem render: masterTap", () => {
+  const fourOnFloor = (): RenderFixtureOptions => ({
+    pattern: makePattern({
+      steps: [0, 4, 8, 12].map((step) => ({ voice: 0, step })),
+    }),
+    instruments: [makeInstrument(0, "kick")],
+    sampleUrls: [clickUrl],
+    bpm: BPM,
+  });
+
+  it("keeps the grid in both modes; preMaster carries no master-chain latency", async () => {
+    const masterBuffer = await renderWithOptions(fourOnFloor(), {
+      masterTap: "master",
+    });
+    const preBuffer = await renderWithOptions(fourOnFloor(), {
+      masterTap: "preMaster",
+    });
+
+    const masterOnsets = findOnsets(masterBuffer);
+    const preOnsets = findOnsets(preBuffer);
+    expect(masterOnsets).toHaveLength(4);
+    expect(preOnsets).toHaveLength(4);
+
+    for (const onsets of [masterOnsets, preOnsets]) {
+      for (let i = 1; i < onsets.length; i++) {
+        const delta = onsets[i] - onsets[i - 1];
+        expect(delta).toBeGreaterThan(4 * STEP - TOL);
+        expect(delta).toBeLessThan(4 * STEP + TOL);
+      }
+    }
+
+    // The master chain delays everything by ~12ms (comp dry delay +
+    // limiter lookahead); the pre-master tap starts exactly on the bar
+    // line.
+    expect(preOnsets[0]).toBeLessThan(0.005);
+    expect(masterOnsets[0]).toBeGreaterThan(preOnsets[0]);
+  });
+
+  it("drops the master-level reverb send in preMaster mode", async () => {
+    // A single 10ms click at step 0 with the master reverb send up: only
+    // the master tap should carry tail energy long after the click.
+    const fixture = (): RenderFixtureOptions => ({
+      pattern: makePattern({ steps: [{ voice: 0, step: 0 }] }),
+      instruments: [makeInstrument(0, "snare")],
+      sampleUrls: [clickUrl],
+      bpm: BPM,
+      masterParams: { reverb: 100 },
+    });
+
+    const masterBuffer = await renderWithOptions(fixture(), {
+      masterTap: "master",
+    });
+    const preBuffer = await renderWithOptions(fixture(), {
+      masterTap: "preMaster",
+    });
+
+    // Both taps carry the dry hit itself.
+    expect(peakInWindow(masterBuffer, 0, 0.05)).toBeGreaterThan(0.1);
+    expect(peakInWindow(preBuffer, 0, 0.05)).toBeGreaterThan(0.1);
+
+    // Tail window well past the click (which is fully decayed by ~30ms).
+    // The comparison is primarily RELATIVE: the tail's absolute level is
+    // modest (the reverb send is pre-filtered and the click is short), but
+    // pre-master must carry an order of magnitude less of it.
+    const masterTail = rmsInWindow(masterBuffer, 0.1, 0.8);
+    const preTail = rmsInWindow(preBuffer, 0.1, 0.8);
+    expect(masterTail).toBeGreaterThan(0.0005); // reverb tail is present
+    expect(preTail).toBeLessThan(masterTail * 0.1); // and absent pre-master
+  });
+});

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -116,6 +116,23 @@ interface RenderWavOptions {
   sampleRate: number;
   /** Append EXPORT_TAIL_TIME of reverb/release tail after the last bar. */
   includeTail: boolean;
+  /**
+   * Renders a single channel's stem: the channel at this index is treated
+   * as the only soloed channel for this render, silencing every other
+   * channel. Applied to the render's snapshot only - the retained play
+   * params (and live playback) are never touched. A muted channel renders
+   * a silent stem, matching what it contributes to the mix.
+   */
+  soloChannelIndex?: number;
+  /**
+   * Where the rendered signal is tapped. "master" (the default) renders
+   * through the full master chain, exactly like a mix export. "preMaster"
+   * connects the channel chains straight to the offline destination, so
+   * the render carries channel-level processing only (no compression,
+   * saturation, EQ, limiting, or phaser/reverb sends - those are
+   * master-bus-level) and plays at unity master volume.
+   */
+  masterTap?: "master" | "preMaster";
 }
 
 /**
@@ -369,8 +386,11 @@ class AudioEngine {
     if (!kit || !resolver) {
       throw new Error("renderWav: no kit has been loaded");
     }
-    const masterSettings = this.masterSettings;
-    if (!masterSettings) {
+    // Master settings are only needed when rendering through the master
+    // chain; a pre-master stem render is channel processing only.
+    const masterTap = options.masterTap ?? "master";
+    const masterSettings = masterTap === "master" ? this.masterSettings : null;
+    if (masterTap === "master" && !masterSettings) {
       throw new Error("renderWav: no master settings have been pushed");
     }
 
@@ -378,14 +398,28 @@ class AudioEngine {
     // offline samplers load) cannot affect this render.
     const precomputed = this.precomputed;
     const playback = this.playback;
-    const playParams = this.playParams.slice();
+    let playParams = this.playParams.slice();
     const continuousParams = this.continuousParams.slice();
     const bpm = this.bpm;
     const swing = this.swing;
 
     const roles = kit.map((slot) => slot.role);
     const ohatIndex = roles.indexOf("ohat");
-    const anySolos = playParams.some((params) => params?.solo);
+    let anySolos = playParams.some((params) => params?.solo);
+
+    // Stem isolation transforms the SNAPSHOT only: the requested channel
+    // becomes the sole soloed channel and anySolos is forced on, so the
+    // scheduler skips every other channel - including when the isolated
+    // channel has no pushed params yet (an honestly silent stem). Retained
+    // engine state is never mutated, so live playback is unaffected.
+    const soloChannelIndex = options.soloChannelIndex;
+    if (soloChannelIndex !== undefined) {
+      playParams = playParams.map(
+        (params, index) =>
+          params && { ...params, solo: index === soloChannelIndex },
+      );
+      anySolos = true;
+    }
 
     const barDuration = calculateExportDuration(options.bars, bpm);
     // Add tail for reverb/release decay if requested, otherwise end on the
@@ -405,7 +439,11 @@ class AudioEngine {
     // those samples back off after rendering, so the export still begins
     // exactly on the bar line at full amplitude. Step-0 events pulled ahead
     // of the bar line (flam grace notes, negative timing nudges) land
-    // inside the pre-roll and are trimmed from the export.
+    // inside the pre-roll and are trimmed from the export. The pre-roll
+    // applies to the pre-master tap too: it has no compressors to warm up,
+    // but keeping one code path means every render is scheduled, sliced,
+    // and sized identically regardless of tap, and step-0 pre-bar trimming
+    // behaves the same in both modes.
     const prerollSamples = Math.ceil(EXPORT_PREROLL_TIME * options.sampleRate);
     const prerollSeconds = prerollSamples / options.sampleRate;
     // One sample of margin so seconds -> samples truncation inside Offline
@@ -417,12 +455,20 @@ class AudioEngine {
       async ({ transport, destination }) => {
         configureTransportTiming(transport, bpm, swing);
 
-        // Fresh bus and channels against the offline destination, from the
-        // retained settings/descriptors/resolver - created and wired by the
-        // same helpers loadKit uses, so live and offline graphs match.
-        const bus = await MasterBus.create(masterSettings, destination);
+        // Fresh channels against the offline context, from the retained
+        // descriptors/resolver - created and wired by the same helpers
+        // loadKit uses, so live and offline graphs match. The master tap
+        // decides what they feed: the full master chain (masterSettings is
+        // non-null exactly when the tap is "master"), or the offline
+        // destination directly for pre-master stems.
         const channels = await createKitChannels(kit, resolver);
-        attachChannels(channels, bus, continuousParams);
+        if (masterSettings) {
+          const bus = await MasterBus.create(masterSettings, destination);
+          attachChannels(channels, bus, continuousParams);
+        } else {
+          attachChannels(channels, null, continuousParams);
+          channels.forEach((channel) => channel.connectToNode(destination));
+        }
 
         // Offline scheduling reads a fixed snapshot context; the sequence
         // itself is the exact one live playback uses.

--- a/src/core/audio/engine/instrument-channel.ts
+++ b/src/core/audio/engine/instrument-channel.ts
@@ -156,16 +156,30 @@ class InstrumentChannel {
    * and connects the output to the master bus's parallel compression input.
    */
   connectToMasterBus(bus: MasterBus): void {
-    // Chain internal nodes first
+    this.chainInternalNodes();
+
+    // Connect to master bus (parallel compression)
+    bus.connectInput(this.output);
+  }
+
+  /**
+   * Chains internal nodes and connects the output straight to an arbitrary
+   * node, bypassing any master bus. Used for pre-master stem rendering,
+   * where the channel's own processing is the entire chain.
+   */
+  connectToNode(node: ToneAudioNode): void {
+    this.chainInternalNodes();
+    this.output.connect(node);
+  }
+
+  /** Wires the internal signal flow: sampler -> envelope -> LP -> HP -> pan. */
+  private chainInternalNodes(): void {
     this.samplerNode.chain(
       this.envelopeNode,
       this.lowPassFilterNode,
       this.highPassFilterNode,
       this.pannerNode,
     );
-
-    // Connect to master bus (parallel compression)
-    bus.connectInput(this.output);
   }
 
   /**

--- a/src/core/audio/export/download.ts
+++ b/src/core/audio/export/download.ts
@@ -1,0 +1,23 @@
+// --- Shared browser-download trigger for export payloads ---
+
+/**
+ * Triggers a browser download of a binary payload via a temporary object
+ * URL and anchor click. Shared by the WAV, MIDI, and stem exporters.
+ */
+function triggerBlobDownload(
+  data: ArrayBuffer | Uint8Array<ArrayBuffer>,
+  filename: string,
+  mimeType: string,
+): void {
+  const blob = new Blob([data], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export { triggerBlobDownload };

--- a/src/core/audio/export/index.ts
+++ b/src/core/audio/export/index.ts
@@ -12,3 +12,10 @@ export {
   type MidiVoiceDescriptor,
 } from "./midi-exporter";
 export { downloadMidi, encodeMidi } from "./midi-encoder";
+export {
+  exportStems,
+  type StemExportOptions,
+  type StemExportProgress,
+  type StemExportSummary,
+  type StemVoiceDescriptor,
+} from "./stem-exporter";

--- a/src/core/audio/export/midi-encoder.ts
+++ b/src/core/audio/export/midi-encoder.ts
@@ -5,6 +5,8 @@
 // byte-level encoding only - musical decisions (tick math, note mapping,
 // velocities) live in midi-exporter.ts.
 
+import { triggerBlobDownload } from "./download";
+
 /**
  * One note in absolute ticks. The encoder expands this into a note-on /
  * note-off pair and handles delta-time conversion and event ordering.
@@ -195,15 +197,7 @@ function encodeMidi(file: MidiFile): ArrayBuffer {
  * Triggers a browser download of the MIDI file
  */
 function downloadMidi(midiBuffer: ArrayBuffer, filename: string): void {
-  const blob = new Blob([midiBuffer], { type: "audio/midi" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  triggerBlobDownload(midiBuffer, filename, "audio/midi");
 }
 
 export { downloadMidi, encodeMidi, encodeVariableLengthQuantity };

--- a/src/core/audio/export/stem-exporter.test.ts
+++ b/src/core/audio/export/stem-exporter.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import { createEmptyPattern } from "@/features/sequencer/lib/helpers";
+import type {
+  Pattern,
+  PatternChain,
+  VariationId,
+} from "../engine/pattern-types";
+import {
+  buildStemReadme,
+  FULL_MIX_FILENAME,
+  planStemLanes,
+  stemFileName,
+  variationsPlayed,
+  type StemVoiceDescriptor,
+} from "./stem-exporter";
+
+const DEFAULT_NAMES = [
+  "Kick",
+  "Kick2",
+  "Snare",
+  "Clap",
+  "Hat",
+  "OHat",
+  "Tom",
+  "Tom2",
+];
+
+function makeVoices(
+  overrides: Partial<StemVoiceDescriptor>[] = [],
+): StemVoiceDescriptor[] {
+  return DEFAULT_NAMES.map((name, slot) => ({
+    name,
+    mute: false,
+    solo: false,
+    ...overrides[slot],
+  }));
+}
+
+/** An empty pattern with triggers set on the given voice/variation steps. */
+function makePattern(
+  edits: { voice: number; step: number; variation?: VariationId }[],
+): Pattern {
+  const pattern = createEmptyPattern();
+  for (const edit of edits) {
+    pattern.voices[edit.voice].variations[edit.variation ?? 0].triggers[
+      edit.step
+    ] = true;
+  }
+  return pattern;
+}
+
+const NO_CHAIN: PatternChain = { steps: [{ variation: 0, repeats: 1 }] };
+
+function makePlanOptions(
+  pattern: Pattern,
+  overrides: Partial<Parameters<typeof planStemLanes>[0]> = {},
+) {
+  return {
+    pattern,
+    chain: NO_CHAIN,
+    chainEnabled: false,
+    variation: 0 as VariationId,
+    bars: 2,
+    voices: makeVoices(),
+    ...overrides,
+  };
+}
+
+describe("stemFileName", () => {
+  it("numbers stems by slot order and slugs the name", () => {
+    expect(stemFileName(0, "Kick")).toBe("01-kick.wav");
+    expect(stemFileName(4, "Hat")).toBe("05-hat.wav");
+    expect(stemFileName(7, "Tom2")).toBe("08-tom2.wav");
+  });
+
+  it("collapses non-alphanumeric runs and trims edge dashes", () => {
+    expect(stemFileName(2, "Stick Click!")).toBe("03-stick-click.wav");
+    expect(stemFileName(5, "  808 / Sub  ")).toBe("06-808-sub.wav");
+  });
+
+  it("falls back to the channel number when the name has no usable characters", () => {
+    expect(stemFileName(3, "***")).toBe("04-channel-4.wav");
+    expect(stemFileName(3, "")).toBe("04-channel-4.wav");
+  });
+});
+
+describe("variationsPlayed", () => {
+  it("returns only the pushed variation when the chain is disabled", () => {
+    const chain: PatternChain = {
+      steps: [
+        { variation: 0, repeats: 1 },
+        { variation: 3, repeats: 1 },
+      ],
+    };
+    expect(variationsPlayed(chain, false, 2, 4)).toEqual(new Set([2]));
+  });
+
+  it("walks the chain bar by bar when enabled", () => {
+    const chain: PatternChain = {
+      steps: [
+        { variation: 0, repeats: 2 },
+        { variation: 1, repeats: 1 },
+      ],
+    };
+    // 3 bars = exactly one chain pass: A, A, B.
+    expect(variationsPlayed(chain, true, 0, 3)).toEqual(new Set([0, 1]));
+    // 2 bars never reach B.
+    expect(variationsPlayed(chain, true, 0, 2)).toEqual(new Set([0]));
+  });
+
+  it("wraps the chain when bars exceed one pass", () => {
+    const chain: PatternChain = {
+      steps: [
+        { variation: 0, repeats: 1 },
+        { variation: 2, repeats: 1 },
+      ],
+    };
+    expect(variationsPlayed(chain, true, 0, 5)).toEqual(new Set([0, 2]));
+  });
+});
+
+describe("planStemLanes", () => {
+  it("skips lanes with no triggers in the exported bars and keeps the rest", () => {
+    const pattern = makePattern([
+      { voice: 0, step: 0 },
+      { voice: 2, step: 4 },
+    ]);
+    const lanes = planStemLanes(makePlanOptions(pattern));
+
+    expect(lanes).toHaveLength(8);
+    expect(lanes[0]).toEqual({
+      slot: 0,
+      name: "Kick",
+      fileName: "01-kick.wav",
+      skipReason: null,
+    });
+    expect(lanes[2].skipReason).toBeNull();
+    for (const slot of [1, 3, 4, 5, 6, 7]) {
+      expect(lanes[slot].skipReason).toBe("empty");
+    }
+  });
+
+  it("treats triggers outside the played variations as empty", () => {
+    // Triggers only in variation B, but the export plays variation A.
+    const pattern = makePattern([{ voice: 0, step: 0, variation: 1 }]);
+    const lanes = planStemLanes(makePlanOptions(pattern));
+    expect(lanes[0].skipReason).toBe("empty");
+
+    // A chain that reaches variation B keeps the lane.
+    const chained = planStemLanes(
+      makePlanOptions(pattern, {
+        chain: {
+          steps: [
+            { variation: 0, repeats: 1 },
+            { variation: 1, repeats: 1 },
+          ],
+        },
+        chainEnabled: true,
+      }),
+    );
+    expect(chained[0].skipReason).toBeNull();
+  });
+
+  it("skips muted lanes and lanes silenced by another channel's solo", () => {
+    const pattern = makePattern([
+      { voice: 0, step: 0 },
+      { voice: 1, step: 2 },
+      { voice: 2, step: 4 },
+    ]);
+    const lanes = planStemLanes(
+      makePlanOptions(pattern, {
+        voices: makeVoices([{ mute: true }, { solo: true }]),
+      }),
+    );
+
+    expect(lanes[0].skipReason).toBe("muted");
+    expect(lanes[1].skipReason).toBeNull(); // the soloed lane renders
+    expect(lanes[2].skipReason).toBe("not-soloed");
+    // Empty takes precedence: silent lanes are "empty" regardless of solo.
+    expect(lanes[3].skipReason).toBe("empty");
+  });
+});
+
+describe("buildStemReadme", () => {
+  const meta = {
+    presetName: "Test Preset",
+    bpm: 95,
+    bars: 4,
+    sampleRate: 48000,
+  };
+
+  it("lists preset facts, the pre-master note, and rendered stems", () => {
+    const lanes = planStemLanes(
+      makePlanOptions(makePattern([{ voice: 0, step: 0 }])),
+    );
+    const readme = buildStemReadme(meta, lanes);
+
+    expect(readme).toContain("Test Preset - stems");
+    expect(readme).toContain("Tempo: 95 BPM");
+    expect(readme).toContain("Length: 4 bars");
+    expect(readme).toContain("Sample rate: 48000 Hz");
+    expect(readme).toContain(FULL_MIX_FILENAME);
+    expect(readme).toContain("PRE-MASTER");
+    expect(readme).toContain("  01-kick.wav");
+  });
+
+  it("lists every skipped lane with its reason", () => {
+    const lanes = planStemLanes(
+      makePlanOptions(
+        makePattern([
+          { voice: 0, step: 0 },
+          { voice: 4, step: 2 },
+        ]),
+        { voices: makeVoices([{}, {}, {}, {}, { mute: true }]) },
+      ),
+    );
+    const readme = buildStemReadme(meta, lanes);
+
+    expect(readme).toContain("Skipped (would have rendered silence):");
+    expect(readme).toContain("05-hat.wav (muted)");
+    expect(readme).toContain("02-kick2.wav (no triggers in the exported bars)");
+    // Rendered stems never appear in the skipped section.
+    expect(readme.split("Skipped")[1]).not.toContain("01-kick.wav");
+  });
+});

--- a/src/core/audio/export/stem-exporter.ts
+++ b/src/core/audio/export/stem-exporter.ts
@@ -1,0 +1,331 @@
+// --- Stem export: one pre-master WAV per channel + the full mix, zipped ---
+//
+// Rendering rides the single renderWav path (issue #308): each stem is a
+// render with soloChannelIndex isolating one channel and masterTap
+// "preMaster", so stems carry channel-level processing only and recombine
+// linearly in a DAW. The full mix is rendered through the master chain (the
+// production export sound) so the pack is self-contained.
+//
+// Lane planning is store-free like midi-exporter.ts: the feature layer
+// passes the pattern, chain arrangement, and per-slot voice descriptors in
+// as arguments. Lanes that would render silence - no triggers in any
+// variation the arrangement plays, muted, or silenced by another channel's
+// solo - are skipped and reported, so users don't get useless files.
+
+import { strToU8, zipSync, type Zippable } from "fflate";
+
+import { getAudioEngine } from "../engine";
+import {
+  sanitizeChain,
+  type Pattern,
+  type PatternChain,
+  type VariationId,
+} from "../engine/pattern-types";
+import {
+  advanceChainAtEndOfBar,
+  variationForBarStart,
+  type ChainPlaybackState,
+} from "../engine/variation/chain";
+import { triggerBlobDownload } from "./download";
+import { encodeWav } from "./wav-encoder";
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+/** A slot's identity and mix flags, in slot order. */
+interface StemVoiceDescriptor {
+  name: string;
+  mute: boolean;
+  solo: boolean;
+}
+
+interface StemExportOptions {
+  /** Zip filename without extension; the download is `{filename}-stems.zip`. */
+  filename: string;
+  bars: number;
+  sampleRate: number;
+  /** Append the reverb/release tail after the last bar of every render. */
+  includeTail: boolean;
+  /** Written to the pack's README. */
+  presetName: string;
+  /** Written to the pack's README. */
+  bpm: number;
+  pattern: Pattern;
+  chain: PatternChain;
+  chainEnabled: boolean;
+  /** Variation played for every bar when the chain is disabled. */
+  variation: VariationId;
+  /** Per-slot voice descriptors, in slot order. */
+  voices: StemVoiceDescriptor[];
+}
+
+/** Why a lane renders silence and is therefore left out of the pack. */
+type StemSkipReason = "empty" | "muted" | "not-soloed";
+
+/** One slot's export plan: its file name and whether/why it is skipped. */
+interface StemLanePlan {
+  slot: number;
+  name: string;
+  /** `{nn}-{slot-name}.wav`, nn = slot number in slot order (01-08). */
+  fileName: string;
+  skipReason: StemSkipReason | null;
+}
+
+interface StemExportProgress {
+  phase: "preparing" | "rendering" | "packaging" | "complete";
+  percent: number;
+  /** Present while rendering: "full mix" or "stem {k}/{n}". */
+  label?: string;
+}
+
+interface StemExportSummary {
+  zipFileName: string;
+  rendered: StemLanePlan[];
+  skipped: StemLanePlan[];
+}
+
+/** The full mix's entry name; 00 keeps it sorted ahead of the stems. */
+const FULL_MIX_FILENAME = "00-full-mix.wav";
+
+// -----------------------------------------------------------------------------
+// Lane planning (pure, exported for tests)
+// -----------------------------------------------------------------------------
+
+/**
+ * The set of variations the export arrangement actually plays: the chain
+ * walked bar by bar (wrapping) when enabled, otherwise just the pushed
+ * variation. Mirrors the bar arrangement of WAV and MIDI export.
+ */
+function variationsPlayed(
+  chain: PatternChain,
+  chainEnabled: boolean,
+  variation: VariationId,
+  bars: number,
+): Set<VariationId> {
+  const sanitized = sanitizeChain(chain);
+  const chainState: ChainPlaybackState = {
+    stepIndex: 0,
+    repeatsRemaining: sanitized.steps[0]?.repeats ?? 1,
+  };
+
+  const played = new Set<VariationId>();
+  for (let bar = 0; bar < bars; bar++) {
+    played.add(
+      variationForBarStart(chainEnabled, sanitized, chainState, variation),
+    );
+    advanceChainAtEndOfBar(chainEnabled, sanitized, chainState);
+  }
+  return played;
+}
+
+/**
+ * A stem entry name: `{nn}-{slot-name}.wav` in slot order (01-08), the
+ * slot name lowercased and slugged. A name with no usable characters falls
+ * back to `channel-{n}`.
+ */
+function stemFileName(slot: number, name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const number = String(slot + 1).padStart(2, "0");
+  return `${number}-${slug || `channel-${slot + 1}`}.wav`;
+}
+
+/**
+ * Plans every slot's stem: its file name plus a skip reason for lanes that
+ * would render silence - "empty" (no triggers in any variation the
+ * arrangement plays), "muted", or "not-soloed" (another channel's solo
+ * silences it). Skipped lanes are reported, never dropped silently.
+ */
+function planStemLanes(
+  options: Pick<
+    StemExportOptions,
+    "pattern" | "chain" | "chainEnabled" | "variation" | "bars" | "voices"
+  >,
+): StemLanePlan[] {
+  const played = variationsPlayed(
+    options.chain,
+    options.chainEnabled,
+    options.variation,
+    options.bars,
+  );
+  const anySolos = options.voices.some((voice) => voice.solo);
+
+  return options.voices.map((voice, slot) => {
+    const hasTriggers = [...played].some((variation) =>
+      options.pattern.voices[slot]?.variations[variation]?.triggers.some(
+        Boolean,
+      ),
+    );
+
+    let skipReason: StemSkipReason | null = null;
+    if (!hasTriggers) skipReason = "empty";
+    else if (voice.mute) skipReason = "muted";
+    else if (anySolos && !voice.solo) skipReason = "not-soloed";
+
+    return {
+      slot,
+      name: voice.name,
+      fileName: stemFileName(slot, voice.name),
+      skipReason,
+    };
+  });
+}
+
+// -----------------------------------------------------------------------------
+// README (pure, exported for tests)
+// -----------------------------------------------------------------------------
+
+const SKIP_REASON_TEXT: Record<StemSkipReason, string> = {
+  empty: "no triggers in the exported bars",
+  muted: "muted",
+  "not-soloed": "silenced by another channel's solo",
+};
+
+/**
+ * The pack's README: what the stems are (pre-master), what the mix is,
+ * and which lanes were skipped and why.
+ */
+function buildStemReadme(
+  options: Pick<
+    StemExportOptions,
+    "presetName" | "bpm" | "bars" | "sampleRate"
+  >,
+  lanes: StemLanePlan[],
+): string {
+  const rendered = lanes.filter((lane) => lane.skipReason === null);
+  const skipped = lanes.filter((lane) => lane.skipReason !== null);
+
+  const lines = [
+    `${options.presetName} - stems`,
+    "",
+    "Exported from Drumhaus (https://www.drumhaus.io)",
+    "",
+    `Tempo: ${options.bpm} BPM`,
+    `Length: ${options.bars} ${options.bars === 1 ? "bar" : "bars"}`,
+    `Sample rate: ${options.sampleRate} Hz`,
+    "",
+    `${FULL_MIX_FILENAME} is the full mix, rendered through the master`,
+    "chain (the production Drumhaus sound).",
+    "",
+    "The numbered stems are PRE-MASTER: each channel is rendered with its",
+    "own tune, decay, filter, pan, and volume, but without the master-chain",
+    "compression, saturation, EQ, limiting, or reverb/phaser sends, and at",
+    "unity master volume. Summed together they reproduce the un-mastered",
+    "mix exactly, so they rebalance cleanly under your own bus processing.",
+    "",
+    "Stems:",
+    ...rendered.map((lane) => `  ${lane.fileName}`),
+  ];
+
+  if (skipped.length > 0) {
+    lines.push(
+      "",
+      "Skipped (would have rendered silence):",
+      ...skipped.map(
+        (lane) =>
+          `  ${lane.fileName} (${SKIP_REASON_TEXT[lane.skipReason as StemSkipReason]})`,
+      ),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+// -----------------------------------------------------------------------------
+// Export
+// -----------------------------------------------------------------------------
+
+/**
+ * Exports the current pattern as a zip of per-channel pre-master stems plus
+ * the master-chain full mix and a README. Renders sequentially through the
+ * engine's single render path, reporting per-stem progress. Returns a
+ * summary of rendered and skipped lanes for the UI to surface.
+ */
+async function exportStems(
+  options: StemExportOptions,
+  onProgress?: (progress: StemExportProgress) => void,
+): Promise<StemExportSummary> {
+  onProgress?.({ phase: "preparing", percent: 0 });
+
+  const lanes = planStemLanes(options);
+  const rendered = lanes.filter((lane) => lane.skipReason === null);
+  const skipped = lanes.filter((lane) => lane.skipReason !== null);
+
+  const engine = getAudioEngine();
+  const renderOptions = {
+    bars: options.bars,
+    sampleRate: options.sampleRate,
+    includeTail: options.includeTail,
+  };
+
+  // Renders spread across 5-85%; the full mix counts as one render.
+  const renderCount = rendered.length + 1;
+  const renderPercent = (done: number) =>
+    Math.round(5 + (done / renderCount) * 80);
+
+  const files: Zippable = {
+    "README.txt": strToU8(buildStemReadme(options, lanes)),
+  };
+
+  onProgress?.({
+    phase: "rendering",
+    percent: renderPercent(0),
+    label: "full mix",
+  });
+  const mixBuffer = await engine.renderWav(renderOptions);
+  files[FULL_MIX_FILENAME] = new Uint8Array(encodeWav(mixBuffer));
+
+  for (const [index, lane] of rendered.entries()) {
+    onProgress?.({
+      phase: "rendering",
+      percent: renderPercent(index + 1),
+      label: `stem ${index + 1}/${rendered.length}`,
+    });
+    const stemBuffer = await engine.renderWav({
+      ...renderOptions,
+      soloChannelIndex: lane.slot,
+      masterTap: "preMaster",
+    });
+    files[lane.fileName] = new Uint8Array(encodeWav(stemBuffer));
+  }
+
+  onProgress?.({ phase: "packaging", percent: 90 });
+
+  // STORE (no compression): WAV data barely deflates and stems are large;
+  // an uncompressed zip packages fast and stays streamable.
+  const zip = zipSync(files, { level: 0 });
+
+  onProgress?.({ phase: "complete", percent: 100 });
+
+  const zipFileName = `${options.filename}-stems.zip`;
+  triggerBlobDownload(
+    zip as Uint8Array<ArrayBuffer>,
+    zipFileName,
+    "application/zip",
+  );
+
+  return { zipFileName, rendered, skipped };
+}
+
+// Bar-count suggestion is shared with WAV export so every format follows
+// the same arrangement semantics.
+export { getSuggestedBars } from "./wav-exporter";
+export {
+  buildStemReadme,
+  exportStems,
+  FULL_MIX_FILENAME,
+  planStemLanes,
+  stemFileName,
+  variationsPlayed,
+};
+export type {
+  StemExportOptions,
+  StemExportProgress,
+  StemExportSummary,
+  StemLanePlan,
+  StemSkipReason,
+  StemVoiceDescriptor,
+};

--- a/src/core/audio/export/wav-encoder.ts
+++ b/src/core/audio/export/wav-encoder.ts
@@ -1,6 +1,7 @@
 // --- WAV encoding utilities for AudioBuffer export ---
 
 import { clamp } from "@/shared/lib/utils";
+import { triggerBlobDownload } from "./download";
 
 /**
  * Encodes an AudioBuffer to WAV format (PCM 16-bit)
@@ -68,15 +69,7 @@ function writeString(view: DataView, offset: number, str: string): void {
  * Triggers a browser download of the WAV file
  */
 function downloadWav(wavBuffer: ArrayBuffer, filename: string): void {
-  const blob = new Blob([wavBuffer], { type: "audio/wav" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  triggerBlobDownload(wavBuffer, filename, "audio/wav");
 }
 
 /**

--- a/src/features/preset/dialogs/export-dialog.tsx
+++ b/src/features/preset/dialogs/export-dialog.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { MidiExportForm } from "@/features/preset/forms/midi-export-form";
 import { PresetFileExportForm } from "@/features/preset/forms/preset-file-export-form";
+import { StemsExportForm } from "@/features/preset/forms/stems-export-form";
 import { WavExportForm } from "@/features/preset/forms/wav-export-form";
 import {
   Dialog,
@@ -20,7 +21,7 @@ interface ExportDialogProps {
   onClose: () => void;
 }
 
-type ExportTab = "file" | "wav" | "midi";
+type ExportTab = "file" | "wav" | "stems" | "midi";
 
 function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
   const [activeTab, setActiveTab] = useState<ExportTab>("file");
@@ -39,9 +40,10 @@ function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
           value={activeTab}
           onValueChange={(value) => setActiveTab(value as ExportTab)}
         >
-          <TabsList className="grid w-full grid-cols-3">
+          <TabsList className="grid w-full grid-cols-4">
             <TabsTrigger value="file">Preset File</TabsTrigger>
             <TabsTrigger value="wav">WAV</TabsTrigger>
+            <TabsTrigger value="stems">Stems</TabsTrigger>
             <TabsTrigger value="midi">MIDI</TabsTrigger>
           </TabsList>
 
@@ -51,6 +53,10 @@ function ExportDialog({ isOpen, onClose }: ExportDialogProps) {
 
           <TabsContent value="wav">
             <WavExportForm onClose={onClose} />
+          </TabsContent>
+
+          <TabsContent value="stems">
+            <StemsExportForm onClose={onClose} />
           </TabsContent>
 
           <TabsContent value="midi">

--- a/src/features/preset/forms/stems-export-form.tsx
+++ b/src/features/preset/forms/stems-export-form.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useMemo, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, useWatch } from "react-hook-form";
+import { z } from "zod";
+
+import {
+  exportStems,
+  getSuggestedBars,
+  type StemExportProgress,
+} from "@/core/audio/export/stem-exporter";
+import { calculateExportDuration } from "@/core/audio/export/wav-exporter";
+import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
+import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
+import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
+import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import { PixelatedSpinner } from "@/shared/components/pixelated-spinner";
+import {
+  Button,
+  Checkbox,
+  DialogDescription,
+  DialogFooter,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+  Slider,
+  useToast,
+} from "@/shared/ui";
+
+interface StemsExportFormProps {
+  onClose: () => void;
+}
+
+type SampleRateOption = "system" | "44100" | "48000";
+
+const sampleRateOptions: { value: SampleRateOption; label: string }[] = [
+  { value: "system", label: "System" },
+  { value: "44100", label: "44.1 kHz" },
+  { value: "48000", label: "48 kHz" },
+];
+
+const stemsExportSchema = z.object({
+  filename: z.string().trim().min(1, "Filename is required"),
+  bars: z.number().int().min(1, "At least 1 bar").max(8, "Maximum 8 bars"),
+  sampleRate: z.enum(["system", "44100", "48000"]),
+  includeTail: z.boolean(),
+});
+
+type StemsExportFormValues = z.infer<typeof stemsExportSchema>;
+
+/** Progress line for the submit button, e.g. "Rendering stem 3/8". */
+function progressLabel(progress: StemExportProgress | null): string {
+  if (!progress) return "Exporting";
+  switch (progress.phase) {
+    case "rendering":
+      return progress.label ? `Rendering ${progress.label}` : "Rendering";
+    case "packaging":
+      return "Packaging";
+    default:
+      return "Exporting";
+  }
+}
+
+function StemsExportForm({ onClose }: StemsExportFormProps) {
+  const pattern = usePatternStore((state) => state.pattern);
+  const chain = usePatternStore((state) => state.chain);
+  const chainEnabled = usePatternStore((state) => state.chainEnabled);
+  const variation = usePatternStore((state) => state.variation);
+  const bpm = useTransportStore((state) => state.bpm);
+  const instruments = useInstrumentsStore((state) => state.instruments);
+  const presetName = usePresetMetaStore(
+    (state) => state.currentPresetMeta.name,
+  );
+
+  const { toast } = useToast();
+  const recommendedBars = getSuggestedBars(chain, chainEnabled);
+  const [progress, setProgress] = useState<StemExportProgress | null>(null);
+
+  const defaultValues = useMemo(
+    () => ({
+      filename: presetName,
+      bars: recommendedBars,
+      sampleRate: "system" as const,
+      includeTail: false,
+    }),
+    [presetName, recommendedBars],
+  );
+
+  const form = useForm<StemsExportFormValues>({
+    resolver: zodResolver(stemsExportSchema),
+    defaultValues,
+    mode: "onChange",
+  });
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    control,
+    formState: { errors, isSubmitting, isValid },
+  } = form;
+
+  useEffect(() => {
+    setValue("filename", presetName, { shouldValidate: true });
+  }, [presetName, setValue]);
+
+  useEffect(() => {
+    setValue("bars", recommendedBars, { shouldValidate: true });
+  }, [recommendedBars, setValue]);
+
+  const bars = useWatch({ control, name: "bars" });
+  const includeTail = useWatch({ control, name: "includeTail" });
+  const sampleRate = useWatch({ control, name: "sampleRate" });
+
+  const baseDuration = calculateExportDuration(bars ?? recommendedBars, bpm);
+  const duration = baseDuration + ((includeTail ?? false) ? 2 : 0);
+
+  const onSubmit = handleSubmit(async (values) => {
+    try {
+      const actualSampleRate =
+        values.sampleRate === "system"
+          ? new AudioContext().sampleRate
+          : parseInt(values.sampleRate, 10);
+
+      const summary = await exportStems(
+        {
+          filename: values.filename.trim() || "drumhaus-export",
+          bars: values.bars,
+          sampleRate: actualSampleRate,
+          includeTail: values.includeTail,
+          presetName,
+          bpm,
+          pattern,
+          chain,
+          chainEnabled,
+          variation,
+          voices: instruments.map((instrument) => ({
+            name: instrument.meta.name,
+            mute: instrument.params.mute,
+            solo: instrument.params.solo,
+          })),
+        },
+        setProgress,
+      );
+
+      const stemCount = summary.rendered.length;
+      const skippedNames = summary.skipped.map((lane) => lane.name);
+      toast({
+        title: "Export successful",
+        description:
+          `${stemCount} ${stemCount === 1 ? "stem" : "stems"} + full mix zipped.` +
+          (skippedNames.length > 0
+            ? ` Skipped silent lanes: ${skippedNames.join(", ")}.`
+            : ""),
+        duration: 8000,
+      });
+      onClose();
+    } catch (error) {
+      console.error("Export failed:", error);
+      toast({
+        title: "Something went wrong",
+        description: "Couldn't export stems. Please try again.",
+        status: "error",
+        duration: 8000,
+      });
+    } finally {
+      setProgress(null);
+    }
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <div className="space-y-4">
+        <DialogDescription>
+          Export each channel as its own pre-master WAV stem (dry of
+          master-chain processing, so stems recombine cleanly in a DAW), zipped
+          together with the full mix. Silent channels are skipped.
+        </DialogDescription>
+
+        <FieldGroup>
+          <Field data-invalid={Boolean(errors.filename)}>
+            <FieldLabel htmlFor="stems-filename">Filename</FieldLabel>
+            <Input
+              id="stems-filename"
+              autoFocus
+              aria-invalid={Boolean(errors.filename)}
+              disabled={isSubmitting}
+              {...register("filename")}
+            />
+            <FieldError errors={[errors.filename]} />
+          </Field>
+
+          <FieldSeparator />
+
+          <FieldSet>
+            <FieldLegend>Export options</FieldLegend>
+            <FieldGroup>
+              <Field data-invalid={Boolean(errors.bars)}>
+                <FieldLabel htmlFor="stems-bars">Length</FieldLabel>
+
+                <div className="flex items-center justify-between">
+                  <FieldDescription>
+                    Recommended: {recommendedBars}{" "}
+                    {recommendedBars === 1 ? "bar" : "bars"}
+                  </FieldDescription>
+                  <span className="text-sm">
+                    {bars} {bars === 1 ? "bar" : "bars"}
+                  </span>
+                </div>
+                <div>
+                  <Slider
+                    id="stems-bars"
+                    value={[bars ?? recommendedBars]}
+                    onValueChange={([value]) =>
+                      setValue("bars", value, { shouldValidate: true })
+                    }
+                    min={1}
+                    max={8}
+                    step={1}
+                    disabled={isSubmitting}
+                  />
+                  <div className="flex justify-between px-[8px]">
+                    {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
+                      <div key={n} className="flex flex-col items-center">
+                        <div className="h-1 w-px" />
+                        <span
+                          className={`mt-0.5 text-[10px] ${[1, 2, 4, 8].includes(n) ? "text-foreground-emphasis" : "text-foreground-muted"}`}
+                        >
+                          {n}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <FieldError errors={[errors.bars]} />
+              </Field>
+
+              <Field data-invalid={Boolean(errors.sampleRate)}>
+                <FieldLabel>Sample rate</FieldLabel>
+                <FieldDescription>
+                  For audio nerds. System is usually fine.
+                </FieldDescription>
+                <RadioGroup
+                  value={sampleRate}
+                  onValueChange={(value) =>
+                    setValue("sampleRate", value as SampleRateOption, {
+                      shouldValidate: true,
+                    })
+                  }
+                  disabled={isSubmitting}
+                >
+                  {sampleRateOptions.map((option) => (
+                    <div key={option.value} className="flex items-center gap-2">
+                      <RadioGroupItem
+                        value={option.value}
+                        id={`stems-${option.value}`}
+                      />
+                      <FieldLabel
+                        htmlFor={`stems-${option.value}`}
+                        className="font-normal"
+                      >
+                        {option.label}
+                      </FieldLabel>
+                    </div>
+                  ))}
+                </RadioGroup>
+
+                <FieldError errors={[errors.sampleRate]} />
+              </Field>
+              <FieldSet>
+                <FieldLabel>Reverb Tail</FieldLabel>
+                <FieldDescription>
+                  Add extra time at the end of every render so long decays
+                  aren’t cut off.
+                </FieldDescription>
+
+                <FieldGroup data-slot="checkbox-group">
+                  <Field orientation="horizontal">
+                    <Checkbox
+                      id="stems-includeTail"
+                      checked={includeTail}
+                      onCheckedChange={(checked) =>
+                        setValue("includeTail", checked === true)
+                      }
+                      disabled={isSubmitting}
+                    />
+                    <FieldLabel
+                      htmlFor="stems-includeTail"
+                      className="font-normal"
+                    >
+                      Preserve tails in export
+                    </FieldLabel>
+                  </Field>
+                </FieldGroup>
+              </FieldSet>
+            </FieldGroup>
+          </FieldSet>
+        </FieldGroup>
+        <FieldSeparator />
+      </div>
+
+      <DialogFooter className="pt-6">
+        <Field className="gap-0">
+          <FieldLabel>Duration</FieldLabel>
+          <FieldDescription>{duration.toFixed(1)}s</FieldDescription>
+        </Field>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!isValid || isSubmitting}>
+          <span className={isSubmitting ? "mr-2" : ""}>
+            {isSubmitting ? progressLabel(progress) : "Export"}
+          </span>
+          {isSubmitting && (
+            <PixelatedSpinner
+              color="currentColor"
+              size={20}
+              pixelSize={2}
+              gap={2}
+            />
+          )}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+export { StemsExportForm };


### PR DESCRIPTION
Adds per-channel WAV stem export behind a new Stems tab in the export dialog, riding the engine's single offline render path.

## Engine (commit 1)

`renderWav` gains two options instead of a parallel renderer:

- `soloChannelIndex` isolates one channel by transforming the render's snapshot (the target becomes the only soloed channel); retained engine state is never mutated, so live playback is unaffected.
- `masterTap: "master" | "preMaster"` selects the tap point: the full master chain (as mix exports do today) or the channel chains wired straight to the offline destination.

The #318 warm-up pre-roll applies uniformly in both modes so every render is scheduled, sliced, and sized identically.

## Pre-master stems (maintainer decision)

Stems ship pre-master, with no UI toggle.
Pre-master stems are linear, so they sum back to the un-mastered mix exactly and rebalance cleanly under a DAW's own bus processing; master-chain stems bake in nonlinear mix-bus processing reacting to a single channel and can never recombine to the mix (audition measured a 0.18x-RMS residual and +3 dB sum overshoot).
The master-chain tap remains implemented in the engine, just not surfaced.

## Packaging (proposal, implemented)

- One download: `{filename}-stems.zip`, built with `fflate` (small, tree-shakeable) using STORE entries, since WAV data barely deflates and uncompressed packaging is fast.
- Stems are named `{nn}-{slot-name}.wav` in slot order (e.g. `01-kick.wav`), so files sort like the machine reads.
- The pack includes the full mix as `00-full-mix.wav`, rendered through the master chain (the production sound), so the pack is self-contained for sharing.
- A short `README.txt` states preset name, BPM, bars, sample rate, the pre-master contract, and every skipped lane with its reason.

## Empty-lane policy

Lanes that would render silence are skipped rather than exported as useless files, and no skip is silent: the README and the success toast both list skipped lanes with reasons.
"Silent" covers three knowable cases: no triggers in any variation the exported bars actually play (chain-aware), muted, or silenced by another channel's solo.

## UI

The Stems tab mirrors the WAV form: filename, bar-count slider with the chain-based suggestion, sample rate, tail toggle, and per-file duration hint.
The submit button reports per-stem progress ("Rendering stem 3/8", "Packaging") during the sequential renders.
The form copy states that stems are pre-master.

## Tests

- Browser tests for the renderWav options (isolation by onset count/position, snapshot-only solo override, silent muted stems, grid integrity and zero added latency pre-master, dropped master reverb send).
- Unit tests for lane planning (chain-aware emptiness, mute, solo), stem naming, and README content.
- E2E (`e2e/stem-export.spec.ts`): toggles steps on two lanes, exports, unzips the download with fflate, asserts the exact entry set (empty-lane policy), validates each WAV's RIFF header and audio content against the promised duration, and checks the skip summary in the toast.

Gates: prettier, oxlint, vitest (731 passed), build, lightshow smoke, full Playwright suite (9 passed), and both engine-purity greps are green.

Closes #308
