### PR TITLE
feat(audio): retune swing to the TR-909 range with an honest MPC display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 __screenshots__
 /playwright-report
 /test-results
+/audition-out
 
 # vite
 /dist

--- a/docs/preset-persistence.md
+++ b/docs/preset-persistence.md
@@ -4,6 +4,11 @@ Status: accepted (audit complete, greenfield redesign adopted in review, impleme
 Author: Max, July 2026.
 Tracking issue: #329.
 
+Update (2026-07-14, #269): the swing retune landed before this design's document model shipped, as `.dh` version 1.5.
+Version 1.5 is a knob-space revision of the v1 shape (identical fields; `transport.swing` knob values written under the old curve are rescaled by 4/3 on load, see `src/features/preset/document/migrate.ts`), the share codec gained a `v` field mirroring the file version (absent = legacy URL, swing migrated on decode), and the transport persist is now versioned (v1, with a swing migrate).
+Version 2 remains the domain-unit document described below, unchanged; its 1-to-2 migration must now also accept 1.5 as input (the swing rescale is already applied there).
+The audit sections still describe the pre-#269 state where they mention an unversioned codec and transport persist.
+
 ## Summary
 
 The audio engine is now a framework-free facade that deals in musical data pushed through the bridge, but `.dh` files remain snapshots of React-side store state, loaded through a non-atomic sequence of store writes with shallow validation and heuristic migrations.

--- a/src/core/audio/bridge/domain-to-knob.test.ts
+++ b/src/core/audio/bridge/domain-to-knob.test.ts
@@ -144,11 +144,29 @@ describe("split-filter positions", () => {
 });
 
 describe("transport swing", () => {
-  it.each(KNOB_VALUES)("round-trips knob %f through 0-0.5", (knobValue) => {
-    const knob = transportSwingDomainToKnob(
-      transportSwingKnobToDomain(knobValue),
-    );
-    expect(Math.abs(knob - knobValue)).toBeLessThanOrEqual(EPSILON);
+  it.each(KNOB_VALUES)(
+    "round-trips knob %f through the Tone swing domain",
+    (knobValue) => {
+      const knob = transportSwingDomainToKnob(
+        transportSwingKnobToDomain(knobValue),
+      );
+      expect(Math.abs(knob - knobValue)).toBeLessThanOrEqual(EPSILON);
+    },
+  );
+
+  // Pins the #269 retune: the knob maps linearly onto the TR-909 shuffle
+  // range, so knob 100 = Tone swing 0.375 (MPC 62.5%) and knob 50 = 0.1875
+  // (MPC 56.25%).
+  it("maps knob 100 to Tone swing 0.375 (the 909 ceiling)", () => {
+    expect(transportSwingKnobToDomain(100)).toBe(0.375);
+  });
+
+  it("maps knob 50 to Tone swing 0.1875", () => {
+    expect(transportSwingKnobToDomain(50)).toBe(0.1875);
+  });
+
+  it("maps knob 0 to straight time", () => {
+    expect(transportSwingKnobToDomain(0)).toBe(0);
   });
 });
 

--- a/src/core/audio/bridge/domain-to-knob.ts
+++ b/src/core/audio/bridge/domain-to-knob.ts
@@ -198,8 +198,8 @@ function playParamsToInstrumentKnobs(
 }
 
 /**
- * Converts Tone transport swing (0-0.5) back to the 0-100 swing knob value.
- * Inverse of transportSwingKnobToDomain.
+ * Converts Tone transport swing (0-TRANSPORT_SWING_MAX) back to the 0-100
+ * swing knob value. Inverse of transportSwingKnobToDomain.
  */
 function transportSwingDomainToKnob(swing: number): number {
   return clampKnob((swing / TRANSPORT_SWING_MAX) * TRANSPORT_SWING_RANGE[1]);

--- a/src/core/audio/bridge/knob-to-domain.ts
+++ b/src/core/audio/bridge/knob-to-domain.ts
@@ -111,7 +111,9 @@ function instrumentKnobsToPlayParams(
 }
 
 /**
- * Converts the 0-100 swing knob value to Tone transport swing (0-0.5).
+ * Converts the 0-100 swing knob value linearly to Tone transport swing
+ * (0-TRANSPORT_SWING_MAX): knob 100 = 0.375 = the TR-909's maximum shuffle
+ * = MPC 62.5% (#269).
  */
 function transportSwingKnobToDomain(swing: number): number {
   return (swing / TRANSPORT_SWING_RANGE[1]) * TRANSPORT_SWING_MAX;

--- a/src/core/audio/engine/__tests__/golden-render.browser.test.ts
+++ b/src/core/audio/engine/__tests__/golden-render.browser.test.ts
@@ -34,14 +34,15 @@ const TOL = 0.005;
 
 /**
  * Swing offset applied to odd 16th steps at swing knob 50.
- * Engine: transport.swing = (50 / 100) * TRANSPORT_SWING_MAX(0.5) = 0.25.
+ * Engine (#269 retune): transport.swing = (50 / 100) *
+ * TRANSPORT_SWING_MAX(0.375) = 0.1875 (MPC 56.25%).
  * Tone Transport._processTick (tone@15.5.25): for ticks halfway between
  * swing subdivision pairs, offset = sin(pi * 0.5) * swing * Ticks((swingTicks * 2) / 3).
  * With 16n subdivision (48 ticks at PPQ 192): (48 * 2) / 3 = 32 ticks
  * = (32 / 192) beats = (1 / 6) * (60 / BPM) seconds.
- * At 120 BPM: 0.25 * (1 / 6) * 0.5 = 0.0208333s.
+ * At 120 BPM: 0.1875 * (1 / 6) * 0.5 = 0.0156250s.
  */
-const SWING_50_OFFSET = 0.25 * (1 / 6) * (60 / BPM);
+const SWING_50_OFFSET = 0.1875 * (1 / 6) * (60 / BPM);
 
 /** FLAM_OFFSET_SECONDS in engine/sequencer/sequencer.ts. */
 const FLAM_OFFSET = 0.015;

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -183,7 +183,7 @@ class AudioEngine {
   private anySolos = false;
   private masterSettings: MasterChainSettings | null = null;
   private bpm = 120;
-  /** Transport swing in Tone units (0-0.5); the bridge converts from knobs. */
+  /** Transport swing in Tone units (0-TRANSPORT_SWING_MAX); the bridge converts from knobs. */
   private swing = 0;
 
   // --- Lifecycle & playback state ---

--- a/src/core/audio/engine/constants.ts
+++ b/src/core/audio/engine/constants.ts
@@ -63,9 +63,17 @@ const MASTER_VOLUME_DEFAULT = 92; // Knob ~92% = 0 dB
 
 const TRANSPORT_BPM_RANGE: Range = [40, 300];
 
-// UI swing control (0–100) mapped to Tone.Transport swing (0–0.5)
+// UI swing control (0–100) mapped to Tone.Transport swing (0–TRANSPORT_SWING_MAX)
 const TRANSPORT_SWING_RANGE: Range = [0, 100];
-const TRANSPORT_SWING_MAX = 0.5;
+/**
+ * Maximum Tone.Transport swing (#269).
+ *
+ * The ceiling is the TR-909's maximum shuffle: 6 ticks at 96 PPQN = 25% of
+ * a 16th note, i.e. MPC 62.5% swing. Tone applies swing as a delay of
+ * swing * 1/6 beat on odd 16ths, so 0.375 * 1/6 = 1/16 beat = 25% of a
+ * 16th. (The previous ceiling of 0.5 was a full triplet shift, MPC 66.7%.)
+ */
+const TRANSPORT_SWING_MAX = 0.375;
 
 // ============================================================================
 // Sequencer

--- a/src/core/audio/engine/transport/transport.ts
+++ b/src/core/audio/engine/transport/transport.ts
@@ -42,8 +42,8 @@ function setTransportBpm(bpm: number): void {
 }
 
 /**
- * Set the live transport swing in domain units (0-0.5 Tone swing),
- * preserving the current bpm. Knob-value conversion happens at the
+ * Set the live transport swing in domain units (Tone swing, clamped by the
+ * engine to 0-TRANSPORT_SWING_MAX), preserving the current bpm. Knob-value conversion happens at the
  * boundary in bridge/knob-to-domain.ts (transportSwingKnobToDomain).
  */
 function setTransportSwing(swing: number): void {
@@ -51,7 +51,7 @@ function setTransportSwing(swing: number): void {
 }
 
 /**
- * Configures transport timing settings from domain values (bpm, 0-0.5 swing).
+ * Configures transport timing settings from domain values (bpm, Tone swing).
  * Works with both online (getTransport) and offline transport objects, and
  * is the single assignment point for transport timing - the live setters
  * above route through it.

--- a/src/core/audio/export/midi-exporter.test.ts
+++ b/src/core/audio/export/midi-exporter.test.ts
@@ -83,8 +83,8 @@ describe("tick math", () => {
   it.runIf(BAKE_SWING_INTO_EXPORT)(
     "delays offbeat 16ths by swing * 2/3 of an 8th, like Tone.js",
     () => {
-      // Max app swing (knob 100) is Tone swing 0.5 -> 40 ticks.
-      expect(swingDelayTicks(1, TRANSPORT_SWING_MAX)).toBe(40);
+      // Max app swing (knob 100) is Tone swing 0.375 -> 30 ticks (#269).
+      expect(swingDelayTicks(1, TRANSPORT_SWING_MAX)).toBe(30);
       expect(swingDelayTicks(3, 0.25)).toBe(20);
       // Even steps sit on 8th boundaries and never swing.
       expect(swingDelayTicks(0, TRANSPORT_SWING_MAX)).toBe(0);
@@ -258,7 +258,7 @@ describe("buildMidiFile", () => {
       sequence.triggers[1] = true;
       sequence.triggers[2] = true;
 
-      expect(ticksForSlot(options, 0)).toEqual([0, 120 + 40, 240]);
+      expect(ticksForSlot(options, 0)).toEqual([0, 120 + 30, 240]);
     },
   );
 

--- a/src/core/audio/export/midi-exporter.ts
+++ b/src/core/audio/export/midi-exporter.ts
@@ -174,7 +174,7 @@ interface MidiExportOptions {
   /** Number of bars to export; the chain arrangement advances per bar. */
   bars: number;
   bpm: number;
-  /** Transport swing in Tone domain units (0-0.5), converted at the boundary. */
+  /** Transport swing in Tone domain units (0-TRANSPORT_SWING_MAX), converted at the boundary. */
   swing: number;
   pattern: Pattern;
   chain: PatternChain;

--- a/src/core/dh/defaults/A Drum Called Haus.dh
+++ b/src/core/dh/defaults/A Drum Called Haus.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "13c02b9a-086d-4a88-bd4e-9dbad4d56151",
     "name": "A Drum Called Haus",
@@ -246,7 +246,7 @@
   },
   "transport": {
     "bpm": 95,
-    "swing": 48
+    "swing": 64
   },
   "sequencer": {
     "pattern": {

--- a/src/core/dh/defaults/Amsterdam.dh
+++ b/src/core/dh/defaults/Amsterdam.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "549d57e2-5502-4144-b1d4-0759c84903d7",
     "name": "Amsterdam",

--- a/src/core/dh/defaults/Polaroid Bounce.dh
+++ b/src/core/dh/defaults/Polaroid Bounce.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "8aeda78c-e907-44a9-85b9-05849ef68406",
     "name": "Polaroid Bounce",

--- a/src/core/dh/defaults/Purple Haus.dh
+++ b/src/core/dh/defaults/Purple Haus.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "76adcf06-fc35-474d-ac9d-51e6cf45ebd9",
     "name": "Purple Haus",

--- a/src/core/dh/defaults/Rich Kids.dh
+++ b/src/core/dh/defaults/Rich Kids.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "369ff62c-c195-4ccd-ad03-e5c52510335a",
     "name": "Rich Kids",

--- a/src/core/dh/defaults/Slime Time.dh
+++ b/src/core/dh/defaults/Slime Time.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "37088980-248c-4ea0-8daf-08f6fce01dbb",
     "name": "Slime Time",
@@ -206,7 +206,7 @@
   },
   "transport": {
     "bpm": 124,
-    "swing": 38
+    "swing": 50.666666666666664
   },
   "sequencer": {
     "pattern": {

--- a/src/core/dh/defaults/Sunflower.dh
+++ b/src/core/dh/defaults/Sunflower.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "c28f5b62-afd3-40f3-a1c3-9c326b2ac699",
     "name": "Sunflower",
@@ -206,7 +206,7 @@
   },
   "transport": {
     "bpm": 91,
-    "swing": 15
+    "swing": 20
   },
   "sequencer": {
     "pattern": {

--- a/src/core/dh/defaults/Super Dream Haus.dh
+++ b/src/core/dh/defaults/Super Dream Haus.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "cf0a9d3b-841d-4eeb-9a54-0003afa037b3",
     "name": "Super Dream Haus",

--- a/src/core/dh/defaults/Together Again.dh
+++ b/src/core/dh/defaults/Together Again.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "c35f4733-d235-4a9e-a9bd-467ce8e0818e",
     "name": "Together Again",

--- a/src/core/dh/defaults/Welcome to the Haus.dh
+++ b/src/core/dh/defaults/Welcome to the Haus.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "5406d5c2-85bc-48fb-9323-6bc968d78bbd",
     "name": "Welcome to the Haus",

--- a/src/core/dh/defaults/init.dh
+++ b/src/core/dh/defaults/init.dh
@@ -1,6 +1,6 @@
 {
   "kind": "drumhaus.preset",
-  "version": 1,
+  "version": 1.5,
   "meta": {
     "id": "53b9eebd-6af5-43ed-b43e-eec354dbc4cc",
     "name": "init",

--- a/src/features/preset/document/__fixtures__/README.md
+++ b/src/features/preset/document/__fixtures__/README.md
@@ -57,7 +57,8 @@ Exercises envelope validation: a structurally valid document whose `kind` is not
 ## future-version.json
 
 Source: synthetic (modern `v1-current.json` with `version` changed to `2`).
-Exercises envelope validation: a document with a `version` newer than the reader supports must be rejected or handled explicitly, not silently parsed as v1.
+Exercises envelope validation: a document with a `version` newer than the reader supports must be rejected or handled explicitly, not silently parsed.
+Note the knob-space reader accepts versions 1 and 1.5 (the #269 swing revision); version 2 is the domain-unit preset document, which has a different shape, so a v1-shaped file stamped `2` must be rejected.
 
 ## missing-sequencer.json
 

--- a/src/features/preset/document/corpus.test.ts
+++ b/src/features/preset/document/corpus.test.ts
@@ -31,11 +31,18 @@ const ERA_FIXTURES = [
 ];
 
 describe("historical corpus", () => {
-  it.each(ERA_FIXTURES)("%s parses as a v1 preset file", (name) => {
-    const preset = parsePresetFileV1(readFixture(name));
-    expect(preset.kind).toBe("drumhaus.preset");
-    expect(preset.version).toBe(1);
-  });
+  it.each(ERA_FIXTURES)(
+    "%s parses as a v1 preset file, normalized to version 1.5",
+    (name) => {
+      const preset = parsePresetFileV1(readFixture(name));
+      expect(preset.kind).toBe("drumhaus.preset");
+      // validatePresetFileV1 normalizes v1 files to the current version
+      // (the #269 swing retune bump); every fixture in this corpus has
+      // swing 0, which migrates to 0.
+      expect(preset.version).toBe(1.5);
+      expect(preset.transport.swing).toBe(0);
+    },
+  );
 
   it.each(ERA_FIXTURES)("%s flows through today's migrators", (name) => {
     const preset = parsePresetFileV1(readFixture(name)) as PresetFileV1;

--- a/src/features/preset/document/document.test.ts
+++ b/src/features/preset/document/document.test.ts
@@ -1,7 +1,7 @@
 /**
- * Parse-level tests for the v2 preset document schema: a hand-built valid
- * document parses, and each range/arity violation fails at the offending
- * path.
+ * Parse-level tests for the domain-unit (v3) preset document schema: a
+ * hand-built valid document parses, and each range/arity violation fails
+ * at the offending path.
  */
 
 import { describe, expect, it } from "vitest";
@@ -143,19 +143,25 @@ describe("presetDocumentSchema", () => {
     );
   });
 
-  it("rejects version 1", () => {
+  it("rejects the knob-space file-family versions 1 and 1.5", () => {
     expectFailureAt(
       mutated((d) => {
         d.version = 1 as PresetDocument["version"];
       }),
       ["version"],
     );
-  });
-
-  it("rejects swing above 0.5", () => {
     expectFailureAt(
       mutated((d) => {
-        d.transport.swing = 0.6;
+        d.version = 1.5 as PresetDocument["version"];
+      }),
+      ["version"],
+    );
+  });
+
+  it("rejects swing above the 0.375 ceiling", () => {
+    expectFailureAt(
+      mutated((d) => {
+        d.transport.swing = 0.5;
       }),
       ["transport", "swing"],
     );

--- a/src/features/preset/document/document.ts
+++ b/src/features/preset/document/document.ts
@@ -1,11 +1,16 @@
 /**
- * The v2 preset document model.
+ * The domain-unit preset document model (docs/preset-persistence.md).
  *
  * A `.dh` file, version 2: a domain-space (dB, seconds, semitones, -1..1
  * pan) description of a preset, decoupled from 0-100 knob positions except
  * for split-filter positions, whose 0-100 position IS the domain value.
  * The zod schema is the single source of truth; the PresetDocument type is
  * inferred from it. No production code consumes this yet.
+ *
+ * The #269 swing retune sits between v1 and this document as version 1.5,
+ * a knob-space revision of the v1 file shape
+ * (src/features/preset/document/migrate.ts); version 2 remains this
+ * domain document, as designed.
  */
 
 import { z } from "zod";

--- a/src/features/preset/document/file-v1.ts
+++ b/src/features/preset/document/file-v1.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 /**
- * Zod schemas for the v1 .dh preset file format.
+ * Zod schemas for the knob-space .dh preset file format (versions 1 and 1.5;
+ * the two versions share one shape, and v1.5 only marks the #269 swing knob
+ * reinterpretation handled by migratePresetFileVersion).
  *
  * Deliberately tolerant: these schemas must accept every legacy shape the
  * runtime migrators (src/features/sequencer/lib/migrations.ts) accept, so
@@ -87,7 +89,7 @@ const sequencerSchema = z.object({
 
 const presetFileV1Schema = z.object({
   kind: z.literal("drumhaus.preset"),
-  version: z.literal(1),
+  version: z.union([z.literal(1), z.literal(1.5)]),
   meta: metaSchema,
   kit: kitSchema,
   transport: transportSchema,

--- a/src/features/preset/document/index.ts
+++ b/src/features/preset/document/index.ts
@@ -6,4 +6,9 @@ export {
 } from "./errors";
 export type { PresetDocumentErrorCode } from "./errors";
 export { presetFileV1Schema } from "./file-v1";
+export {
+  PRESET_FILE_VERSION,
+  isReadablePresetFileVersion,
+  migratePresetFileVersion,
+} from "./migrate";
 export { parsePresetFileV1, validatePresetFileV1 } from "./parse";

--- a/src/features/preset/document/migrate.ts
+++ b/src/features/preset/document/migrate.ts
@@ -1,0 +1,47 @@
+import type { PresetFileV1 } from "@/features/preset/types/preset";
+import { migrateLegacySwingKnob } from "@/features/transport/lib/legacy-swing";
+
+/**
+ * Current version of the knob-space .dh preset file format.
+ *
+ * v1 and v1.5 share the exact same shape; the bump marks the #269 swing
+ * retune, which reinterpreted the persisted 0-100 swing knob value (old
+ * curve: Tone swing = knob / 200; new curve: knob * 0.00375). The bump is
+ * fractional so version 2 stays reserved for the domain-unit preset document
+ * (docs/preset-persistence.md, src/features/preset/document/document.ts).
+ */
+const PRESET_FILE_VERSION = 1.5;
+
+function isReadablePresetFileVersion(version: unknown): boolean {
+  return version === 1 || version === PRESET_FILE_VERSION;
+}
+
+/**
+ * Normalizes a readable preset file to the current version.
+ *
+ * v1 -> v1.5 rescales the swing knob value so the preset keeps the feel it
+ * was saved with under the pre-#269 curve; every other field is untouched
+ * (the shape is identical across the two versions). Idempotent: current
+ * version presets pass through by reference.
+ *
+ * Every ingress must run this: file import and share URLs get it via
+ * validatePresetFileV1, while presets stored verbatim in localStorage
+ * (customPresets) get it in usePresetLoading.loadPreset.
+ */
+function migratePresetFileVersion(preset: PresetFileV1): PresetFileV1 {
+  if (preset.version >= PRESET_FILE_VERSION) return preset;
+  return {
+    ...preset,
+    version: PRESET_FILE_VERSION,
+    transport: {
+      ...preset.transport,
+      swing: migrateLegacySwingKnob(preset.transport.swing),
+    },
+  };
+}
+
+export {
+  PRESET_FILE_VERSION,
+  isReadablePresetFileVersion,
+  migratePresetFileVersion,
+};

--- a/src/features/preset/document/parse.test.ts
+++ b/src/features/preset/document/parse.test.ts
@@ -168,11 +168,13 @@ describe("validatePresetFileV1", () => {
     vi.restoreAllMocks();
   });
 
-  it("parses a minimal valid current-v1 preset", () => {
+  it("parses a minimal valid v1 preset, normalized to version 1.5", () => {
     const preset = makePreset();
     const parsed = validatePresetFileV1(preset);
 
-    expect(parsed).toEqual(preset);
+    // The v1 -> v2 normalization only touches the version marker (swing 0
+    // migrates to 0); everything else round-trips unchanged.
+    expect(parsed).toEqual({ ...preset, version: 1.5 });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -182,7 +184,37 @@ describe("validatePresetFileV1", () => {
     expect(parsed.meta.name).toBe("Legacy Preset");
     expect(Array.isArray(parsed.sequencer.pattern)).toBe(true);
     expect(parsed.sequencer.variationCycle).toBe("AB");
+    // v1 swing knob 20 (old Tone swing 0.1) rescales by 4/3 (#269).
+    expect(parsed.transport.swing).toBeCloseTo(80 / 3, 12);
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("migrates v1 swing knob values into the retuned knob space (#269)", () => {
+    const preset = makePreset();
+    preset.transport.swing = 48;
+
+    const parsed = validatePresetFileV1(preset);
+
+    expect(parsed.version).toBe(1.5);
+    expect(parsed.transport.swing).toBe(64);
+  });
+
+  it("clamps v1 swing values above 75 to knob 100 (#269)", () => {
+    const preset = makePreset();
+    preset.transport.swing = 90;
+
+    const parsed = validatePresetFileV1(preset);
+
+    expect(parsed.transport.swing).toBe(100);
+  });
+
+  it("passes version-1.5 presets through without touching swing", () => {
+    const preset = { ...makePreset(), version: 1.5 };
+    preset.transport.swing = 64;
+
+    const parsed = validatePresetFileV1(preset);
+
+    expect(parsed).toEqual(preset);
   });
 
   it("throws InvalidFileError for a non-object", () => {

--- a/src/features/preset/document/parse.ts
+++ b/src/features/preset/document/parse.ts
@@ -5,12 +5,16 @@ import {
   UnsupportedVersionError,
 } from "./errors";
 import { collectStrippedKeyPaths, presetFileV1Schema } from "./file-v1";
+import {
+  isReadablePresetFileVersion,
+  migratePresetFileVersion,
+} from "./migrate";
 
 /**
  * Parse and validate a preset from raw file text.
  *
  * @throws {InvalidFileError} If the text is not JSON or not a preset file
- * @throws {UnsupportedVersionError} If the preset version is not 1
+ * @throws {UnsupportedVersionError} If the preset version is not 1 or 1.5
  * @throws {CorruptFieldError} If a field inside the envelope is corrupt
  */
 function parsePresetFileV1(text: string): PresetFileV1 {
@@ -24,13 +28,15 @@ function parsePresetFileV1(text: string): PresetFileV1 {
 }
 
 /**
- * Validate an already-parsed value as a v1 preset file.
+ * Validate an already-parsed value as a knob-space (v1-family) preset file
+ * and normalize it to the current version (v1.5): version-1 files get the
+ * #269 swing knob migration applied (see migratePresetFileVersion).
  *
  * Unknown keys at the envelope and section level are stripped from the
  * returned value and reported once via console.warn.
  *
  * @throws {InvalidFileError} If the value is not an object or the wrong kind
- * @throws {UnsupportedVersionError} If the preset version is not 1
+ * @throws {UnsupportedVersionError} If the preset version is not 1 or 1.5
  * @throws {CorruptFieldError} If a field inside the envelope is corrupt
  */
 function validatePresetFileV1(data: unknown): PresetFileV1 {
@@ -43,7 +49,7 @@ function validatePresetFileV1(data: unknown): PresetFileV1 {
   if (raw.kind !== "drumhaus.preset") {
     throw new InvalidFileError("Invalid preset file type");
   }
-  if (raw.version !== 1) {
+  if (!isReadablePresetFileVersion(raw.version)) {
     throw new UnsupportedVersionError(raw.version);
   }
 
@@ -62,7 +68,7 @@ function validatePresetFileV1(data: unknown): PresetFileV1 {
 
   // The schema is intentionally looser than the compile-time type; the
   // migrators invoked by loadPreset normalize the remaining legacy variance.
-  return result.data as unknown as PresetFileV1;
+  return migratePresetFileVersion(result.data as unknown as PresetFileV1);
 }
 
 export { parsePresetFileV1, validatePresetFileV1 };

--- a/src/features/preset/hooks/use-preset-loading.ts
+++ b/src/features/preset/hooks/use-preset-loading.ts
@@ -7,6 +7,7 @@ import {
 import { init } from "@/core/dh";
 import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
 import { useMasterChainStore } from "@/features/master-bus/store/use-master-chain-store";
+import { migratePresetFileVersion } from "@/features/preset/document";
 import { getDefaultPresets } from "@/features/preset/lib/constants";
 import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
@@ -75,7 +76,13 @@ function usePresetLoading(): UsePresetLoadingResult {
   }, [toast]);
 
   const loadPreset = useCallback(
-    (preset: PresetFileV1) => {
+    (rawPreset: PresetFileV1) => {
+      // Normalize the file version first (idempotent): file imports and
+      // share URLs arrive already normalized via validatePresetFileV1, but
+      // library presets persisted verbatim in localStorage can still be
+      // version 1 and need the #269 swing knob migration.
+      const preset = migratePresetFileVersion(rawPreset);
+
       // Stop playback if currently playing (samples will reload)
       if (isPlaying) {
         void togglePlay();

--- a/src/features/preset/lib/helpers.ts
+++ b/src/features/preset/lib/helpers.ts
@@ -1,5 +1,6 @@
 import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
 import { getMasterChainParams } from "@/features/master-bus/store/use-master-chain-store";
+import { PRESET_FILE_VERSION } from "@/features/preset/document";
 import { getDefaultPresets } from "@/features/preset/lib/constants";
 import type { Meta } from "@/features/preset/types/meta";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
@@ -21,7 +22,7 @@ function getCurrentPreset(presetMeta: Meta, kitMeta: Meta): PresetFileV1 {
 
   return {
     kind: "drumhaus.preset",
-    version: 1,
+    version: PRESET_FILE_VERSION,
     meta: {
       ...presetMeta,
       updatedAt: new Date().toISOString(),

--- a/src/features/preset/lib/serialization/compact.test.ts
+++ b/src/features/preset/lib/serialization/compact.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Share-URL codec tests for the #269 swing retune.
+ *
+ * The compact codec was unversioned before the retune; the `v` field now
+ * marks post-retune URLs. Decoding must treat a missing `v` as a legacy
+ * URL whose `sw` value (or implied default, when omitted) is in the OLD
+ * swing knob space and rescale it, while `v: 1.5` URLs pass through.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { init } from "@/core/dh";
+import type { CompactPreset } from "./compact";
+import { decodePreset } from "./decode";
+import { encodePreset } from "./encode";
+
+function makePresetWithSwing(swing: number) {
+  const preset = init();
+  preset.transport.swing = swing;
+  return preset;
+}
+
+describe("compact codec versioning (#269)", () => {
+  it("stamps encoded presets with codec version 1.5", () => {
+    const compact = encodePreset(makePresetWithSwing(0));
+    expect(compact.v).toBe(1.5);
+  });
+
+  it("round-trips a post-retune swing value unchanged", () => {
+    const compact = encodePreset(makePresetWithSwing(64));
+    expect(compact.sw).toBe(64);
+
+    const decoded = decodePreset(compact);
+    expect(decoded.version).toBe(1.5);
+    expect(decoded.transport.swing).toBe(64);
+  });
+
+  it("omits sw at the init default and still decodes to it", () => {
+    const compact = encodePreset(makePresetWithSwing(0));
+    expect(compact.sw).toBeUndefined();
+
+    expect(decodePreset(compact).transport.swing).toBe(0);
+  });
+
+  it("migrates a legacy URL's swing from the old knob space", () => {
+    const compact = encodePreset(makePresetWithSwing(48));
+    delete compact.v; // Simulate a pre-retune URL: unversioned, old space.
+
+    const decoded = decodePreset(compact);
+    expect(decoded.version).toBe(1.5);
+    expect(decoded.transport.swing).toBe(64);
+  });
+
+  it("clamps a legacy URL's swing above 75 to knob 100", () => {
+    const compact = encodePreset(makePresetWithSwing(90));
+    delete compact.v;
+
+    expect(decodePreset(compact).transport.swing).toBe(100);
+  });
+
+  it("decodes a legacy URL with omitted swing to straight time", () => {
+    const compact: CompactPreset = encodePreset(makePresetWithSwing(0));
+    delete compact.v;
+    expect(compact.sw).toBeUndefined();
+
+    expect(decodePreset(compact).transport.swing).toBe(0);
+  });
+});

--- a/src/features/preset/lib/serialization/compact.ts
+++ b/src/features/preset/lib/serialization/compact.ts
@@ -20,7 +20,9 @@ import {
   VARIATION_LABELS,
   VariationCycle,
 } from "@/features/sequencer/types/sequencer";
+import { migrateLegacySwingKnob } from "@/features/transport/lib/legacy-swing";
 import { init } from "../../../../core/dh";
+import { PRESET_FILE_VERSION } from "../../document/migrate";
 import { PresetFileV1 } from "../../types/preset";
 import { compactCodeToKitId, kitIdToCompactCode } from "./default-kits";
 
@@ -31,6 +33,12 @@ import { compactCodeToKitId, kitIdToCompactCode } from "./default-kits";
  * - Single-letter keys
  * - Kit ID as single digit (0-9)
  * - Omit default values
+ *
+ * Versioning: the codec was originally unversioned; the `v` field was
+ * introduced with the #269 swing retune, mirroring the .dh file version
+ * (PRESET_FILE_VERSION = 1.5). A URL without `v` was written by a pre-retune
+ * build, so its `sw` value (or the implied default when omitted) is in the
+ * OLD swing knob space and is migrated on decode.
  */
 
 const PACKED_TRIGGER_HEX_LENGTH = Math.ceil(STEP_COUNT / 4);
@@ -197,6 +205,7 @@ type CompactParams = {
  */
 type CompactPreset = {
   id: string; // preset UUID (new UUID generated when sharing)
+  v?: number; // codec version, mirrors PRESET_FILE_VERSION (absent = pre-#269 legacy URL)
   k: string; // kit ID (single digit 0-9)
   n?: string; // preset name
   ip: CompactParams[]; // instrument params (8 items, only non-defaults)
@@ -326,6 +335,7 @@ function encodeCompactPreset(preset: PresetFileV1): CompactPreset {
 
   const compact: CompactPreset = {
     id: preset.meta.id, // Include the UUID (generated fresh when sharing)
+    v: PRESET_FILE_VERSION,
     k: kitId,
     ip: preset.kit.instruments.map((inst: InstrumentData) =>
       encodeParams(inst.params),
@@ -482,6 +492,27 @@ function decodeMasterChain(compact?: CompactMasterChain): MasterChainParams {
   };
 }
 
+/**
+ * Init-preset swing default of every pre-`v` (pre-#269) build: `sw` was
+ * omitted when the swing knob equaled it. Pinned as a literal because the
+ * legacy decode branch must not drift if the current init default ever
+ * changes.
+ */
+const LEGACY_DEFAULT_SWING = 0;
+
+/**
+ * Decodes the swing knob value. Legacy URLs (no `v` field) carry `sw` in
+ * the pre-#269 swing knob space and are migrated; when `sw` is omitted the
+ * writing build's init default applies before migration.
+ */
+function decodeSwing(compact: CompactPreset): number {
+  const isLegacyUrl = compact.v === undefined;
+  if (isLegacyUrl) {
+    return migrateLegacySwingKnob(compact.sw ?? LEGACY_DEFAULT_SWING);
+  }
+  return compact.sw ?? DEFAULT_SWING;
+}
+
 function decodeCompactPreset(
   compact: CompactPreset,
   kitLoader: (kitId: string) => KitFileV1,
@@ -551,7 +582,9 @@ function decodeCompactPreset(
 
   return {
     kind: "drumhaus.preset",
-    version: 1,
+    // Decoded presets are always normalized to the current file version:
+    // decodeSwing has already applied the legacy-URL swing migration.
+    version: PRESET_FILE_VERSION,
     meta: {
       id: compact.id, // Use the UUID from the encoded preset
       name: compact.n || "Shared Preset",
@@ -566,7 +599,7 @@ function decodeCompactPreset(
     },
     transport: {
       bpm: compact.bpm ?? DEFAULT_BPM,
-      swing: compact.sw ?? DEFAULT_SWING,
+      swing: decodeSwing(compact),
     },
     sequencer: {
       pattern,

--- a/src/features/preset/types/preset.ts
+++ b/src/features/preset/types/preset.ts
@@ -6,9 +6,15 @@ import { Meta } from "./meta";
 
 // Presets hold all serializable data for a project
 // They are always deconstructed at runtime into their respective stores
+//
+// Versions 1 and 1.5 share this exact shape ("V1" names the knob-space file
+// family); version 1.5 marks the #269 swing retune, which reinterpreted the
+// persisted swing knob value. Runtime objects are normalized to version 1.5
+// on load (migratePresetFileVersion); version 1 can still appear in
+// objects read verbatim from storage before normalization.
 interface PresetFileV1 {
   kind: "drumhaus.preset";
-  version: 1;
+  version: 1 | 1.5;
   meta: Meta;
   kit: KitFileV1;
   transport: TransportParams;

--- a/src/features/transport/components/tempo-controls-screen.tsx
+++ b/src/features/transport/components/tempo-controls-screen.tsx
@@ -1,3 +1,4 @@
+import { TRANSPORT_SWING_RANGE } from "@/core/audio/engine/constants";
 import { VariationBadge } from "@/features/sequencer/components/variation-badge";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { VARIATION_LABELS } from "@/features/sequencer/types/sequencer";
@@ -8,7 +9,7 @@ import {
   transportBpmMapping,
   transportSwingMapping,
 } from "@/shared/knob/lib/mapping";
-import { cn } from "@/shared/lib/utils";
+import { clamp, cn } from "@/shared/lib/utils";
 
 function TempoControlsScreen() {
   const bpm = useTransportStore((state) => state.bpm);
@@ -25,10 +26,18 @@ function TempoControlsScreen() {
     setBpm(Math.round(domainValue));
   };
 
-  const swingKnobValue = transportSwingMapping.domainToKnob(swing);
+  // The store's swing IS the 0-100 knob value (the mapping's domain is the
+  // MPC display percent), so the knob value passes through directly.
+  // Integer rounding matches tempo-controls.tsx so both swing entry points
+  // persist the same granularity.
   const handleSwingChange = (knobValue: number) => {
-    const domainValue = transportSwingMapping.knobToDomain(knobValue);
-    setSwing(domainValue);
+    setSwing(
+      clamp(
+        Math.round(knobValue),
+        TRANSPORT_SWING_RANGE[0],
+        TRANSPORT_SWING_RANGE[1],
+      ),
+    );
   };
 
   // Convert chain to string format (e.g., "AABBABCD")
@@ -48,7 +57,7 @@ function TempoControlsScreen() {
           labelClassName="text-xs"
         />
         <ClickableValue
-          value={swingKnobValue}
+          value={swing}
           onValueChange={handleSwingChange}
           mapping={transportSwingMapping}
           sensitivity={0.2}

--- a/src/features/transport/components/tempo-controls.tsx
+++ b/src/features/transport/components/tempo-controls.tsx
@@ -55,12 +55,14 @@ const TempoControls = () => {
     };
   }, [mode, bpm, swing]);
 
-  const knobValue = mapping.domainToKnob(value);
+  // BPM is stored in domain units (bpm) and needs the inverse mapping;
+  // swing is stored as the raw 0-100 knob value (the swing mapping's domain
+  // is the MPC display percent), so it passes through directly.
+  const knobValue = mode === "bpm" ? mapping.domainToKnob(value) : value;
 
   const handleKnobChange = (newKnobValue: number) => {
-    const domainValue = mapping.knobToDomain(newKnobValue);
-
     if (mode === "bpm") {
+      const domainValue = mapping.knobToDomain(newKnobValue);
       const clamped = clamp(
         Math.round(domainValue),
         TRANSPORT_BPM_RANGE[0],
@@ -70,8 +72,10 @@ const TempoControls = () => {
       return;
     }
 
+    // Integer knob rounding matches tempo-controls-screen.tsx so both swing
+    // entry points persist the same granularity.
     const clamped = clamp(
-      Math.round(domainValue),
+      Math.round(newKnobValue),
       TRANSPORT_SWING_RANGE[0],
       TRANSPORT_SWING_RANGE[1],
     );

--- a/src/features/transport/lib/legacy-swing.test.ts
+++ b/src/features/transport/lib/legacy-swing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { migrateLegacySwingKnob } from "./legacy-swing";
+
+/**
+ * Feel-preserving property of the #269 swing retune: the migrated knob
+ * value must produce the same Tone swing under the new curve (k * 0.00375)
+ * as the original did under the old curve (k / 200), up to the new 0.375
+ * ceiling.
+ */
+describe("migrateLegacySwingKnob", () => {
+  it("keeps straight time at 0", () => {
+    expect(migrateLegacySwingKnob(0)).toBe(0);
+  });
+
+  it("migrates the shipped default-preset values exactly", () => {
+    // A Drum Called Haus
+    expect(migrateLegacySwingKnob(48)).toBe(64);
+    // Sunflower
+    expect(migrateLegacySwingKnob(15)).toBe(20);
+    // Slime Time (152 / 3, non-terminating)
+    expect(migrateLegacySwingKnob(38)).toBeCloseTo(152 / 3, 12);
+  });
+
+  it("maps the exact boundary 75 (old Tone swing 0.375) to knob 100", () => {
+    expect(migrateLegacySwingKnob(75)).toBe(100);
+  });
+
+  it("clamps old values above 75 (old Tone swing beyond 0.375) to 100", () => {
+    expect(migrateLegacySwingKnob(76)).toBe(100);
+    expect(migrateLegacySwingKnob(100)).toBe(100);
+  });
+
+  it("preserves the Tone swing feel for every value at or below 75", () => {
+    for (let k = 0; k <= 75; k++) {
+      const oldToneSwing = k / 200;
+      const newToneSwing = migrateLegacySwingKnob(k) * 0.00375;
+      expect(newToneSwing).toBeCloseTo(oldToneSwing, 12);
+    }
+  });
+
+  it("defends against corrupt persisted values", () => {
+    expect(migrateLegacySwingKnob(Number.NaN)).toBe(0);
+    expect(migrateLegacySwingKnob(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(migrateLegacySwingKnob(-10)).toBe(0);
+  });
+});

--- a/src/features/transport/lib/legacy-swing.ts
+++ b/src/features/transport/lib/legacy-swing.ts
@@ -1,0 +1,30 @@
+import { TRANSPORT_SWING_RANGE } from "@/core/audio/engine/constants";
+
+/**
+ * Migration for swing knob values persisted before the #269 swing retune.
+ *
+ * Swing is persisted in KNOB space (0-100) everywhere (.dh files, share
+ * URLs, localStorage), so retuning the knob curve reinterprets every stored
+ * value. Pre-retune the knob mapped linearly onto Tone swing 0-0.5
+ * (s = k / 200); the retune lowered the ceiling to the TR-909's maximum
+ * shuffle, TRANSPORT_SWING_MAX = 0.375 (s = k * 0.00375). The
+ * feel-preserving conversion is therefore
+ *
+ *   k_new = k_old * (1/200) / (3/800) = k_old * 4/3
+ *
+ * Old values above 75 (Tone swing beyond the new 0.375 ceiling) clamp to
+ * knob 100 - an accepted trade-off of the retune (#269).
+ */
+function migrateLegacySwingKnob(swing: number): number {
+  if (!Number.isFinite(swing)) return TRANSPORT_SWING_RANGE[0];
+  // (swing * 4) / 3 rather than swing * (4 / 3): the numerator is exact in
+  // floating point, so shipped integer values migrate without float noise
+  // (48 -> 64, 75 -> 100).
+  const migrated = (swing * 4) / 3;
+  return Math.min(
+    TRANSPORT_SWING_RANGE[1],
+    Math.max(TRANSPORT_SWING_RANGE[0], migrated),
+  );
+}
+
+export { migrateLegacySwingKnob };

--- a/src/features/transport/store/use-transport-store.persist.test.ts
+++ b/src/features/transport/store/use-transport-store.persist.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Rehydration tests for the transport store's persist migration (#269).
+ *
+ * Pre-retune localStorage (persist version 0) stores swing knob values
+ * written under the old curve (Tone swing = knob / 200); the version-1
+ * migrate rescales them (k * 4/3, clamped) so the persisted feel survives
+ * the retune. The engine module is mocked so this runs in the node project.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { transportSwingKnobToDomain } from "@/core/audio/bridge/knob-to-domain";
+
+const engineMock = vi.hoisted(() => ({
+  play: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  stop: vi.fn(),
+  setTempo: vi.fn(),
+  setSwing: vi.fn(),
+}));
+
+vi.mock("@/core/audio/engine", () => ({
+  getAudioEngine: () => engineMock,
+}));
+
+function stubStoredTransport(payload: unknown): void {
+  const storage = {
+    getItem: (key: string) =>
+      key === "drumhaus-transport-storage" ? JSON.stringify(payload) : null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  // zustand's persist default storage reads window.localStorage, so the
+  // node project needs a window stub carrying the fake storage.
+  vi.stubGlobal("localStorage", storage);
+  vi.stubGlobal("window", { localStorage: storage });
+}
+
+async function importFreshStore() {
+  vi.resetModules();
+  const { useTransportStore } = await import("./use-transport-store");
+  return useTransportStore;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("transport persist migration (#269 swing retune)", () => {
+  it("rescales a version-0 swing knob value by 4/3 on rehydrate", async () => {
+    stubStoredTransport({ state: { bpm: 128, swing: 48 }, version: 0 });
+
+    const store = await importFreshStore();
+
+    expect(store.getState().bpm).toBe(128);
+    expect(store.getState().swing).toBe(64);
+    // onRehydrateStorage pushes the MIGRATED value into the engine.
+    expect(engineMock.setSwing).toHaveBeenCalledWith(
+      transportSwingKnobToDomain(64),
+    );
+  });
+
+  it("clamps a version-0 swing above 75 to knob 100", async () => {
+    stubStoredTransport({ state: { bpm: 120, swing: 90 }, version: 0 });
+
+    const store = await importFreshStore();
+
+    expect(store.getState().swing).toBe(100);
+  });
+
+  it("leaves version-1 state untouched", async () => {
+    stubStoredTransport({ state: { bpm: 120, swing: 64 }, version: 1 });
+
+    const store = await importFreshStore();
+
+    expect(store.getState().swing).toBe(64);
+  });
+});

--- a/src/features/transport/store/use-transport-store.ts
+++ b/src/features/transport/store/use-transport-store.ts
@@ -4,6 +4,7 @@ import { immer } from "zustand/middleware/immer";
 
 import { transportSwingKnobToDomain } from "@/core/audio/bridge/knob-to-domain";
 import { getAudioEngine } from "@/core/audio/engine";
+import { migrateLegacySwingKnob } from "@/features/transport/lib/legacy-swing";
 
 interface TransportState {
   // Playback state
@@ -65,6 +66,17 @@ const useTransportStore = create<TransportState>()(
       })),
       {
         name: "drumhaus-transport-storage",
+        // v1 (#269 swing retune): persisted swing knob values written under
+        // the old curve (Tone swing = knob / 200) are reinterpreted by the
+        // new curve (knob * 0.00375) and must be rescaled to keep the feel.
+        version: 1,
+        migrate: (persistedState, version) => {
+          const state = persistedState as { bpm: number; swing: number };
+          if (version < 1 && typeof state?.swing === "number") {
+            return { ...state, swing: migrateLegacySwingKnob(state.swing) };
+          }
+          return state;
+        },
         // Only persist user-facing state, not Tone.js refs
         partialize: (state) => ({
           bpm: state.bpm,

--- a/src/shared/knob/lib/format.ts
+++ b/src/shared/knob/lib/format.ts
@@ -39,8 +39,8 @@ const formatDisplayPercentage = (value: number) => {
   return { value: `${(value * 100).toFixed(0)}`, append: "%" };
 };
 
-const formatDisplayPercentageValue = (value: number) => {
-  return { value: value.toFixed(0), append: "%" };
+const formatDisplaySwingMpc = (value: number) => {
+  return { value: value.toFixed(1), append: "%" };
 };
 
 const formatDisplayCompRatio = (value: number) => {
@@ -75,6 +75,6 @@ export {
   formatDisplayBpm,
   formatDisplaySplitFilter,
   formatDisplayPercentage,
-  formatDisplayPercentageValue,
+  formatDisplaySwingMpc,
   formatDisplayCompRatio,
 };

--- a/src/shared/knob/lib/mapping.ts
+++ b/src/shared/knob/lib/mapping.ts
@@ -28,7 +28,7 @@ import {
   MASTER_VOLUME_DEFAULT,
   MASTER_VOLUME_RANGE,
   TRANSPORT_BPM_RANGE,
-  TRANSPORT_SWING_RANGE,
+  TRANSPORT_SWING_MAX,
 } from "@/core/audio/engine/constants";
 import { FormattedValue, ParamMapping } from "../types/types";
 import { KNOB_VALUE_DEFAULT, KNOB_VALUE_MAX } from "./constants";
@@ -38,7 +38,7 @@ import {
   formatDisplayDecayDuration,
   formatDisplayFilter,
   formatDisplayPercentage,
-  formatDisplayPercentageValue,
+  formatDisplaySwingMpc,
   formatDisplayTuneSemitone,
   formatDisplayVolumeInstrument as formatDisplayVolume,
   formatDisplayVolumeMaster,
@@ -379,17 +379,34 @@ const saturationAmountMapping = makeLinearMapping(
 );
 
 /**
- * Transport swing (0-100%)
+ * MPC swing percent displayed by the transport swing knob: 50.0% (straight)
+ * at knob 0 up to 62.5% (TR-909 max shuffle) at knob 100 (#269).
+ *
+ * MPC% = 50 + (100 / 3) * toneSwing, and the knob maps linearly onto Tone
+ * swing 0..TRANSPORT_SWING_MAX, so with the 0.375 ceiling the display is
+ * 50 + knob / 8. Derived from the constant so display and audio ceiling
+ * cannot drift apart.
+ */
+const TRANSPORT_SWING_MPC_DISPLAY_RANGE: [number, number] = [
+  50,
+  50 + (100 / 3) * TRANSPORT_SWING_MAX,
+];
+
+/**
+ * Transport swing knob, displayed as MPC swing percent (50.0-62.5%).
+ *
+ * The mapping's domain is the DISPLAY percent, not Tone swing: the store
+ * keeps the raw 0-100 knob value and the bridge
+ * (transportSwingKnobToDomain) owns the knob -> Tone swing conversion.
+ * knobToDomain/domainToKnob are exact inverses (both linear over powers of
+ * two), so ParamKnob's canonicalization round-trip is lossless.
  */
 const transportSwingMapping = makeLinearMapping(
-  TRANSPORT_SWING_RANGE,
-  formatDisplayPercentageValue,
+  TRANSPORT_SWING_MPC_DISPLAY_RANGE,
+  formatDisplaySwingMpc,
   {
-    knobValueCount: TRANSPORT_SWING_RANGE[1] - TRANSPORT_SWING_RANGE[0],
-    defaultKnobValue: inverseTransformKnobValue(
-      TRANSPORT_SWING_RANGE[0],
-      TRANSPORT_SWING_RANGE,
-    ),
+    knobValueCount: 100,
+    defaultKnobValue: 0,
   },
 );
 

--- a/src/test/audition/swing-audition.browser.test.ts
+++ b/src/test/audition/swing-audition.browser.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Swing AUDITION harness for issue #269 - NOT a regression test.
+ *
+ * Renders WAV artifacts into audition-out/ (gitignored) so the shipped
+ * swing curve can be auditioned by ear against the MPC reference ladder
+ * and the TR-909 detents. Gated behind VITE_AUDITION so it never runs in
+ * CI or in a plain `pnpm test`.
+ *
+ * Run with:
+ *   VITE_AUDITION=1 npx vitest run --project browser \
+ *     src/test/audition/swing-audition.browser.test.ts
+ *
+ * Musical material: closed hat on all 16 steps, kick on 0/4/8/12, snare on
+ * 4/12, real kit-0 samples, 95 BPM, 4 bars per render.
+ *
+ * Swing values are set in DOMAIN units directly on a single throwaway
+ * engine (built once via createFixtureEngine). Values above the compiled
+ * clamp TRANSPORT_SWING_MAX (0.375 since the #269 retune) are written to
+ * the retained private `swing` field - renderWav reads it unclamped and
+ * Tone accepts 0-1 - so the reference ladder can render beyond the
+ * production ceiling without source changes.
+ */
+
+import { getContext } from "tone/build/esm/index";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { server } from "vitest/browser";
+
+import { transportSwingKnobToDomain } from "@/core/audio/bridge/knob-to-domain";
+import type { AudioEngine } from "@/core/audio/engine";
+import { TRANSPORT_SWING_MAX } from "@/core/audio/engine/constants";
+import { encodeWav } from "@/core/audio/export/wav-encoder";
+import { findOnsets } from "@/test/analysis";
+import { makeInstrument, makePattern } from "@/test/fixtures";
+import { createFixtureEngine } from "@/test/render";
+
+const BPM = 95;
+const BARS = 4;
+/** Duration of one 16th note at 95 BPM. */
+const STEP = 60 / BPM / 4;
+const OUT_DIR = "audition-out";
+/** Per-render timeout headroom: offline render of ~10s of audio + sampler loads. */
+const RENDER_TIMEOUT = 300_000;
+
+/** Knob positions to audition on the shipped curve. */
+const KNOBS = [0, 25, 50, 67, 85, 100];
+
+/**
+ * MPC reference ladder: fixed domain swing values. Values above the
+ * production ceiling (0.375) render via the retained-field escape hatch
+ * for by-ear comparison against what the clamp gives up.
+ */
+const REF_SWINGS = [0, 0.125, 0.25, 0.375, 0.5, 0.6, 0.75];
+
+/**
+ * Domain swing -> MPC-style percentage label. MPC% maps 50% (straight) to
+ * 62.5% at Tone swing 0.375 and 75% at 0.75: pct = 50 + (100 / 3) * s.
+ * One decimal, trailing ".0" stripped (e.g. "56.3", "70").
+ */
+function mpcLabel(s: number): string {
+  const pct = Math.round((50 + (100 / 3) * s) * 10) / 10;
+  return Number.isInteger(pct) ? String(pct) : pct.toFixed(1);
+}
+
+/**
+ * Sets the swing retained by the engine in DOMAIN units. Values within the
+ * production clamp go through the real command; values above it (audition
+ * only) are written to the retained field directly, which renderWav reads
+ * unclamped.
+ */
+function setEngineSwing(engine: AudioEngine, s: number): void {
+  if (s <= TRANSPORT_SWING_MAX) {
+    engine.setSwing(s);
+  } else {
+    (engine as unknown as { swing: number }).swing = s;
+  }
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+/** Fetches a real kit sample served from public/ and wraps it in a blob URL. */
+async function fetchSampleUrl(path: string): Promise<string> {
+  const res = await fetch(path);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch sample ${path}: ${res.status}`);
+  }
+  return URL.createObjectURL(await res.blob());
+}
+
+/**
+ * Measures the mean delay of the odd 16th steps against the straight grid,
+ * using step 0's onset as the timing anchor (absolute onsets carry a small
+ * constant master-chain latency, so only relative positions are meaningful).
+ * Swing only delays, and never past the next even step, so matches are
+ * accepted in [-STEP/4, 0.75*STEP] around the nominal grid time.
+ */
+function measureOddStepOffset(buffer: AudioBuffer): number {
+  const onsets = findOnsets(buffer, { threshold: 0.04, refractoryMs: 20 });
+  expect(onsets.length).toBeGreaterThan(32);
+  const t0 = onsets[0];
+
+  const offsets: number[] = [];
+  for (let step = 1; step < BARS * 16; step += 2) {
+    const nominal = t0 + step * STEP;
+    let best = Number.POSITIVE_INFINITY;
+    for (const t of onsets) {
+      const d = t - nominal;
+      if (Math.abs(d) < Math.abs(best)) best = d;
+    }
+    if (best >= -STEP / 4 && best <= 0.75 * STEP) {
+      offsets.push(best);
+    }
+  }
+  expect(offsets.length).toBeGreaterThan(16);
+  return offsets.reduce((a, b) => a + b, 0) / offsets.length;
+}
+
+describe.runIf(!!import.meta.env.VITE_AUDITION)(
+  "swing audition renders (issue #269)",
+  () => {
+    let engine: AudioEngine;
+
+    beforeAll(async () => {
+      const sampleUrls = await Promise.all([
+        fetchSampleUrl("/samples/0/kick.wav"),
+        fetchSampleUrl("/samples/0/snare.wav"),
+        fetchSampleUrl("/samples/0/hat.wav"),
+      ]);
+      engine = await createFixtureEngine({
+        pattern: makePattern({
+          steps: [
+            ...[0, 4, 8, 12].map((step) => ({ voice: 0, step })),
+            ...[4, 12].map((step) => ({ voice: 1, step })),
+            ...Array.from({ length: 16 }, (_, step) => ({ voice: 2, step })),
+          ],
+        }),
+        instruments: [
+          makeInstrument(0, "kick"),
+          makeInstrument(1, "snare"),
+          makeInstrument(2, "hat"),
+        ],
+        sampleUrls,
+        bpm: BPM,
+        swing: 0,
+      });
+    }, 120_000);
+
+    afterAll(() => {
+      engine?.dispose();
+    });
+
+    async function renderToFile(
+      s: number,
+      filename: string,
+    ): Promise<AudioBuffer> {
+      setEngineSwing(engine, s);
+      const buffer = await engine.renderWav({
+        bars: BARS,
+        sampleRate: getContext().sampleRate,
+        includeTail: false,
+      });
+      const wav = encodeWav(buffer);
+      await server.commands.writeFile(
+        `${OUT_DIR}/${filename}`,
+        arrayBufferToBase64(wav),
+        "base64",
+      );
+      expect(wav.byteLength).toBeGreaterThan(100_000);
+      return buffer;
+    }
+
+    it(
+      `renders the shipped curve at knob ${KNOBS.join("/")}`,
+      async () => {
+        for (const k of KNOBS) {
+          const s = transportSwingKnobToDomain(k);
+          await renderToFile(
+            s,
+            `swing-shipped-knob${k}-mpc${mpcLabel(s)}-${BPM}bpm.wav`,
+          );
+        }
+      },
+      RENDER_TIMEOUT,
+    );
+
+    it(
+      "renders the MPC reference ladder and sanity-checks odd-16th offsets",
+      async () => {
+        const buffers = new Map<number, AudioBuffer>();
+        for (const s of REF_SWINGS) {
+          buffers.set(
+            s,
+            await renderToFile(s, `swing-ref-mpc${mpcLabel(s)}-${BPM}bpm.wav`),
+          );
+        }
+
+        // Tone applies swing as offset = s * (1/6) * (60 / BPM) seconds on
+        // the odd 16ths (see golden-render.browser.test.ts derivation).
+        const expected = (s: number) => s * (1 / 6) * (60 / BPM);
+
+        const measured667 = measureOddStepOffset(buffers.get(0.5)!);
+        const measured75 = measureOddStepOffset(buffers.get(0.75)!);
+        const report = [
+          `mpc66.7 (s=0.5): measured ${measured667.toFixed(4)}s, expected ${expected(0.5).toFixed(4)}s`,
+          `mpc75 (s=0.75): measured ${measured75.toFixed(4)}s, expected ${expected(0.75).toFixed(4)}s`,
+        ].join("\n");
+        console.log(`[audition]\n${report}`);
+        await server.commands.writeFile(
+          `${OUT_DIR}/onset-check.txt`,
+          `${report}\n`,
+          "utf-8",
+        );
+
+        expect(Math.abs(measured667 - expected(0.5))).toBeLessThan(0.008);
+        expect(Math.abs(measured75 - expected(0.75))).toBeLessThan(0.008);
+        expect(measured75).toBeGreaterThan(measured667);
+      },
+      RENDER_TIMEOUT,
+    );
+
+    /**
+     * TR-909-style discrete shuffle: seven detents where detent n maps to
+     * Tone swing s = n/16 (n = 0..6, max s = 0.375 = MPC 62.5% =
+     * TRANSPORT_SWING_MAX, the shipped ceiling). Detent 0 is straight
+     * (identical to the mpc50 renders), so only the six nonzero detents
+     * are rendered. All values sit within the production clamp, so plain
+     * engine.setSwing applies.
+     */
+    describe("909-style detents", () => {
+      it(
+        "renders detents 1-6 and sanity-checks detent 6",
+        async () => {
+          let detent6Buffer: AudioBuffer | undefined;
+          for (let n = 1; n <= 6; n++) {
+            const s = n / 16;
+            const buffer = await renderToFile(
+              s,
+              `swing-909-detent${n}-mpc${mpcLabel(s)}-${BPM}bpm.wav`,
+            );
+            if (n === 6) detent6Buffer = buffer;
+          }
+
+          const s6 = 6 / 16;
+          const expected6 = s6 * (1 / 6) * (60 / BPM);
+          const measured6 = measureOddStepOffset(detent6Buffer!);
+          const report =
+            `909 detent6 (s=${s6}): measured ${measured6.toFixed(4)}s, ` +
+            `expected ${expected6.toFixed(4)}s`;
+          console.log(`[audition] ${report}`);
+          await server.commands.writeFile(
+            `${OUT_DIR}/onset-check-909.txt`,
+            `${report}\n`,
+            "utf-8",
+          );
+          expect(Math.abs(measured6 - expected6)).toBeLessThan(0.008);
+        },
+        RENDER_TIMEOUT,
+      );
+    });
+  },
+);


### PR DESCRIPTION
Closes #269.

## The decision (signed off by Max after auditioning rendered candidates)

Swing keeps a continuous linear knob but the ceiling drops from a full triplet (Tone 0.5, MPC 66.7%) to the **TR-909's maximum shuffle**: 6 ticks at 96 PPQN = 25% of a 16th = **Tone 0.375 = MPC 62.5%**. Verified against the Roland TR-909 owner's manual (the 32nd-scale setting-pairing proves the 1-tick/96 PPQN arithmetic) and the Nava clone firmware's shuffle table. The knob now displays **true MPC swing percent** (50.0-62.5%, one decimal) instead of a raw knob number that read like MPC% but wasn't - the display range is derived from `TRANSPORT_SWING_MAX` so audio and label cannot drift apart.

## Migration

Swing is persisted in knob space (0-100) everywhere, so the curve change reinterprets stored values. One shared helper applies the exact feel-preserving `k_new = min(100, k * 4/3)` (pre-retune values above 75 clamp to the new ceiling - the accepted trade-off):

- **Shipped defaults**: all 11 `.dh` files rewritten in place to v1.5 (A Drum Called Haus 48→64, Slime Time 38→152/3, Sunflower 15→20) - identical sound, no runtime migration.
- **User .dh files**: `PRESET_FILE_VERSION = 1.5` with on-load migration; v1 accepted and normalized, anything newer still rejected.
- **Share URLs**: the compact codec gains a `v` field; URLs without it are pre-retune and their `sw` (or the pinned legacy default when omitted) migrates on decode.
- **localStorage**: transport persist bumps to version 1 with a migrate.

**Versioning note**: the swing revision ships as `.dh` **version 1.5** (fractional on purpose, per Max) so **version 2 stays reserved for the domain-unit preset document** from the persistence design (#329/#339), whose numbering is untouched. The design doc gets a short scoped update note; the domain document's 1-to-2 migration will accept 1.5 as input (the swing rescale is already applied there).

## Also in here

- Tempo screen swing input now rounds to integer knob values like the knob control (both entry points persist the same granularity).
- Golden render tests updated to the new curve (knob 50 = Tone 0.1875 = MPC 56.25%); MIDI exporter tests re-pinned (max swing = 30 ticks, was 40) - the exporter itself is domain-native and unchanged.
- The `VITE_AUDITION`-gated audition harness used to A/B the candidates is adopted at `src/test/audition/` (CI never runs it; renders 909-detent/reference ladders to a gitignored `audition-out/`).
- New tests: migration helper (boundaries, clamps, feel-preservation sweep), transport persist migrate, compact codec versioning round-trips, bridge curve pins.

## Gates

`pnpm test` 752 passed / 4 skipped (the gated audition file), `pnpm test:e2e` 9/9, `pnpm lint` / `pnpm build` / `pnpm prettier --check` clean, engine purity greps clean. Verified in a real browser: pre-retune localStorage (`{swing: 48, version: 0}`) boots to knob 64 displaying 58.0% and re-persists as v1.