### PR TITLE
feat(preset): snapshot/apply pipeline with kit-failure rollback

### DIFF
--- a/src/core/audio/bridge/kit-subscription.browser.test.ts
+++ b/src/core/audio/bridge/kit-subscription.browser.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Bridge rollback tests for kit-load failure (decision 5 in
+ * docs/preset-persistence.md).
+ *
+ * Drives subscribeKitToEngine against the real instruments store and a
+ * stub engine (the rollback logic is store orchestration; the engine's own
+ * failure semantics are covered by the engine browser tests). A failed
+ * store-driven load must roll the store back to the previous instruments
+ * and fire the kit-load-failure event exactly once, and a rollback whose
+ * own redundant load also fails must not loop.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type {
+  KitLoadResult,
+  KitSampleDescriptor,
+} from "@/core/audio/engine/audio-engine";
+import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
+import type { InstrumentData } from "@/features/instrument/types/instrument";
+import { makeInstrument } from "@/test/fixtures";
+import { onKitLoadFailure, subscribeKitToEngine } from "./kit-subscription";
+
+/** Stub engine recording every loadKit call; outcome decided per kit. */
+function makeStubEngine(
+  resultFor: (kit: KitSampleDescriptor[]) => KitLoadResult,
+) {
+  const calls: KitSampleDescriptor[][] = [];
+  return {
+    calls,
+    loadKit: (kit: KitSampleDescriptor[]) => {
+      calls.push(kit);
+      return Promise.resolve(resultFor(kit));
+    },
+  };
+}
+
+/** Whether every descriptor in the kit belongs to these instruments. */
+function isKitOf(kit: KitSampleDescriptor[], instruments: InstrumentData[]) {
+  const ids = new Set(instruments.map((instrument) => instrument.meta.id));
+  return kit.every((slot) => ids.has(slot.instrumentId));
+}
+
+/** Drains the loadKit -> rollback -> redundant loadKit microtask chains. */
+async function flushKitLoads(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const cleanups: (() => void)[] = [];
+
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup());
+});
+
+describe("kit subscription rollback (decision 5)", () => {
+  it("rolls the store back on failure and fires the failure event once", async () => {
+    const goodKit = [makeInstrument(0, "kick"), makeInstrument(1, "snare")];
+    const badKit = [makeInstrument(2, "kick"), makeInstrument(3, "snare")];
+    useInstrumentsStore.getState().setAllInstruments(goodKit);
+
+    const engine = makeStubEngine((kit) =>
+      isKitOf(kit, badKit) ? "failed" : "loaded",
+    );
+    cleanups.push(subscribeKitToEngine(engine));
+
+    let failures = 0;
+    cleanups.push(
+      onKitLoadFailure(() => {
+        failures += 1;
+      }),
+    );
+
+    // Commit the bad kit, exactly like a kit/preset switch does.
+    useInstrumentsStore.getState().setAllInstruments(badKit);
+    await flushKitLoads();
+
+    // Rolled back to the exact previous instruments value.
+    expect(useInstrumentsStore.getState().instruments).toBe(goodKit);
+    expect(failures).toBe(1);
+
+    // Loads: initial good kit, the failed bad kit, then the rollback's
+    // redundant reload of the good kit (harmless - the engine holds it).
+    expect(engine.calls).toHaveLength(3);
+    expect(isKitOf(engine.calls[1], badKit)).toBe(true);
+    expect(isKitOf(engine.calls[2], goodKit)).toBe(true);
+  });
+
+  it("does not loop when the rollback's own load also fails", async () => {
+    const goodKit = [makeInstrument(0, "kick"), makeInstrument(1, "snare")];
+    const badKit = [makeInstrument(2, "kick"), makeInstrument(3, "snare")];
+    useInstrumentsStore.getState().setAllInstruments(goodKit);
+
+    // Every load fails (e.g. the network died entirely).
+    const engine = makeStubEngine(() => "failed");
+    cleanups.push(subscribeKitToEngine(engine));
+
+    let failures = 0;
+    cleanups.push(
+      onKitLoadFailure(() => {
+        failures += 1;
+      }),
+    );
+
+    useInstrumentsStore.getState().setAllInstruments(badKit);
+    await flushKitLoads();
+    await flushKitLoads();
+
+    // The bad kit rolled back once; the rollback's own failed load hit the
+    // loop guard: no second rollback, no second event, no further loads.
+    expect(useInstrumentsStore.getState().instruments).toBe(goodKit);
+    expect(failures).toBe(1);
+    // Initial load, the bad kit, the rollback reload - and nothing after.
+    expect(engine.calls).toHaveLength(3);
+  });
+
+  it("leaves the store alone when loads succeed or are superseded", async () => {
+    const kitA = [makeInstrument(0, "kick"), makeInstrument(1, "snare")];
+    const kitB = [makeInstrument(2, "kick"), makeInstrument(3, "snare")];
+    useInstrumentsStore.getState().setAllInstruments(kitA);
+
+    const engine = makeStubEngine((kit) =>
+      isKitOf(kit, kitB) ? "loaded" : "superseded",
+    );
+    cleanups.push(subscribeKitToEngine(engine));
+
+    let failures = 0;
+    cleanups.push(
+      onKitLoadFailure(() => {
+        failures += 1;
+      }),
+    );
+
+    useInstrumentsStore.getState().setAllInstruments(kitB);
+    await flushKitLoads();
+
+    expect(useInstrumentsStore.getState().instruments).toBe(kitB);
+    expect(failures).toBe(0);
+  });
+});

--- a/src/core/audio/bridge/kit-subscription.ts
+++ b/src/core/audio/bridge/kit-subscription.ts
@@ -1,0 +1,129 @@
+/**
+ * Bridge between the instruments store and engine kit loads.
+ *
+ * Subscribes to the instruments store, pushes descriptor changes into
+ * engine.loadKit, and reconciles failures per decision 5 in
+ * docs/preset-persistence.md (roll back and notify): when a store-driven
+ * kit load fails, the instruments store is rolled back to the previous
+ * value - the kit the engine still holds - and a bridge-level
+ * kit-load-failure event fires so the UI can toast. The UI never keeps
+ * showing a kit the audio does not have.
+ *
+ * The failure event lives here rather than on the engine because it is a
+ * bridge fact, not an engine fact: it means "your kit change was rolled
+ * back and the previous kit is still active", which is only true for
+ * store-driven loads that this module reconciled. Engine-internal loads
+ * (rebuild's reload of the retained kit) fail under different
+ * circumstances and must not emit it.
+ */
+
+import type {
+  KitLoadResult,
+  KitSampleDescriptor,
+} from "@/core/audio/engine/audio-engine";
+import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
+import type { InstrumentData } from "@/features/instrument/types/instrument";
+import {
+  kitDescriptorsChanged,
+  toKitSampleDescriptors,
+} from "./kit-descriptors";
+
+/**
+ * The slice of the engine the kit subscription drives. Structural so tests
+ * can exercise the rollback logic against a stub without a real audio graph.
+ */
+interface KitLoader {
+  loadKit(kit: KitSampleDescriptor[]): Promise<KitLoadResult>;
+}
+
+// -----------------------------------------------------------------------------
+// Kit-load-failure event (bridge-level)
+// -----------------------------------------------------------------------------
+
+const failureListeners = new Set<() => void>();
+
+/**
+ * Subscribes to kit-load-failure events, fired after a store-driven kit
+ * load fails and the instruments store has been rolled back to the kit the
+ * engine still holds. Returns an unsubscribe function.
+ */
+function onKitLoadFailure(listener: () => void): () => void {
+  failureListeners.add(listener);
+  return () => {
+    failureListeners.delete(listener);
+  };
+}
+
+function emitKitLoadFailure(): void {
+  failureListeners.forEach((listener) => listener());
+}
+
+// -----------------------------------------------------------------------------
+// Store subscription
+// -----------------------------------------------------------------------------
+
+/**
+ * Subscribes engine kit loads to the instruments store (keyed on the full
+ * id / path / role descriptor tuples), loading the current kit immediately
+ * and again on every descriptor change. Returns an unsubscribe function.
+ *
+ * Failure reconciliation: each subscription-driven load is awaited; on
+ * "failed" the store rolls back to the value it held before the write
+ * (which carries any param edits made since the engine's kit last loaded)
+ * and the kit-load-failure event fires. "loaded" and "superseded" change
+ * nothing - a superseded load's outcome belongs to the newer load that won.
+ *
+ * The rollback write re-fires this subscription, so the engine sees a
+ * redundant loadKit for the kit it already holds - harmless (last-wins,
+ * cached samples). If even that load fails, `rollbackTarget` breaks the
+ * loop: a failed load OF the value we just rolled back to is never rolled
+ * back again, otherwise two failing kits would ping-pong forever.
+ */
+function subscribeKitToEngine(engine: KitLoader): () => void {
+  let active = true;
+  let prevKit = toKitSampleDescriptors(
+    useInstrumentsStore.getState().instruments,
+  );
+  /** The instruments value the last failed load was rolled back to; cleared
+   * once any subscription-driven load succeeds. */
+  let rollbackTarget: InstrumentData[] | null = null;
+
+  // Initial load: if this fails there is no previous kit to roll back to
+  // (the engine holds nothing yet), so failures stay engine-logged only.
+  if (prevKit.length > 0) {
+    void engine.loadKit(prevKit);
+  }
+
+  const unsubscribe = useInstrumentsStore.subscribe((state, prevState) => {
+    if (!kitDescriptorsChanged(prevKit, state.instruments)) return;
+
+    const instruments = state.instruments;
+    const previousInstruments = prevState.instruments;
+    prevKit = toKitSampleDescriptors(instruments);
+    if (prevKit.length === 0) return;
+
+    void engine.loadKit(prevKit).then((result) => {
+      if (!active) return;
+      if (result === "loaded") {
+        rollbackTarget = null;
+        return;
+      }
+      if (result !== "failed") return;
+
+      // Loop guard: this failed load IS the rollback we just issued; the
+      // engine kept its kit, so a second rollback would only ping-pong.
+      if (instruments === rollbackTarget) return;
+
+      rollbackTarget = previousInstruments;
+      useInstrumentsStore.getState().setAllInstruments(previousInstruments);
+      emitKitLoadFailure();
+    });
+  });
+
+  return () => {
+    active = false;
+    unsubscribe();
+  };
+}
+
+export { onKitLoadFailure, subscribeKitToEngine };

