### PR TITLE
fix(transport): keep the swing display on one line in the screen bar

### DIFF
--- a/src/features/transport/components/tempo-controls-screen.tsx
+++ b/src/features/transport/components/tempo-controls-screen.tsx
@@ -55,6 +55,7 @@ function TempoControlsScreen() {
           sensitivity={0.3}
           label="bpm"
           labelClassName="text-xs"
+          className="whitespace-nowrap tabular-nums"
         />
         <ClickableValue
           value={swing}
@@ -63,6 +64,7 @@ function TempoControlsScreen() {
           sensitivity={0.2}
           label="swing"
           labelClassName="text-xs"
+          className="whitespace-nowrap tabular-nums"
         />
 
         <span className="flex w-full items-center justify-start">

--- a/src/features/transport/components/tempo-controls-screen.tsx
+++ b/src/features/transport/components/tempo-controls-screen.tsx
@@ -1,4 +1,5 @@
 import { TRANSPORT_SWING_RANGE } from "@/core/audio/engine/constants";
+import { MAX_CHAIN_STEPS } from "@/core/audio/engine/pattern-types";
 import { VariationBadge } from "@/features/sequencer/components/variation-badge";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { VARIATION_LABELS } from "@/features/sequencer/types/sequencer";
@@ -47,7 +48,10 @@ function TempoControlsScreen() {
 
   return (
     <ScreenBar>
-      <div className="grid w-full grid-cols-5 place-items-stretch gap-0">
+      {/* Content-sized cells with the leftover space spread evenly between
+          them. Each numeric value reserves its widest rendering (min-w in
+          ch, tabular digits) so neighbors don't shift while dragging. */}
+      <div className="flex w-full items-center justify-between gap-1 whitespace-nowrap tabular-nums">
         <ClickableValue
           value={bpmKnobValue}
           onValueChange={handleBpmChange}
@@ -55,7 +59,7 @@ function TempoControlsScreen() {
           sensitivity={0.3}
           label="bpm"
           labelClassName="text-xs"
-          className="whitespace-nowrap tabular-nums"
+          valueClassName="inline-block min-w-[3.5ch]"
         />
         <ClickableValue
           value={swing}
@@ -64,21 +68,35 @@ function TempoControlsScreen() {
           sensitivity={0.2}
           label="swing"
           labelClassName="text-xs"
-          className="whitespace-nowrap tabular-nums"
+          valueClassName="inline-block min-w-[4ch]"
         />
 
-        <span className="flex w-full items-center justify-start">
-          <span className="pr-2 pl-1 text-xs">play</span>
+        <span className="flex items-center">
+          <span className="pr-2 text-xs">play</span>
           <VariationBadge variation={playbackVariation} />
         </span>
-        <span className="col-span-2 flex w-full items-center justify-start">
+        <span className="flex items-center">
           <span className="text-xs">chain</span>
-          <span
-            className={cn("flex-1 pl-1", {
-              "flex w-full items-center justify-center": !chainEnabled,
-            })}
-          >
-            {chainEnabled ? chainString : "—"}
+          {/* Reserve the worst-case chain width: one invisible sizer per
+              variation letter, each repeated to the maximum chain length,
+              stacked in the same grid cell so the widest letter wins. */}
+          <span className="ml-1 grid">
+            {VARIATION_LABELS.map((letter) => (
+              <span
+                key={letter}
+                aria-hidden="true"
+                className="invisible col-start-1 row-start-1"
+              >
+                {letter.repeat(MAX_CHAIN_STEPS)}
+              </span>
+            ))}
+            <span
+              className={cn("col-start-1 row-start-1", {
+                "text-center": !chainEnabled,
+              })}
+            >
+              {chainEnabled ? chainString : "—"}
+            </span>
           </span>
         </span>
       </div>

--- a/src/shared/components/clickable-value.tsx
+++ b/src/shared/components/clickable-value.tsx
@@ -15,6 +15,7 @@ interface ClickableValueProps {
   onEditingChange?: (isEditing: boolean) => void;
   label?: string;
   labelClassName?: string;
+  valueClassName?: string;
 }
 
 const defaultParse = (text: string) => parseFloat(text);
@@ -34,6 +35,7 @@ function ClickableValue({
   onEditingChange,
   label,
   labelClassName = "",
+  valueClassName = "",
 }: ClickableValueProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -264,7 +266,7 @@ function ClickableValue({
 
   return (
     <div
-      className={cn("focus-ring", className)}
+      className={cn("focus-ring relative", className)}
       onPointerDown={handlePointerDown}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -276,26 +278,28 @@ function ClickableValue({
       aria-valuenow={value}
       style={{ cursor: isDragging ? "ns-resize" : "pointer" }}
     >
-      {isEditing ? (
+      {/* The display stays in flow (invisible while editing) so the
+          component keeps its width when the input overlays it, even in
+          content-sized layouts. */}
+      <span className={cn({ invisible: isEditing })}>
+        {label && <span className={labelClassName}>{label} </span>}
+        <span className={cn(label ? "pl-0.5" : "", valueClassName)}>
+          {formattedDisplay.value}
+        </span>
+        {!label && formattedDisplay.append ? (
+          <span className="pl-0.5">{formattedDisplay.append}</span>
+        ) : null}
+      </span>
+      {isEditing && (
         <Input
           ref={inputRef}
           value={inputValue}
           onChange={handleInputChange}
           onBlur={handleSubmit}
           onKeyDown={handleInputKeyDown}
-          className="text-primary-foreground m-0 h-auto w-full min-w-0 rounded-none border-none bg-transparent p-0 text-center font-sans leading-none shadow-none ring-0 ring-offset-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+          className="text-primary-foreground absolute inset-0 m-0 h-auto w-full min-w-0 rounded-none border-none bg-transparent p-0 text-center font-sans leading-none shadow-none ring-0 ring-offset-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
           style={{ height: "auto", minHeight: "0", lineHeight: "inherit" }}
         />
-      ) : (
-        <>
-          {label && <span className={labelClassName}>{label} </span>}
-          <span className={label ? "pl-0.5" : ""}>
-            {formattedDisplay.value}
-          </span>
-          {!label && formattedDisplay.append ? (
-            <span className="pl-0.5">{formattedDisplay.append}</span>
-          ) : null}
-        </>
       )}
     </div>
   );

--- a/src/shared/knob/lib/format.ts
+++ b/src/shared/knob/lib/format.ts
@@ -40,7 +40,9 @@ const formatDisplayPercentage = (value: number) => {
 };
 
 const formatDisplaySwingMpc = (value: number) => {
-  return { value: value.toFixed(1), append: "%" };
+  // One decimal of honest MPC precision, minus a gratuitous trailing ".0"
+  // so integral values render as e.g. "50" instead of "50.0".
+  return { value: value.toFixed(1).replace(/\.0$/, ""), append: "%" };
 };
 
 const formatDisplayCompRatio = (value: number) => {


### PR DESCRIPTION
## Problem

#344 (the #269 swing retune) changed the MPC swing formatter to `toFixed(1)` for the honest MPC display. Every swing value became 4 characters ("50.0"-"62.5") and the swing cell of the tempo screen bar wrapped onto a second line. Beyond the wrap, the underlying `grid-cols-5` layout gave chain 40% of the bar while a wide swing value filled its whole 20% column, so spacing read as cramped next to empty space.

## Fix

**Formatter** (`e248ad15`): `formatDisplaySwingMpc` keeps one decimal of honest MPC precision but strips a gratuitous trailing `.0`: min shows `50`, intermediates show e.g. `55.4`, max stays `62.5` (not rounded to a dishonest `63`).

**Layout** (`c73fb883`): content-sized flex cells with `justify-between`, so leftover space spreads evenly between bpm, swing, play, and chain.
- Chain reserves its worst case (every variation letter repeated to `MAX_CHAIN_STEPS`, stacked as invisible sizers so the widest letter wins) instead of 2/5 of the bar; the disabled em dash centers within that reserved area as before.
- bpm and swing values reserve their widest rendering (`min-w` in ch, tabular digits) so neighbors don't shift while dragging.
- `ClickableValue` keeps its display in flow (invisible) under the edit input, so edit mode no longer depends on a stretched grid cell for its width. The tempo screen is its only consumer.

## Verification

- Playwright against the dev server, driving the real UI (chain programmed via the vari-chain flow): bpm 300 / swing 62.5 / chain `AABBCCDD` renders on one line with even ~4px gaps and zero overflow; chain-disabled dash centers in the reserved area; bpm 40 / swing 50 keeps identical cell positions.
- Cell x/width tuples are byte-identical across swing 50↔62.5, bpm 40↔300, and edit mode - no jitter while dragging or editing.
- Edit-mode round trip is safe: values parse with `parseFloat`, which handles both `50` and `62.5`.
- 752 unit tests passed, lint and typecheck clean.