--- a/src/core/audio/bridge/use-engine-bridge.ts
+++ b/src/core/audio/bridge/use-engine-bridge.ts
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { shallow } from "zustand/shallow";
 
 import { getAudioEngine } from "@/core/audio/engine";
-import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
 import {
   getMasterChainParams,
   useMasterChainStore,
@@ -11,10 +10,7 @@ import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
 import { useAudioContextGuards } from "../hooks/use-audio-context-guards";
 import { subscribeInstrumentParamsToEngine } from "./instrument-params";
-import {
-  kitDescriptorsChanged,
-  toKitSampleDescriptors,
-} from "./kit-descriptors";
+import { subscribeKitToEngine } from "./kit-subscription";
 import { mapParamsToSettings, type MasterChainParams } from "./knob-to-domain";
 
 /**
@@ -73,23 +69,8 @@ function useEngineBridge(): void {
     // --- Instrument params (continuous + play params, knob -> domain) ---
     unsubscribers.push(subscribeInstrumentParamsToEngine(engine));
 
-    // --- Kit (keyed on the full id / path / role descriptor tuples) ---
-    let prevKit = toKitSampleDescriptors(
-      useInstrumentsStore.getState().instruments,
-    );
-    if (prevKit.length > 0) {
-      void engine.loadKit(prevKit);
-    }
-    unsubscribers.push(
-      useInstrumentsStore.subscribe((state) => {
-        if (kitDescriptorsChanged(prevKit, state.instruments)) {
-          prevKit = toKitSampleDescriptors(state.instruments);
-          if (prevKit.length > 0) {
-            void engine.loadKit(prevKit);
-          }
-        }
-      }),
-    );
+    // --- Kit (descriptor-keyed loads + failure rollback, decision 5) ---
+    unsubscribers.push(subscribeKitToEngine(engine));
 
     // --- Master chain ---
     let prevMasterParams: MasterChainParams | null = null;

--- a/src/core/audio/bridge/use-kit-load-failure.ts
+++ b/src/core/audio/bridge/use-kit-load-failure.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+import { useToast } from "@/shared/ui";
+import { onKitLoadFailure } from "./kit-subscription";
+
+/**
+ * Toasts kit-load failures. Subscribes to the bridge's kit-load-failure
+ * event (fired after the instruments store rolled back to the kit the
+ * engine still holds, decision 5 in docs/preset-persistence.md) and tells
+ * the user their kit change did not take. Mounted alongside the engine
+ * bridge in DrumhausProvider.
+ */
+function useKitLoadFailureToast(): void {
+  const { toast } = useToast();
+
+  useEffect(
+    () =>
+      onKitLoadFailure(() => {
+        toast({
+          title: "Kit Failed to Load",
+          description:
+            "The kit's samples could not be loaded, so the previous kit is still active.",
+          status: "error",
+          duration: 6000,
+        });
+      }),
+    [toast],
+  );
+}
+
+export { useKitLoadFailureToast };

--- a/src/core/audio/engine/__tests__/kit-load-failure.browser.test.ts
+++ b/src/core/audio/engine/__tests__/kit-load-failure.browser.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Browser tests for loadKit's KitLoadResult (decision 5 in
+ * docs/preset-persistence.md).
+ *
+ * A failed load must resolve "failed" while leaving the engine on the
+ * previous kit with unpoisoned retained descriptors: renderWav and
+ * rebuild re-create channels from those descriptors, so both must keep
+ * targeting the last kit that actually loaded. A load superseded by a
+ * newer one must resolve "superseded" while the winner resolves "loaded".
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { KitSampleDescriptor } from "@/core/audio/engine/audio-engine";
+import { findOnsets } from "@/test/analysis";
+import {
+  makeClickSampleUrl,
+  makeInstrument,
+  makePattern,
+} from "@/test/fixtures";
+import { createFixtureEngine } from "@/test/render";
+
+const BPM = 120;
+const SAMPLE_RATE = 44100;
+
+let clickUrl: string;
+
+beforeAll(() => {
+  clickUrl = makeClickSampleUrl();
+});
+
+describe("kit load failure (decision 5)", () => {
+  it('resolves "failed" and keeps the previous kit and retained descriptors intact', async () => {
+    const engine = await createFixtureEngine({
+      pattern: makePattern({
+        steps: [
+          ...[0, 4, 8, 12].map((step) => ({ voice: 0, step })),
+          { voice: 1, step: 6 },
+        ],
+      }),
+      instruments: [makeInstrument(0, "kick"), makeInstrument(1, "snare")],
+      sampleUrls: [clickUrl, clickUrl],
+      bpm: BPM,
+    });
+
+    try {
+      const renderOptions = {
+        bars: 1,
+        sampleRate: SAMPLE_RATE,
+        includeTail: false,
+      };
+      const baselineOnsets = findOnsets(await engine.renderWav(renderOptions));
+      expect(baselineOnsets).toHaveLength(5);
+
+      let kitLoadedEvents = 0;
+      engine.onKitLoaded(() => {
+        kitLoadedEvents += 1;
+      });
+
+      // A bad kit whose second sample path fails to resolve, like a 404ing
+      // sample would.
+      const badKit: KitSampleDescriptor[] = [
+        { instrumentId: "bad-0", samplePath: "bad-sample-0.wav", role: "kick" },
+        {
+          instrumentId: "bad-1",
+          samplePath: "bad-sample-1.wav",
+          role: "snare",
+        },
+      ];
+      const result = await engine.loadKit(badKit, async (path: string) => {
+        if (path === "bad-sample-1.wav") {
+          throw new Error("sample not found");
+        }
+        return { url: clickUrl };
+      });
+
+      expect(result).toBe("failed");
+      expect(kitLoadedEvents).toBe(0);
+
+      // The previous kit's channels are still live.
+      expect(engine.isChannelReady(0)).toBe(true);
+      expect(engine.isChannelReady(1)).toBe(true);
+
+      // Retained descriptors are unpoisoned: renderWav re-creates channels
+      // from them, so a poisoned retention would reject (bad resolver) - it
+      // must still render the old kit's onsets instead.
+      const afterFailure = findOnsets(await engine.renderWav(renderOptions));
+      expect(afterFailure).toHaveLength(baselineOnsets.length);
+
+      // rebuild() reloads from the same retained descriptors and must also
+      // land back on the old kit.
+      await engine.rebuild();
+      expect(engine.isChannelReady(0)).toBe(true);
+      expect(engine.isChannelReady(1)).toBe(true);
+      const afterRebuild = findOnsets(await engine.renderWav(renderOptions));
+      expect(afterRebuild).toHaveLength(baselineOnsets.length);
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it('resolves "superseded" for the losing load and "loaded" for the winner', async () => {
+    const instruments = [makeInstrument(0, "kick"), makeInstrument(1, "snare")];
+    const engine = await createFixtureEngine({
+      pattern: makePattern({ steps: [{ voice: 0, step: 0 }] }),
+      instruments,
+      sampleUrls: [clickUrl, clickUrl],
+      bpm: BPM,
+    });
+
+    try {
+      let kitLoadedEvents = 0;
+      engine.onKitLoaded(() => {
+        kitLoadedEvents += 1;
+      });
+
+      const resolver = async () => ({ url: clickUrl });
+      const descriptors = instruments.map((instrument) => ({
+        instrumentId: instrument.meta.id,
+        samplePath: instrument.sample.path,
+        role: instrument.role,
+      }));
+
+      // The second call bumps loadSeq synchronously, so the first is
+      // superseded regardless of which resolver settles first.
+      const loser = engine.loadKit(descriptors, resolver);
+      const winner = engine.loadKit(descriptors, resolver);
+
+      await expect(loser).resolves.toBe("superseded");
+      await expect(winner).resolves.toBe("loaded");
+      expect(kitLoadedEvents).toBe(1);
+    } finally {
+      engine.dispose();
+    }
+  });
+});

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -88,6 +88,18 @@ interface KitSampleDescriptor {
 }
 
 /**
+ * Outcome of a loadKit call. "loaded" means this call's channels are now
+ * live. "superseded" means a newer loadKit (or dispose) won the loadSeq
+ * race while this one was in flight - not an error, the newer load owns
+ * the engine's kit. "failed" means this call was still the latest but its
+ * samples could not be loaded; the engine keeps the previous kit's
+ * channels and the retained descriptors stay untouched, so the caller can
+ * reconcile (the bridge rolls the instruments store back, decision 5 in
+ * docs/preset-persistence.md).
+ */
+type KitLoadResult = "loaded" | "superseded" | "failed";
+
+/**
  * Playback configuration pushed from the pattern store.
  */
 interface PlaybackConfig {
@@ -300,6 +312,11 @@ class AudioEngine {
    * while it is in flight, the orphaned new channels are disposed and the
    * active ones are left untouched.
    *
+   * Resolves with the outcome (see KitLoadResult); it never rejects. On
+   * "failed" the previous kit stays live and the retained descriptors are
+   * not poisoned, so rebuild and renderWav keep targeting the last kit
+   * that actually loaded.
+   *
    * During playback the live sequence is deliberately left untouched: the
    * scheduler reads channels fresh on every step, so it picks up the new
    * kit on its next step, and recreating the sequence here would reset the
@@ -308,7 +325,7 @@ class AudioEngine {
   async loadKit(
     kit: KitSampleDescriptor[],
     resolver?: SampleSourceResolver,
-  ): Promise<void> {
+  ): Promise<KitLoadResult> {
     const token = ++this.loadSeq;
     let newChannels: InstrumentChannel[] = [];
 
@@ -321,7 +338,7 @@ class AudioEngine {
 
       if (token !== this.loadSeq) {
         newChannels.forEach((channel) => channel.dispose());
-        return;
+        return "superseded";
       }
 
       // Retain the kit only now that it has fully loaded (still guarded by
@@ -357,12 +374,14 @@ class AudioEngine {
       );
 
       this.kitLoadedListeners.forEach((listener) => listener());
+      return "loaded";
     } catch (error) {
       if (token !== this.loadSeq) {
         newChannels.forEach((channel) => channel.dispose());
-        return;
+        return "superseded";
       }
       console.error("Error loading audio buffers:", error);
+      return "failed";
     }
   }
 
@@ -1042,6 +1061,7 @@ function getAudioEngine(): AudioEngine {
 export { AudioEngine, calculateExportDuration, getAudioEngine };
 export type {
   EngineDiagnostics,
+  KitLoadResult,
   KitSampleDescriptor,
   PlaybackConfig,
   RenderWavOptions,

--- a/src/core/providers/drumhaus-provider/drumhaus-context.ts
+++ b/src/core/providers/drumhaus-provider/drumhaus-context.ts
@@ -1,9 +1,11 @@
 import { createContext } from "react";
 
+import type { PresetDocument } from "@/features/preset/document";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
 
 interface DrumhausContextValue {
-  loadPreset: (preset: PresetFileV1) => void;
+  loadPresetFile: (preset: PresetFileV1) => void;
+  loadPresetFileText: (text: string) => PresetDocument | null;
 }
 
 const DrumhausContext = createContext<DrumhausContextValue | null>(null);

--- a/src/core/providers/drumhaus-provider/drumhaus-provider.tsx
+++ b/src/core/providers/drumhaus-provider/drumhaus-provider.tsx
@@ -1,4 +1,5 @@
 import { useEngineBridge } from "@/core/audio/bridge/use-engine-bridge";
+import { useKitLoadFailureToast } from "@/core/audio/bridge/use-kit-load-failure";
 import { usePresetLoading } from "@/features/preset/hooks/use-preset-loading";
 import { DrumhausContext, type DrumhausContextValue } from "./drumhaus-context";
 
@@ -9,10 +10,12 @@ interface DrumhausProviderProps {
 const DrumhausProvider = ({ children }: DrumhausProviderProps) => {
   // --- Audio Engine Bridge and Preset Loading ---
   useEngineBridge();
-  const { loadPreset } = usePresetLoading();
+  useKitLoadFailureToast();
+  const { loadPresetFile, loadPresetFileText } = usePresetLoading();
 
   const value: DrumhausContextValue = {
-    loadPreset,
+    loadPresetFile,
+    loadPresetFileText,
   };
 
   return (

--- a/src/features/preset/components/preset-control.tsx
+++ b/src/features/preset/components/preset-control.tsx
@@ -57,7 +57,7 @@ const ConfirmSelectPresetDialog = lazy(() =>
 );
 
 function PresetControl() {
-  const { loadPreset } = useDrumhaus();
+  const { loadPresetFile, loadPresetFileText } = useDrumhaus();
   const {
     kits,
     defaultPresets,
@@ -68,7 +68,7 @@ function PresetControl() {
     importPreset,
     saveCurrentPreset,
     sharePreset,
-  } = usePresetManager({ loadPreset });
+  } = usePresetManager({ loadPresetFile, loadPresetFileText });
 
   // Store state
   const currentPresetMeta = usePresetMetaStore(
@@ -93,7 +93,7 @@ function PresetControl() {
   const handleConfirmPresetChange = () => {
     closeDialog();
     const preset = allPresets.find((p) => p.meta.id === dialogData.preset?.id);
-    if (preset) loadPreset(preset);
+    if (preset) loadPresetFile(preset);
   };
 
   // Preset management handlers

--- a/src/features/preset/dialogs/delete-confirm-dialog.tsx
+++ b/src/features/preset/dialogs/delete-confirm-dialog.tsx
@@ -25,7 +25,7 @@ function DeleteConfirmDialog({
   presetId,
   presetName,
 }: DeleteConfirmDialogProps) {
-  const { loadPreset } = useDrumhaus();
+  const { loadPresetFile } = useDrumhaus();
   const deleteCustomPreset = usePresetMetaStore(
     (state) => state.deleteCustomPreset,
   );
@@ -43,7 +43,7 @@ function DeleteConfirmDialog({
 
     // If deleting current preset, load init preset
     if (isDeletingCurrent) {
-      loadPreset(init());
+      loadPresetFile(init());
       toast({
         title: "Preset deleted",
         description: "Loaded default preset",

--- a/src/features/preset/document/apply.test.ts
+++ b/src/features/preset/document/apply.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for applyPresetDocument, the commit half of the pipeline.
+ *
+ * The engine module is mocked (vi.mock) so these run in the node project:
+ * apply's contract is store-level (conversion before the first write, the
+ * legacy setter order, the cleanPreset dirty baseline); bridge-to-engine
+ * propagation is covered by the browser and e2e suites.
+ */
+
+import { readFileSync } from "node:fs";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PresetDocument } from "./document";
+
+const engineMock = vi.hoisted(() => ({
+  play: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  stop: vi.fn(),
+  setTempo: vi.fn(),
+  setSwing: vi.fn(),
+}));
+
+vi.mock("@/core/audio/engine", () => ({
+  getAudioEngine: () => engineMock,
+}));
+
+// Everything store-adjacent is imported dynamically in beforeAll, after the
+// localStorage stub is in place for zustand's persist middleware.
+let applyPresetDocument: typeof import("./apply").applyPresetDocument;
+let decodePresetFileText: typeof import("./decode").decodePresetFileText;
+let encodePresetDocument: typeof import("./encode").encodePresetDocument;
+let UnknownKitError: typeof import("./errors").UnknownKitError;
+let migrateV1ToDocument: typeof import("./migrate-v1").migrateV1ToDocument;
+let parsePresetFileV1: typeof import("./parse").parsePresetFileV1;
+let useInstrumentsStore: typeof import("@/features/instrument/store/use-instruments-store").useInstrumentsStore;
+let useMasterChainStore: typeof import("@/features/master-bus/store/use-master-chain-store").useMasterChainStore;
+let usePresetMetaStore: typeof import("@/features/preset/store/use-preset-meta-store").usePresetMetaStore;
+let usePatternStore: typeof import("@/features/sequencer/store/use-pattern-store").usePatternStore;
+let useTransportStore: typeof import("@/features/transport/store/use-transport-store").useTransportStore;
+
+function readFixture(name: string): string {
+  return readFileSync(
+    new URL(`./__fixtures__/${name}`, import.meta.url),
+    "utf-8",
+  );
+}
+
+function migrateFixture(name: string): PresetDocument {
+  return migrateV1ToDocument(parsePresetFileV1(readFixture(name)));
+}
+
+const ERA_FIXTURES = [
+  "v1-current.json",
+  "v1-legacy-params.json",
+  "v1-legacy-master.json",
+  "v1-legacy-cycle.json",
+  "v1-legacy-pattern-array.json",
+];
+
+/** The musical store surface, as data (for untouched-stores comparisons). */
+function snapshotStores() {
+  const pattern = usePatternStore.getState();
+  const transport = useTransportStore.getState();
+  const master = useMasterChainStore.getState();
+  const meta = usePresetMetaStore.getState();
+  return {
+    instruments: useInstrumentsStore.getState().instruments,
+    pattern: pattern.pattern,
+    variation: pattern.variation,
+    chain: pattern.chain,
+    chainEnabled: pattern.chainEnabled,
+    mode: pattern.mode,
+    isPlaying: transport.isPlaying,
+    bpm: transport.bpm,
+    swing: transport.swing,
+    master: {
+      filter: master.filter,
+      saturation: master.saturation,
+      phaser: master.phaser,
+      reverb: master.reverb,
+      compThreshold: master.compThreshold,
+      compRatio: master.compRatio,
+      compAttack: master.compAttack,
+      compMix: master.compMix,
+      masterVolume: master.masterVolume,
+    },
+    currentPresetMeta: meta.currentPresetMeta,
+    currentKitMeta: meta.currentKitMeta,
+    cleanPreset: meta.cleanPreset,
+    customPresets: meta.customPresets,
+  };
+}
+
+type StoreSnapshot = ReturnType<typeof snapshotStores>;
+let defaults: StoreSnapshot;
+
+beforeAll(async () => {
+  // zustand's persist middleware expects a Web Storage; give it an
+  // in-memory stub so the store modules can be imported under node.
+  vi.stubGlobal("localStorage", {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  });
+
+  ({ applyPresetDocument } = await import("./apply"));
+  ({ decodePresetFileText } = await import("./decode"));
+  ({ encodePresetDocument } = await import("./encode"));
+  ({ UnknownKitError } = await import("./errors"));
+  ({ migrateV1ToDocument } = await import("./migrate-v1"));
+  ({ parsePresetFileV1 } = await import("./parse"));
+  ({ useInstrumentsStore } =
+    await import("@/features/instrument/store/use-instruments-store"));
+  ({ useMasterChainStore } =
+    await import("@/features/master-bus/store/use-master-chain-store"));
+  ({ usePresetMetaStore } =
+    await import("@/features/preset/store/use-preset-meta-store"));
+  ({ usePatternStore } =
+    await import("@/features/sequencer/store/use-pattern-store"));
+  ({ useTransportStore } =
+    await import("@/features/transport/store/use-transport-store"));
+
+  defaults = snapshotStores();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useInstrumentsStore.setState({ instruments: defaults.instruments });
+  usePatternStore.setState({
+    pattern: defaults.pattern,
+    variation: defaults.variation,
+    chain: defaults.chain,
+    chainEnabled: defaults.chainEnabled,
+    mode: defaults.mode,
+    voiceIndex: 0,
+  });
+  useTransportStore.setState({
+    isPlaying: defaults.isPlaying,
+    bpm: defaults.bpm,
+    swing: defaults.swing,
+  });
+  useMasterChainStore.setState(defaults.master);
+  usePresetMetaStore.setState({
+    currentPresetMeta: defaults.currentPresetMeta,
+    currentKitMeta: defaults.currentKitMeta,
+    cleanPreset: defaults.cleanPreset,
+    customPresets: defaults.customPresets,
+  });
+});
+
+describe("applyPresetDocument", () => {
+  it("commits a migrated fixture document to every store", () => {
+    const document = migrateFixture("v1-current.json");
+    applyPresetDocument(document);
+
+    // Sequencer: pattern and playback land as-is.
+    const pattern = usePatternStore.getState();
+    expect(pattern.pattern).toEqual(document.pattern);
+    expect(pattern.chain).toEqual({ steps: [{ variation: 0, repeats: 1 }] });
+    expect(pattern.chainEnabled).toBe(false);
+    expect(pattern.variation).toBe(0);
+    expect(pattern.mode).toEqual({ type: "voice", voiceIndex: 0 });
+
+    // Transport: bpm raw, swing knob = inverse of the engine fraction.
+    const transport = useTransportStore.getState();
+    expect(transport.bpm).toBe(100);
+    expect(transport.swing).toBe(0);
+
+    // Master: knob values recovered from the golden domain surface.
+    const master = useMasterChainStore.getState();
+    expect(master.filter).toBe(50);
+    expect(master.compThreshold).toBeCloseTo(100, 6); // 0 dB
+    expect(master.compRatio).toBeCloseTo(400 / 7, 9); // ratio 5:1
+    expect(master.compAttack).toBeCloseTo(50, 6);
+    expect(master.compMix).toBeCloseTo(70, 6);
+    expect(master.masterVolume).toBeCloseTo(92, 6); // 0 dB
+
+    // Instruments: registry kit-0 rehydrated, knob params inverted.
+    const instruments = useInstrumentsStore.getState().instruments;
+    expect(instruments).toHaveLength(8);
+    const params = instruments[0].params;
+    expect(params.decay).toBeCloseTo(100, 6); // 5 s
+    expect(params.filter).toBe(50);
+    expect(params.volume).toBeCloseTo(92, 6); // 0 dB
+    expect(params.pan).toBeCloseTo(50, 6);
+    expect(params.tune).toBeCloseTo(50, 6); // 0 semitones
+    expect(params.solo).toBe(false);
+    expect(params.mute).toBe(false);
+
+    // Meta: current meta and the clean baseline point at the loaded preset.
+    const meta = usePresetMetaStore.getState();
+    expect(meta.currentPresetMeta.id).toBe(document.meta.id);
+    expect(meta.currentKitMeta.id).toBe("kit-0");
+    expect(meta.currentKitMeta.name).toBe("808");
+    expect(meta.cleanPreset?.meta.id).toBe(document.meta.id);
+    expect(meta.cleanPreset?.kit.instruments).toBe(instruments);
+  });
+
+  it("stops playback before committing (the kit swap reloads samples)", () => {
+    useTransportStore.setState({ isPlaying: true });
+    applyPresetDocument(migrateFixture("v1-current.json"));
+    expect(useTransportStore.getState().isPlaying).toBe(false);
+    expect(engineMock.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("derives the initial variation from chain step 0 (decision 7)", () => {
+    const base = migrateFixture("v1-current.json");
+    const document: PresetDocument = {
+      ...base,
+      playback: {
+        chain: {
+          steps: [
+            { variation: 2, repeats: 2 },
+            { variation: 1, repeats: 1 },
+          ],
+        },
+        chainEnabled: true,
+      },
+    };
+    applyPresetDocument(document);
+
+    const pattern = usePatternStore.getState();
+    expect(pattern.variation).toBe(2);
+    expect(pattern.chain).toEqual(document.playback.chain);
+    expect(pattern.chainEnabled).toBe(true);
+  });
+
+  it("registers a non-factory preset in the library exactly once", () => {
+    const base = migrateFixture("v1-current.json");
+    const document: PresetDocument = {
+      ...base,
+      meta: { ...base.meta, id: "custom-apply-test", name: "Custom" },
+    };
+    applyPresetDocument(document);
+    applyPresetDocument(document);
+
+    const { customPresets } = usePresetMetaStore.getState();
+    expect(customPresets).toHaveLength(1);
+    expect(customPresets[0].meta.id).toBe("custom-apply-test");
+  });
+
+  it("does not add factory presets to the library", () => {
+    // v1-current.json carries the init preset's factory id.
+    applyPresetDocument(migrateFixture("v1-current.json"));
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(0);
+  });
+
+  it("leaves every store untouched when the kit id is unknown", () => {
+    useTransportStore.setState({ isPlaying: true });
+    const before = snapshotStores();
+
+    const orphaned: PresetDocument = {
+      ...migrateFixture("v1-current.json"),
+      kit: { id: "kit-404" },
+    };
+    expect(() => applyPresetDocument(orphaned)).toThrow(UnknownKitError);
+
+    expect(snapshotStores()).toEqual(before);
+    // Conversion failed before the commit phase: playback was not stopped.
+    expect(engineMock.stop).not.toHaveBeenCalled();
+  });
+});
+
+describe("dirty-detection invariant", () => {
+  // The store payloads and the cleanPreset baseline are fields of ONE
+  // documentToV1 result, so hasUnsavedChanges() (a JSON comparison of a
+  // fresh knob-space store read against cleanPreset) must be false the
+  // instant a preset finishes loading. Two separate conversions could
+  // disagree in float noise; this pins that they never diverge.
+  it.each(ERA_FIXTURES)("%s loads clean through the v1 import path", (name) => {
+    applyPresetDocument(migrateFixture(name));
+    expect(usePresetMetaStore.getState().hasUnsavedChanges()).toBe(false);
+  });
+
+  it.each(ERA_FIXTURES)(
+    "%s loads clean through the v2 import path (decode of encoded text)",
+    (name) => {
+      const document = decodePresetFileText(
+        encodePresetDocument(migrateFixture(name)),
+      );
+      applyPresetDocument(document);
+      expect(usePresetMetaStore.getState().hasUnsavedChanges()).toBe(false);
+    },
+  );
+
+  it("still detects edits made after the load (not vacuously clean)", () => {
+    applyPresetDocument(migrateFixture("v1-current.json"));
+    expect(usePresetMetaStore.getState().hasUnsavedChanges()).toBe(false);
+
+    useTransportStore.getState().setBpm(133);
+    expect(usePresetMetaStore.getState().hasUnsavedChanges()).toBe(true);
+  });
+});

--- a/src/features/preset/document/apply.ts
+++ b/src/features/preset/document/apply.ts
@@ -1,0 +1,89 @@
+/**
+ * The commit half of the preset pipeline: apply a decoded, migrated,
+ * validated preset document to every store in one pass
+ * (docs/preset-persistence.md, "The pipeline and its two halves").
+ *
+ * A plain function over store.getState() actions rather than hook
+ * selectors, so it is callable outside React (boot restore, tests).
+ *
+ * Deliberately not exported from the document barrel (see index.ts): this
+ * module pulls in the stores, whose import graph reaches back into
+ * @/core/dh and would cycle through the barrel.
+ */
+
+import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
+import { useMasterChainStore } from "@/features/master-bus/store/use-master-chain-store";
+import { getDefaultPresets } from "@/features/preset/lib/constants";
+import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
+import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
+import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import type { PresetDocument } from "./document";
+import { documentToV1 } from "./to-v1";
+
+/**
+ * Commit a preset document to the stores, all-or-nothing.
+ *
+ * @throws {UnknownKitError} If the document's kit id does not resolve in
+ * the registry; nothing has been written when this fires
+ */
+function applyPresetDocument(document: PresetDocument): void {
+  // Conversion phase: every store payload is derived up front (registry kit
+  // rehydration plus the domain-to-knob inverses, all inside documentToV1),
+  // so a failure throws before the first store write and the session is
+  // untouched.
+  //
+  // DIRTY-DETECTION INVARIANT: the store payloads and the cleanPreset
+  // baseline must all be fields of this ONE documentToV1 result.
+  // hasUnsavedChanges() JSON-compares getCurrentPreset() (fresh store
+  // reads, knob space) against cleanPreset, so committing a second,
+  // separately converted object could differ in float noise and make a
+  // just-loaded preset read as dirty.
+  const file = documentToV1(document);
+
+  // Decision 7: the selected A/B/C/D pad is performance state, not preset
+  // state; the initial selection derives from the chain's entry point.
+  const initialVariation = document.playback.chain.steps[0]?.variation ?? 0;
+
+  const isCustomPreset = !getDefaultPresets().some(
+    (preset) => preset.meta.id === file.meta.id,
+  );
+
+  // Commit phase: the same setters in the same order as the legacy
+  // loadPreset; the bridge's push order to the engine depends on it.
+
+  // Stop playback first: committing instruments below kicks off the async
+  // engine kit reload (samples will reload).
+  const transport = useTransportStore.getState();
+  if (transport.isPlaying) {
+    void transport.togglePlay();
+  }
+
+  // Add to custom presets if not a default preset
+  const presetMeta = usePresetMetaStore.getState();
+  if (isCustomPreset) {
+    presetMeta.addCustomPreset(file);
+  }
+
+  // Update metadata (also sets the cleanPreset dirty baseline)
+  presetMeta.loadPreset(file);
+
+  // Update sequencer
+  const pattern = usePatternStore.getState();
+  pattern.setVoiceMode(0);
+  pattern.setVariation(initialVariation);
+  pattern.setPattern(document.pattern);
+  pattern.setChain(document.playback.chain);
+  pattern.setChainEnabled(document.playback.chainEnabled);
+
+  // Update transport
+  transport.setBpm(file.transport.bpm);
+  transport.setSwing(file.transport.swing);
+
+  // Update master chain
+  useMasterChainStore.getState().setAllMasterChain(file.masterChain);
+
+  // Update instruments last (triggers the audio engine kit reload)
+  useInstrumentsStore.getState().setAllInstruments(file.kit.instruments);
+}
+
+export { applyPresetDocument };

--- a/src/features/preset/document/index.ts
+++ b/src/features/preset/document/index.ts
@@ -1,3 +1,9 @@
+// apply.ts and snapshot.ts are deliberately NOT re-exported here: both pull
+// in the Zustand stores, whose import graph reaches @/core/dh, which imports
+// this barrel. Surfacing them here would create an import cycle crossing
+// module-scope side effects (the preset-meta store calls init() at module
+// evaluation). Import them directly from
+// "@/features/preset/document/apply" and "@/features/preset/document/snapshot".
 export {
   PRESET_DOCUMENT_KIND,
   PRESET_DOCUMENT_VERSION,

--- a/src/features/preset/document/snapshot.ts
+++ b/src/features/preset/document/snapshot.ts
@@ -1,0 +1,40 @@
+/**
+ * The egress half of the preset pipeline: snapshot the live stores as a v2
+ * preset document (docs/preset-persistence.md, "The pipeline and its two
+ * halves": every egress is snapshot() -> encode).
+ *
+ * DELIBERATE DEVIATION from the design doc's PR 3 line ("replace
+ * getCurrentPreset with snapshot() everywhere"): save, share, and dirty
+ * detection keep reading the stores in knob space via getCurrentPreset()
+ * until PR 5 lands document-hash dirty tracking. Deriving those paths
+ * through knob -> domain -> knob would introduce float noise into the
+ * JSON-equality dirty comparison in hasUnsavedChanges(). Only the .dh
+ * export egress flows through here for now.
+ *
+ * Deliberately not exported from the document barrel (see index.ts): this
+ * module reads the stores via lib/helpers, whose import graph reaches back
+ * into the barrel.
+ */
+
+import { getCurrentPreset } from "@/features/preset/lib/helpers";
+import type { Meta } from "@/features/preset/types/meta";
+import type { PresetDocument } from "./document";
+import { migrateV1ToDocument } from "./migrate-v1";
+
+/**
+ * Snapshot the current store state as a preset document: the knob-space
+ * cross-store read (getCurrentPreset) crossed to domain units once, via the
+ * same migration every other ingress uses.
+ *
+ * @param presetMeta - Identity for the snapshot (minted fresh by exports)
+ * @param kitMeta - The current kit's metadata; its id must resolve in the
+ * registry
+ */
+function snapshotPresetDocument(
+  presetMeta: Meta,
+  kitMeta: Meta,
+): PresetDocument {
+  return migrateV1ToDocument(getCurrentPreset(presetMeta, kitMeta));
+}
+
+export { snapshotPresetDocument };

--- a/src/features/preset/hooks/use-preset-loading.test.ts
+++ b/src/features/preset/hooks/use-preset-loading.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Entry-point integration tests for the preset load boundary in
+ * use-preset-loading.ts. The module-level functions under test are exactly
+ * what the hook binds to the toast context, so these exercise the real
+ * decode -> apply path (file import) and validate -> migrate -> apply path
+ * (library select) with a mock toast, without rendering React.
+ *
+ * The engine module is mocked so the suite runs in the node project.
+ */
+
+import { readFileSync } from "node:fs";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PresetFileV1 } from "@/features/preset/types/preset";
+
+const engineMock = vi.hoisted(() => ({
+  play: vi.fn<() => Promise<void>>(() => Promise.resolve()),
+  stop: vi.fn(),
+  setTempo: vi.fn(),
+  setSwing: vi.fn(),
+}));
+
+vi.mock("@/core/audio/engine", () => ({
+  getAudioEngine: () => engineMock,
+}));
+
+// Store-adjacent modules are imported dynamically in beforeAll, after the
+// localStorage stub is in place for zustand's persist middleware.
+let init: typeof import("@/core/dh").init;
+let encodePresetDocument: typeof import("@/features/preset/document").encodePresetDocument;
+let migrateV1ToDocument: typeof import("@/features/preset/document").migrateV1ToDocument;
+let parsePresetFileV1: typeof import("@/features/preset/document").parsePresetFileV1;
+let loadPresetFile: typeof import("./use-preset-loading").loadPresetFile;
+let loadPresetFileText: typeof import("./use-preset-loading").loadPresetFileText;
+let useInstrumentsStore: typeof import("@/features/instrument/store/use-instruments-store").useInstrumentsStore;
+let useMasterChainStore: typeof import("@/features/master-bus/store/use-master-chain-store").useMasterChainStore;
+let usePresetMetaStore: typeof import("@/features/preset/store/use-preset-meta-store").usePresetMetaStore;
+let usePatternStore: typeof import("@/features/sequencer/store/use-pattern-store").usePatternStore;
+let useTransportStore: typeof import("@/features/transport/store/use-transport-store").useTransportStore;
+
+function readFixture(name: string): string {
+  return readFileSync(
+    new URL(`../document/__fixtures__/${name}`, import.meta.url),
+    "utf-8",
+  );
+}
+
+/** The musical store surface, as data (for untouched-stores comparisons). */
+function snapshotStores() {
+  const pattern = usePatternStore.getState();
+  const transport = useTransportStore.getState();
+  const master = useMasterChainStore.getState();
+  const meta = usePresetMetaStore.getState();
+  return {
+    instruments: useInstrumentsStore.getState().instruments,
+    pattern: pattern.pattern,
+    variation: pattern.variation,
+    chain: pattern.chain,
+    chainEnabled: pattern.chainEnabled,
+    bpm: transport.bpm,
+    swing: transport.swing,
+    master: {
+      filter: master.filter,
+      saturation: master.saturation,
+      phaser: master.phaser,
+      reverb: master.reverb,
+      compThreshold: master.compThreshold,
+      compRatio: master.compRatio,
+      compAttack: master.compAttack,
+      compMix: master.compMix,
+      masterVolume: master.masterVolume,
+    },
+    currentPresetMeta: meta.currentPresetMeta,
+    currentKitMeta: meta.currentKitMeta,
+    cleanPreset: meta.cleanPreset,
+    customPresets: meta.customPresets,
+  };
+}
+
+type StoreSnapshot = ReturnType<typeof snapshotStores>;
+let defaults: StoreSnapshot;
+
+beforeAll(async () => {
+  vi.stubGlobal("localStorage", {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  });
+
+  ({ init } = await import("@/core/dh"));
+  ({ encodePresetDocument, migrateV1ToDocument, parsePresetFileV1 } =
+    await import("@/features/preset/document"));
+  ({ loadPresetFile, loadPresetFileText } =
+    await import("./use-preset-loading"));
+  ({ useInstrumentsStore } =
+    await import("@/features/instrument/store/use-instruments-store"));
+  ({ useMasterChainStore } =
+    await import("@/features/master-bus/store/use-master-chain-store"));
+  ({ usePresetMetaStore } =
+    await import("@/features/preset/store/use-preset-meta-store"));
+  ({ usePatternStore } =
+    await import("@/features/sequencer/store/use-pattern-store"));
+  ({ useTransportStore } =
+    await import("@/features/transport/store/use-transport-store"));
+
+  defaults = snapshotStores();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useInstrumentsStore.setState({ instruments: defaults.instruments });
+  usePatternStore.setState({
+    pattern: defaults.pattern,
+    variation: defaults.variation,
+    chain: defaults.chain,
+    chainEnabled: defaults.chainEnabled,
+  });
+  useTransportStore.setState({
+    isPlaying: false,
+    bpm: defaults.bpm,
+    swing: defaults.swing,
+  });
+  useMasterChainStore.setState(defaults.master);
+  usePresetMetaStore.setState({
+    currentPresetMeta: defaults.currentPresetMeta,
+    currentKitMeta: defaults.currentKitMeta,
+    cleanPreset: defaults.cleanPreset,
+    customPresets: defaults.customPresets,
+  });
+});
+
+describe("file import entry point (loadPresetFileText)", () => {
+  it("loads v2 .dh text through decode -> apply, ending with stores matching the document", () => {
+    const document = migrateV1ToDocument(
+      parsePresetFileV1(readFixture("v1-legacy-master.json")),
+    );
+    const text = encodePresetDocument(document);
+    const toast = vi.fn();
+
+    const loaded = loadPresetFileText(text, toast);
+
+    expect(loaded).toEqual(document);
+    expect(toast).not.toHaveBeenCalled();
+
+    expect(usePatternStore.getState().pattern).toEqual(document.pattern);
+    expect(usePatternStore.getState().chain).toEqual(document.playback.chain);
+    expect(useTransportStore.getState().bpm).toBe(document.transport.bpm);
+    expect(usePresetMetaStore.getState().currentPresetMeta.id).toBe(
+      document.meta.id,
+    );
+    expect(usePresetMetaStore.getState().currentKitMeta.id).toBe(
+      document.kit.id,
+    );
+    // The freshly imported preset starts clean.
+    expect(usePresetMetaStore.getState().hasUnsavedChanges()).toBe(false);
+  });
+
+  it("toasts the typed error for unreadable text without mutating stores", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const before = snapshotStores();
+    const toast = vi.fn();
+
+    const loaded = loadPresetFileText("not json at all", toast);
+
+    expect(loaded).toBeNull();
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith({
+      title: "Something went wrong",
+      description: "Invalid preset file: not valid JSON",
+      status: "error",
+      duration: 8000,
+    });
+    expect(snapshotStores()).toEqual(before);
+    consoleError.mockRestore();
+  });
+});
+
+describe("library select entry point (loadPresetFile)", () => {
+  it("surfaces a typed error as a toast without mutating stores for a corrupt v1 object", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    // A library entry persisted verbatim in localStorage, damaged in place.
+    const corrupt = JSON.parse(JSON.stringify(init())) as Record<
+      string,
+      { bpm: unknown }
+    >;
+    corrupt.transport.bpm = "fast";
+
+    const before = snapshotStores();
+    const toast = vi.fn();
+
+    const loaded = loadPresetFile(corrupt as unknown as PresetFileV1, toast);
+
+    expect(loaded).toBeNull();
+    expect(toast).toHaveBeenCalledTimes(1);
+    const toastArgs = toast.mock.calls[0][0] as {
+      title: string;
+      description: string;
+      status: string;
+    };
+    expect(toastArgs.title).toBe("Something went wrong");
+    expect(toastArgs.status).toBe("error");
+    // CorruptFieldError carries the offending dot path.
+    expect(toastArgs.description).toContain("transport.bpm");
+
+    // The throw happened before the first store write.
+    expect(snapshotStores()).toEqual(before);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("loads a valid v1 library object through validate -> migrate -> apply", () => {
+    const preset = init();
+    const toast = vi.fn();
+
+    const loaded = loadPresetFile(preset, toast);
+
+    expect(loaded).not.toBeNull();
+    expect(toast).not.toHaveBeenCalled();
+    expect(usePresetMetaStore.getState().currentPresetMeta.id).toBe(
+      preset.meta.id,
+    );
+    expect(useTransportStore.getState().bpm).toBe(preset.transport.bpm);
+    expect(usePresetMetaStore.getState().hasUnsavedChanges()).toBe(false);
+  });
+});

--- a/src/features/preset/hooks/use-preset-loading.ts
+++ b/src/features/preset/hooks/use-preset-loading.ts
@@ -1,32 +1,93 @@
 import { useCallback, useEffect, useRef } from "react";
 
-import {
-  DEFAULT_CHAIN,
-  sanitizeChain,
-} from "@/core/audio/engine/pattern-types";
 import { init } from "@/core/dh";
-import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
-import { useMasterChainStore } from "@/features/master-bus/store/use-master-chain-store";
-import { migratePresetFileVersion } from "@/features/preset/document";
-import { getDefaultPresets } from "@/features/preset/lib/constants";
-import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
-import type { PresetFileV1 } from "@/features/preset/types/preset";
-import { legacyCycleToChain } from "@/features/sequencer/lib/chain";
 import {
-  migrateInstruments,
-  migrateMasterChainParams,
-  migratePattern,
-} from "@/features/sequencer/lib/migrations";
-import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
-import { useTransportStore } from "@/features/transport/store/use-transport-store";
-import { useToast } from "@/shared/ui";
+  decodePresetFileText,
+  migrateV1ToDocument,
+  validatePresetFileV1,
+  type PresetDocument,
+} from "@/features/preset/document";
+import { applyPresetDocument } from "@/features/preset/document/apply";
+import type { PresetFileV1 } from "@/features/preset/types/preset";
+import { useToast, type ToastContextValue } from "@/shared/ui";
 
-interface UsePresetLoadingResult {
-  loadPreset: (preset: PresetFileV1) => void;
+type ShowToast = ToastContextValue["toast"];
+
+/**
+ * Map a preset-pipeline failure to its user-facing toast. Typed
+ * PresetDocumentErrors carry user-facing messages (document/errors.ts);
+ * anything else falls back to generic copy.
+ */
+function showPresetLoadErrorToast(toast: ShowToast, error: unknown): void {
+  console.error("Failed to load preset:", error);
+  toast({
+    title: "Something went wrong",
+    description:
+      error instanceof Error
+        ? error.message
+        : "Couldn't open file. It may be invalid or corrupted.",
+    status: "error",
+    duration: 8000,
+  });
 }
 
 /**
- * Loads a preset and updates all stores
+ * The single error boundary for every preset ingress. `produce` runs the
+ * decode/migrate/validate half of the pipeline, so any failure (invalid
+ * file, unsupported version, corrupt field, unknown kit) throws before
+ * applyPresetDocument writes the first store: a rejected preset leaves the
+ * session exactly as it was.
+ */
+function loadPresetDocument(
+  produce: () => PresetDocument,
+  onError: (error: unknown) => void,
+): PresetDocument | null {
+  try {
+    const document = produce();
+    applyPresetDocument(document);
+    return document;
+  } catch (error) {
+    onError(error);
+    return null;
+  }
+}
+
+/**
+ * Load a knob-space (v1-family) preset object: library selections, the
+ * delete fallback, the boot default, and post-save reloads. Library entries
+ * are persisted verbatim in localStorage (until PR 6) and can still be
+ * version 1 or corrupt, so they run the same validate -> migrate ladder as
+ * imported file text before apply.
+ */
+function loadPresetFile(
+  preset: PresetFileV1,
+  toast: ShowToast,
+): PresetDocument | null {
+  return loadPresetDocument(
+    () => migrateV1ToDocument(validatePresetFileV1(preset)),
+    (error) => showPresetLoadErrorToast(toast, error),
+  );
+}
+
+/** Load raw `.dh` file text (file import): decode -> apply. */
+function loadPresetFileText(
+  text: string,
+  toast: ShowToast,
+): PresetDocument | null {
+  return loadPresetDocument(
+    () => decodePresetFileText(text),
+    (error) => showPresetLoadErrorToast(toast, error),
+  );
+}
+
+interface UsePresetLoadingResult {
+  loadPresetFile: (preset: PresetFileV1) => void;
+  loadPresetFileText: (text: string) => PresetDocument | null;
+}
+
+/**
+ * Loads presets through the document pipeline
+ * (decode -> migrate -> validate -> apply) and updates all stores
  *
  * Low-level: handles audio engine, playback stopping, store updates
  */
@@ -35,27 +96,17 @@ function usePresetLoading(): UsePresetLoadingResult {
 
   const hasLoadedFromUrlRef = useRef(false);
 
-  const isPlaying = useTransportStore((state) => state.isPlaying);
-  const togglePlay = useTransportStore((state) => state.togglePlay);
-  const setBpm = useTransportStore((state) => state.setBpm);
-  const setSwing = useTransportStore((state) => state.setSwing);
-
-  const setAllInstruments = useInstrumentsStore(
-    (state) => state.setAllInstruments,
+  const loadFile = useCallback(
+    (preset: PresetFileV1) => {
+      loadPresetFile(preset, toast);
+    },
+    [toast],
   );
 
-  const setVoiceMode = usePatternStore((state) => state.setVoiceMode);
-  const setVariation = usePatternStore((state) => state.setVariation);
-  const setPattern = usePatternStore((state) => state.setPattern);
-  const setChain = usePatternStore((state) => state.setChain);
-  const setChainEnabled = usePatternStore((state) => state.setChainEnabled);
-
-  const setAllMasterChain = useMasterChainStore(
-    (state) => state.setAllMasterChain,
+  const loadFileText = useCallback(
+    (text: string) => loadPresetFileText(text, toast),
+    [toast],
   );
-
-  const loadPresetMeta = usePresetMetaStore((state) => state.loadPreset);
-  const addCustomPreset = usePresetMetaStore((state) => state.addCustomPreset);
 
   const showSharedPresetToast = useCallback(
     (presetName: string) => {
@@ -74,78 +125,6 @@ function usePresetLoading(): UsePresetLoadingResult {
       duration: 8000,
     });
   }, [toast]);
-
-  const loadPreset = useCallback(
-    (rawPreset: PresetFileV1) => {
-      // Normalize the file version first (idempotent): file imports and
-      // share URLs arrive already normalized via validatePresetFileV1, but
-      // library presets persisted verbatim in localStorage can still be
-      // version 1 and need the #269 swing knob migration.
-      const preset = migratePresetFileVersion(rawPreset);
-
-      // Stop playback if currently playing (samples will reload)
-      if (isPlaying) {
-        void togglePlay();
-      }
-
-      // Add to custom presets if not a default preset
-      const defaultPresets = getDefaultPresets();
-      const isCustomPreset = !defaultPresets.some(
-        (p) => p.meta.id === preset.meta.id,
-      );
-      if (isCustomPreset) {
-        addCustomPreset(preset);
-      }
-
-      // Update metadata
-      loadPresetMeta(preset);
-
-      // Update sequencer
-      setVoiceMode(0);
-      const migratedPattern = migratePattern(preset.sequencer.pattern);
-      const legacyCycle = legacyCycleToChain(
-        preset.sequencer.variationCycle,
-        0,
-      );
-      const chain = sanitizeChain(
-        preset.sequencer.chain ?? legacyCycle.chain ?? DEFAULT_CHAIN,
-      );
-      const initialVariation =
-        chain.steps[0]?.variation ?? legacyCycle.variation ?? 0;
-
-      setVariation(initialVariation);
-      setPattern(migratedPattern);
-      setChain(chain);
-      setChainEnabled(
-        preset.sequencer.chainEnabled ?? legacyCycle.chainEnabled ?? false,
-      );
-
-      // Update transport
-      setBpm(preset.transport.bpm);
-      setSwing(preset.transport.swing);
-
-      // Update master chain (with migration for legacy formats)
-      setAllMasterChain(migrateMasterChainParams(preset.masterChain));
-
-      // Update instruments (triggers audio engine reload) w/ migration for legacy presets
-      setAllInstruments(migrateInstruments(preset.kit.instruments));
-    },
-    [
-      isPlaying,
-      addCustomPreset,
-      loadPresetMeta,
-      setAllInstruments,
-      setAllMasterChain,
-      setBpm,
-      setPattern,
-      setSwing,
-      setChain,
-      setChainEnabled,
-      setVariation,
-      setVoiceMode,
-      togglePlay,
-    ],
-  );
 
   const loadFromUrlOrDefault = useCallback(async () => {
     // Prevent duplicate execution
@@ -168,7 +147,7 @@ function usePresetLoading(): UsePresetLoadingResult {
 
       if (!hasPersistedData) {
         // No persisted data, load default init preset
-        loadPreset(init());
+        loadFile(init());
       }
       hasLoadedFromUrlRef.current = true;
       return;
@@ -177,18 +156,30 @@ function usePresetLoading(): UsePresetLoadingResult {
     // Mark as loaded before async operations to prevent race conditions
     hasLoadedFromUrlRef.current = true;
 
+    const onSharedPresetError = (error: unknown) => {
+      console.error("Failed to load shared preset:", error);
+      showSharedPresetErrorToast();
+      loadFile(init());
+    };
+
     try {
       const { urlToPreset } =
         await import("@/features/preset/lib/serialization");
+      // The compact decoder still emits a knob-space v1.5 file (PR 4 moves
+      // it onto the document); it joins the pipeline at the same
+      // validate -> migrate rung as library presets.
       const preset = urlToPreset(presetParam);
-      loadPreset(preset);
-
-      showSharedPresetToast(preset.meta.name);
+      const document = loadPresetDocument(
+        () => migrateV1ToDocument(validatePresetFileV1(preset)),
+        onSharedPresetError,
+      );
+      if (document !== null) {
+        showSharedPresetToast(document.meta.name);
+      }
     } catch (error) {
-      console.error("Failed to load shared preset:", error);
-
-      showSharedPresetErrorToast();
-      loadPreset(init());
+      // urlToPreset itself rejected the link (legacy compact codec, outside
+      // the document pipeline).
+      onSharedPresetError(error);
     } finally {
       // Remove URL parameters after loading preset
       const url = new URL(window.location.href);
@@ -196,14 +187,20 @@ function usePresetLoading(): UsePresetLoadingResult {
       url.searchParams.delete("n");
       window.history.replaceState({}, "", url.toString());
     }
-  }, [loadPreset, showSharedPresetErrorToast, showSharedPresetToast]);
+  }, [loadFile, showSharedPresetErrorToast, showSharedPresetToast]);
 
   // Load initial preset on mount
   useEffect(() => {
     void loadFromUrlOrDefault();
   }, [loadFromUrlOrDefault]);
 
-  return { loadPreset };
+  return { loadPresetFile: loadFile, loadPresetFileText: loadFileText };
 }
 
-export { usePresetLoading };
+export {
+  usePresetLoading,
+  loadPresetDocument,
+  loadPresetFile,
+  loadPresetFileText,
+};
+export type { UsePresetLoadingResult };

--- a/src/features/preset/hooks/use-preset-manager.ts
+++ b/src/features/preset/hooks/use-preset-manager.ts
@@ -4,12 +4,12 @@ import { init } from "@/core/dh";
 import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
 import { getAllKits } from "@/features/kit/lib/constants";
 import { KitFileV1 } from "@/features/kit/types/kit";
+import type { PresetDocument } from "@/features/preset/document";
 import { getDefaultPresets } from "@/features/preset/lib/constants";
 import {
   createPresetForExport,
   downloadPreset,
   generateShareUrl,
-  parsePresetFile,
 } from "@/features/preset/lib/operations";
 import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
@@ -18,13 +18,15 @@ import { useToast } from "@/shared/ui";
 
 interface UsePresetManagerProps {
   /**
-   * Load preset function from usePresetLoading
-   * This orchestrates updating all stores and stopping playback
+   * Preset loaders from usePresetLoading: the document pipeline entry
+   * points (decode/migrate/validate -> apply), which orchestrate updating
+   * all stores, stopping playback, and the shared error boundary.
    *
-   * Externalized because it depends on instrument runtimes and
-   * is defined in usePresetLoading hook.
+   * Externalized because they depend on instrument runtimes and
+   * are defined in usePresetLoading hook.
    */
-  loadPreset: (preset: PresetFileV1) => void;
+  loadPresetFile: (preset: PresetFileV1) => void;
+  loadPresetFileText: (text: string) => PresetDocument | null;
 }
 
 interface UsePresetManagerResult {
@@ -59,7 +61,8 @@ interface UsePresetManagerResult {
  * low level runtime updates
  */
 function usePresetManager({
-  loadPreset,
+  loadPresetFile,
+  loadPresetFileText,
 }: UsePresetManagerProps): UsePresetManagerResult {
   const { toast } = useToast();
 
@@ -145,9 +148,9 @@ function usePresetManager({
         return;
       }
 
-      loadPreset(preset);
+      loadPresetFile(preset);
     },
-    [hasUnsavedChanges, allPresets, loadPreset, openDialog],
+    [hasUnsavedChanges, allPresets, loadPresetFile, openDialog],
   );
 
   // --- File Operations ---
@@ -164,9 +167,9 @@ function usePresetManager({
 
       // Update state
       markPresetClean(preset);
-      loadPreset(preset);
+      loadPresetFile(preset);
     },
-    [currentKitMeta, markPresetClean, loadPreset],
+    [currentKitMeta, markPresetClean, loadPresetFile],
   );
 
   /**
@@ -207,31 +210,28 @@ function usePresetManager({
 
       const reader = new FileReader();
       reader.onload = (e) => {
-        try {
-          const result = e.target?.result;
-          if (typeof result !== "string") throw new Error("Invalid file");
-
-          const preset = parsePresetFile(result);
-          loadPreset(preset);
-          toast({
-            title: "Preset loaded",
-            description: preset.meta.name,
-            status: "success",
-          });
-        } catch (error) {
-          console.error("Failed to import preset:", error);
+        const result = e.target?.result;
+        if (typeof result !== "string") {
           toast({
             title: "Something went wrong",
-            description:
-              error instanceof Error
-                ? error.message
-                : "Couldn't open file. It may be invalid or corrupted.",
+            description: "There was a problem reading the file.",
             status: "error",
             duration: 8000,
           });
-        } finally {
           cleanup();
+          return;
         }
+
+        // The pipeline's shared error boundary toasts on failure.
+        const loaded = loadPresetFileText(result);
+        if (loaded !== null) {
+          toast({
+            title: "Preset loaded",
+            description: loaded.meta.name,
+            status: "success",
+          });
+        }
+        cleanup();
       };
       reader.onerror = () => {
         toast({
@@ -247,7 +247,7 @@ function usePresetManager({
     input.onerror = cleanup;
     document.body.appendChild(input);
     input.click();
-  }, [loadPreset, toast]);
+  }, [loadPresetFileText, toast]);
 
   // --- PRESET MANAGEMENT ---
 
@@ -271,7 +271,7 @@ function usePresetManager({
         const newPreset = saveCurrentAsNewPreset(name);
         if (newPreset) {
           markPresetClean(newPreset);
-          loadPreset(newPreset);
+          loadPresetFile(newPreset);
           toast({
             title: "Preset saved",
             description: name,
@@ -293,7 +293,7 @@ function usePresetManager({
       updateCustomPreset,
       saveCurrentAsNewPreset,
       markPresetClean,
-      loadPreset,
+      loadPresetFile,
       toast,
     ],
   );
@@ -346,7 +346,7 @@ function usePresetManager({
       deleteCustomPreset(id);
 
       if (isDeletingCurrent) {
-        loadPreset(init());
+        loadPresetFile(init());
         toast({
           title: "Preset deleted",
           description: "Loaded default preset",
@@ -359,7 +359,7 @@ function usePresetManager({
         });
       }
     },
-    [deleteCustomPreset, currentPresetMeta.id, loadPreset, toast],
+    [deleteCustomPreset, currentPresetMeta.id, loadPresetFile, toast],
   );
 
   // Computed values

--- a/src/features/preset/lib/operations.test.ts
+++ b/src/features/preset/lib/operations.test.ts
@@ -1,134 +1,57 @@
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   encodePresetDocument,
   migrateV1ToDocument,
-  parsePresetFileV1,
-  UnsupportedVersionError,
-  validatePresetFileV1,
 } from "@/features/preset/document";
-import { createPresetExportBlob, parsePresetFile } from "./operations";
+import type { Meta } from "@/features/preset/types/meta";
+import { getCurrentPreset } from "./helpers";
+import { createPresetExportBlob } from "./operations";
 
-function readFixture(name: string): string {
-  return readFileSync(
-    new URL(`../document/__fixtures__/${name}`, import.meta.url),
-    "utf-8",
-  );
-}
-
-const ERA_FIXTURES = [
-  "v1-current.json",
-  "v1-legacy-params.json",
-  "v1-legacy-master.json",
-  "v1-legacy-cycle.json",
-  "v1-legacy-pattern-array.json",
-];
-
-const NUMERIC_EPSILON = 1e-6;
-
-/**
- * Deep equality with a numeric tolerance (mirrors to-v1.test.ts): the
- * document -> v1 -> document trip crosses the inverse knob mappings, which
- * introduce float noise well under 1e-6; anything larger is a real loss.
- */
-function expectDeepClose(actual: unknown, expected: unknown, path: string) {
-  if (typeof expected === "number") {
-    expect(typeof actual, path).toBe("number");
-    expect(Math.abs((actual as number) - expected), path).toBeLessThanOrEqual(
-      NUMERIC_EPSILON,
-    );
-    return;
-  }
-  if (Array.isArray(expected)) {
-    expect(Array.isArray(actual), path).toBe(true);
-    expect((actual as unknown[]).length, path).toBe(expected.length);
-    expected.forEach((item, index) => {
-      expectDeepClose((actual as unknown[])[index], item, `${path}[${index}]`);
-    });
-    return;
-  }
-  if (typeof expected === "object" && expected !== null) {
-    expect(typeof actual, path).toBe("object");
-    expect(actual, path).not.toBeNull();
-    const expectedKeys = Object.keys(expected).sort();
-    expect(Object.keys(actual as object).sort(), path).toEqual(expectedKeys);
-    for (const key of expectedKeys) {
-      expectDeepClose(
-        (actual as Record<string, unknown>)[key],
-        (expected as Record<string, unknown>)[key],
-        `${path}.${key}`,
-      );
-    }
-    return;
-  }
-  expect(actual, path).toBe(expected);
-}
-
-describe("parsePresetFile on v1 files", () => {
-  // Byte-identical legacy behavior: the dispatcher must return exactly what
-  // the legacy parser returns, with no migration or normalization.
-  it.each(ERA_FIXTURES)("%s matches parsePresetFileV1 exactly", (name) => {
-    const text = readFixture(name);
-    expect(parsePresetFile(text)).toEqual(parsePresetFileV1(text));
-  });
+// Store reads happen twice (once inside the blob, once for the expected
+// value); freezing time keeps the stamped meta.updatedAt identical.
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-14T12:00:00.000Z"));
 });
 
-describe("parsePresetFile on v2 files", () => {
-  it.each(ERA_FIXTURES)(
-    "%s (encoded as v2) adapts to a valid v1 that re-migrates losslessly",
-    (name) => {
-      const document = migrateV1ToDocument(
-        parsePresetFileV1(readFixture(name)),
-      );
-      const asV1 = parsePresetFile(encodePresetDocument(document));
-
-      const validated = validatePresetFileV1(asV1);
-      expect(validated.kind).toBe("drumhaus.preset");
-      expect(validated.version).toBe(1.5);
-
-      expectDeepClose(migrateV1ToDocument(asV1), document, "document");
-    },
-  );
-
-  it("refuses a version 3 file", () => {
-    const raw = JSON.parse(readFixture("v1-current.json")) as Record<
-      string,
-      unknown
-    >;
-    raw.version = 3;
-    expect(() => parsePresetFile(JSON.stringify(raw))).toThrow(
-      UnsupportedVersionError,
-    );
-  });
+afterEach(() => {
+  vi.useRealTimers();
 });
 
-describe("export-import loop", () => {
-  // fixture -> import -> export (migrate + encode, exactly the .dh payload)
-  // -> import -> re-migrate: the second migration equals the first.
-  it.each(ERA_FIXTURES)("%s survives the full loop", (name) => {
-    const imported = parsePresetFile(readFixture(name));
-    const exportedText = encodePresetDocument(migrateV1ToDocument(imported));
-    const reimported = parsePresetFile(exportedText);
+const presetMeta: Meta = {
+  id: "export-test",
+  name: "Export Test",
+  createdAt: "2026-07-14T12:00:00.000Z",
+  updatedAt: "2026-07-14T12:00:00.000Z",
+};
 
-    expectDeepClose(
-      migrateV1ToDocument(reimported),
-      migrateV1ToDocument(imported),
-      "document",
-    );
-  });
+const kitMeta: Meta = {
+  id: "kit-0",
+  name: "808",
+  createdAt: "2023-11-20T16:00:00.000Z",
+  updatedAt: "2025-12-12T05:59:26.188Z",
+};
 
-  it("createPresetExportBlob writes the v2 document encoding", async () => {
-    const preset = parsePresetFileV1(readFixture("v1-current.json"));
-    const blob = createPresetExportBlob(preset);
+describe("createPresetExportBlob", () => {
+  // The .dh export egress: snapshot() -> encode. The blob must be exactly
+  // the v2 document encoding of the current store state.
+  it("writes the v2 document snapshot of the current stores", async () => {
+    const blob = createPresetExportBlob(presetMeta, kitMeta);
 
     expect(blob.type).toBe("application/octet-stream");
 
     const text = await blob.text();
-    expect(text).toBe(encodePresetDocument(migrateV1ToDocument(preset)));
+    expect(text).toBe(
+      encodePresetDocument(
+        migrateV1ToDocument(getCurrentPreset(presetMeta, kitMeta)),
+      ),
+    );
 
     const raw = JSON.parse(text) as Record<string, unknown>;
     expect(raw.kind).toBe("drumhaus.preset");
     expect(raw.version).toBe(2);
+    expect((raw.kit as { id: string }).id).toBe("kit-0");
+    expect((raw.meta as Meta).id).toBe("export-test");
   });
 });

--- a/src/features/preset/lib/operations.ts
+++ b/src/features/preset/lib/operations.ts
@@ -1,45 +1,9 @@
-import {
-  decodePresetFileText,
-  documentToV1,
-  encodePresetDocument,
-  migrateV1ToDocument,
-  parsePresetFileV1,
-  PRESET_DOCUMENT_VERSION,
-} from "@/features/preset/document";
+import { encodePresetDocument } from "@/features/preset/document";
+import { snapshotPresetDocument } from "@/features/preset/document/snapshot";
 import type { Meta } from "@/features/preset/types/meta";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
 import { MAX_PRESET_NAME_LENGTH } from "./constants";
 import { getCurrentPreset } from "./helpers";
-
-/**
- * Parse and validate a preset from a JSON string, dual-reading both file
- * versions: v2 documents are decoded and adapted to the v1 shape today's
- * loadPreset consumes, while v1 files keep flowing through the legacy parse
- * path untouched (the heuristic migrators inside loadPreset still normalize
- * them, exactly as before).
- * Throws a typed PresetDocumentError if the preset is invalid.
- */
-function parsePresetFile(jsonString: string): PresetFileV1 {
-  if (peekPresetVersion(jsonString) === PRESET_DOCUMENT_VERSION) {
-    return documentToV1(decodePresetFileText(jsonString));
-  }
-  return parsePresetFileV1(jsonString);
-}
-
-/**
- * Best-effort version peek for dispatch only; malformed text falls through
- * to the legacy parser, which raises the same typed errors it always has.
- */
-function peekPresetVersion(jsonString: string): unknown {
-  try {
-    const data: unknown = JSON.parse(jsonString);
-    return typeof data === "object" && data !== null
-      ? (data as { version?: unknown }).version
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 /**
  * Generate a shareable URL for a preset
@@ -84,7 +48,7 @@ function createPresetForExport(name: string, kitMeta: Meta): PresetFileV1 {
  * Download a preset as a .dh file
  */
 function downloadPreset(preset: PresetFileV1, name: string): void {
-  const blob = createPresetExportBlob(preset);
+  const blob = createPresetExportBlob(preset.meta, preset.kit.meta);
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
@@ -108,12 +72,14 @@ function normalizePresetName(name: string): string {
 }
 
 /**
- * Create a Blob for downloading a preset as a .dh file.
- * The payload is the v2 document encoding: exports write version 2
- * (decision 1), migrated from the store-shaped v1 snapshot.
+ * Create a Blob for downloading the current store state as a .dh file:
+ * the standard egress, snapshot() -> encode. The payload is the v2 document
+ * encoding: exports write version 2 (decision 1).
  */
-function createPresetExportBlob(preset: PresetFileV1): Blob {
-  const json = encodePresetDocument(migrateV1ToDocument(preset));
+function createPresetExportBlob(presetMeta: Meta, kitMeta: Meta): Blob {
+  const json = encodePresetDocument(
+    snapshotPresetDocument(presetMeta, kitMeta),
+  );
   // Use a generic binary MIME type so iOS Safari doesn't append ".json"
   // to the downloaded ".dh" file name.
   return new Blob([json], { type: "application/octet-stream" });
@@ -135,7 +101,6 @@ function toPresetSlug(name: string): string {
 }
 
 export {
-  parsePresetFile,
   generateShareUrl,
   createPresetForExport,
   createPresetExportBlob,


### PR DESCRIPTION
PR 3 of the preset-persistence plan (docs/preset-persistence.md, #329): the pipeline's two halves, one error boundary for every entry point, and kit-load failure surfacing (decision 5). The legacy loadPreset and its inline migrators retire from the hot path.

The pipeline (features/preset/document):

- applyPresetDocument: all conversion happens before the first store write - one documentToV1 call produces every store payload AND the cleanPreset dirty baseline, so a bad document throws with the session untouched, and hasUnsavedChanges() is false by construction after any load (the single-conversion invariant is documented in the code and pinned by tests across all five era fixtures via both v1 and v2 ingress). The commit phase replays the legacy setter sequence in the identical order the bridge's engine-push order depends on.
- snapshotPresetDocument formalizes the export path (getCurrentPreset -> migrateV1ToDocument); the .dh export blob now flows through it.
- One error boundary in use-preset-loading: file import, share URL, library select, delete-fallback, and boot default all route through the same typed-error handling with toasts. Library select previously had NO error handling (a corrupt entry crashed mid-load, leaving half-applied stores); it now validates and fails typed before any write.

Kit-load failure (decision 5, core/audio):

- engine.loadKit returns "loaded" | "superseded" | "failed" - return values only; the loadSeq token semantics, disposal order, and retained-descriptor rules are byte-identical and the golden render / kit-swap / rebuild suites pass unmodified.
- The bridge's kit subscription (extracted to kit-subscription.ts, mirroring the instrument-params pattern) rolls the instruments store back to the previous kit on failure and emits a bridge-level failure event; a reference-equality guard on the rolled-back array prevents two failing kits from ping-ponging (pinned by a test: exactly one rollback, one event, no loop).
- The failure event is deliberately bridge-level, not engine-level: "your kit change was rolled back, the previous kit is still active" is a bridge fact - an engine event would fire falsely during rebuild's internal kit reload. A small hook toasts the user; the UI never shows a kit the audio does not have.

One deliberate deviation from the doc's PR 3 line, noted in code comments: getCurrentPreset is NOT yet replaced by snapshot() for save/share/dirty. Deriving it via knob -> domain -> knob would inject float noise into the JSON-equality dirty check; the save-side switch lands with PR 5's document-hash dirty tracking, where the comparison is document-vs-document.

Behavior deltas, all intended: validation/migration now precede the playback stop (a bad preset no longer stops playback); corrupt library entries toast instead of crashing; reload-after-save can shift stored knob values by <1e-9 (invisible; dirty detection unaffected by construction).

Verification: 1038 vitest tests green across unit and browser projects, all 10 e2e specs green against a production build, oxlint clean, tsc clean, build clean.