### PR TITLE
feat(preset): per-preset library storage with adoption and quotas

### DIFF
--- a/e2e/library.spec.ts
+++ b/e2e/library.spec.ts
@@ -1,0 +1,273 @@
+import { readFileSync } from "node:fs";
+import { expect, test, type Page } from "@playwright/test";
+
+import { gotoApp, step, toggleStep, waitForAppReady } from "./helpers";
+
+/**
+ * Per-preset library storage (docs/preset-persistence.md, "Library storage:
+ * documents under per-preset keys", PR 6): saved presets are their own
+ * storage entries, hydrated synchronously at boot so a saved preset is in the
+ * select immediately after reload (no flash, no async fill racing first
+ * paint). Adoption migrates the legacy customPresets array into entries,
+ * backing it up and quarantining what fails to parse.
+ */
+
+const LEGACY_PRESET_META_KEY = "drumhaus-preset-meta-storage";
+const LIBRARY_BACKUP_KEY = "drumhaus-library-backup";
+const LIBRARY_INDEX_KEY = "drumhaus-preset-index";
+const LIBRARY_ENTRY_PREFIX = "drumhaus-preset-";
+const QUARANTINE_PREFIX = "drumhaus-preset-quarantine-";
+
+/**
+ * The preset select trigger, matched by its stable aria-label rather than the
+ * combobox role: opening the per-preset Manage dialog leaves the select
+ * expanded (the "..." button suppresses the default close), and the trigger's
+ * computed accessible name shifts while expanded, so a role+name lookup can
+ * miss it. The aria-label locator is unaffected by expansion.
+ */
+function presetTrigger(page: Page) {
+  return page.locator('[aria-label="Preset"]');
+}
+
+/**
+ * Close the preset select. Two states must be handled: a genuinely-open
+ * select (content mounted, overlapping the trigger) closes on Escape; a
+ * select left stuck-open by a Manage-dialog flow (trigger reports open but
+ * its listbox is unmounted, so Escape has nothing to dismiss) resets on a
+ * direct trigger click. No-op when already closed.
+ */
+async function closePresetSelect(page: Page): Promise<void> {
+  const trigger = presetTrigger(page);
+  if ((await trigger.getAttribute("aria-expanded")) !== "true") return;
+  await page.keyboard.press("Escape");
+  if ((await trigger.getAttribute("aria-expanded")) === "true") {
+    await trigger.click();
+  }
+  await expect(trigger).toHaveAttribute("aria-expanded", "false");
+}
+
+/** Open the preset select from any state (resetting a stuck-open one). */
+async function openPresetSelect(page: Page): Promise<void> {
+  const trigger = presetTrigger(page);
+  await closePresetSelect(page);
+  await trigger.click();
+  await expect(trigger).toHaveAttribute("aria-expanded", "true");
+}
+
+/** Save the current (factory) state as a new custom preset via the dialog. */
+async function saveAsPreset(page: Page, name: string): Promise<void> {
+  await page.getByRole("button", { name: "Save preset" }).click();
+  const dialog = page.getByRole("dialog", { name: "Save Preset" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel("Preset name").fill(name);
+  await dialog.getByRole("button", { name: "Save" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(presetTrigger(page)).toHaveText(name);
+}
+
+/** Open the preset select and pick an option by exact name. */
+async function selectPreset(page: Page, name: string): Promise<void> {
+  await openPresetSelect(page);
+  await page.getByRole("option", { name, exact: true }).click();
+}
+
+/** Open the per-preset Manage dialog (the "..." action on a custom row). */
+async function openManageDialog(page: Page, name: string): Promise<void> {
+  await openPresetSelect(page);
+  const option = page.getByRole("option", { name, exact: true });
+  await expect(option).toBeVisible();
+  // The row wraps the option (role) and its sibling "..." action button.
+  await option.locator("..").getByRole("button").click();
+  await expect(
+    page.getByRole("dialog", { name: "Manage Preset" }),
+  ).toBeVisible();
+}
+
+async function presetOptionCount(page: Page, name: string): Promise<number> {
+  await openPresetSelect(page);
+  const count = await page.getByRole("option", { name, exact: true }).count();
+  await closePresetSelect(page);
+  return count;
+}
+
+test.describe("preset library storage", () => {
+  test("a saved preset survives reload and applies its edit when selected", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+
+    // A distinctive edit the saved preset must carry.
+    await toggleStep(page, 0, "true");
+    await saveAsPreset(page, "Reload Beat");
+
+    await page.reload();
+    await waitForAppReady(page);
+
+    // Boot hydrated the library synchronously: the preset is in the select.
+    expect(await presetOptionCount(page, "Reload Beat")).toBe(1);
+
+    // Prove selection applies the stored document: switch to init (empty),
+    // then back to the saved preset restores the edit.
+    await selectPreset(page, "init");
+    await expect(step(page, 0)).toHaveAttribute("data-active", "false");
+
+    await selectPreset(page, "Reload Beat");
+    await expect(presetTrigger(page)).toHaveText("Reload Beat");
+    await expect(step(page, 0)).toHaveAttribute("data-active", "true");
+  });
+
+  test("a deleted preset stays gone after reload", async ({ page }) => {
+    await gotoApp(page);
+
+    await saveAsPreset(page, "Doomed Beat");
+    // Move off the saved preset (clean) so deleting it does not leave it as
+    // the current selection.
+    await selectPreset(page, "init");
+
+    await openManageDialog(page, "Doomed Beat");
+    await page.getByRole("button", { name: "Delete" }).click();
+    const confirm = page.getByRole("dialog", { name: "Delete Preset?" });
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole("button", { name: "Delete" }).click();
+    await expect(confirm).not.toBeVisible();
+
+    // Reload to a clean page (opening the Manage dialog from within the select
+    // leaves the trigger in a stuck-open state) and confirm the delete stuck.
+    await page.reload();
+    await waitForAppReady(page);
+    expect(await presetOptionCount(page, "Doomed Beat")).toBe(0);
+  });
+
+  test("a duplicated-and-renamed preset persists across reload", async ({
+    page,
+  }) => {
+    await gotoApp(page);
+
+    await saveAsPreset(page, "Source Beat");
+
+    // Duplicate: the dialog suggests "Source Beat Copy".
+    await openManageDialog(page, "Source Beat");
+    await page.getByRole("button", { name: "Duplicate" }).click();
+    const dupDialog = page.getByRole("dialog", { name: "Duplicate Preset" });
+    await expect(dupDialog).toBeVisible();
+    await dupDialog.getByRole("button", { name: "Duplicate" }).click();
+    await expect(dupDialog).not.toBeVisible();
+
+    // Reload to a clean page (the Manage dialog leaves the trigger stuck open)
+    // and confirm the duplicate persisted through the per-preset entry write.
+    await page.reload();
+    await waitForAppReady(page);
+    expect(await presetOptionCount(page, "Source Beat Copy")).toBe(1);
+
+    // Rename the copy.
+    await openManageDialog(page, "Source Beat Copy");
+    await page.getByRole("button", { name: "Rename" }).click();
+    const renameDialog = page.getByRole("dialog", { name: "Rename Preset" });
+    await expect(renameDialog).toBeVisible();
+    await renameDialog.getByLabel("Preset name").fill("Renamed Beat");
+    await renameDialog.getByRole("button", { name: "Rename" }).click();
+    await expect(renameDialog).not.toBeVisible();
+
+    await page.reload();
+    await waitForAppReady(page);
+
+    expect(await presetOptionCount(page, "Renamed Beat")).toBe(1);
+    expect(await presetOptionCount(page, "Source Beat Copy")).toBe(0);
+  });
+
+  test("adopts a legacy library, backing up and quarantining", async ({
+    page,
+  }) => {
+    // A real v1 preset with a distinctive edit (voice 0, variation A, step 5),
+    // built from a shipped default so the embedded kit resolves on migration.
+    const validPreset = JSON.parse(
+      readFileSync(
+        new URL("../src/core/dh/defaults/init.dh", import.meta.url),
+        "utf-8",
+      ),
+    ) as {
+      meta: { id: string; name: string };
+      sequencer: {
+        pattern: { voices: { variations: { triggers: boolean[] }[] }[] };
+      };
+    };
+    validPreset.meta = {
+      ...validPreset.meta,
+      id: "adopted-valid",
+      name: "Adopted Beat",
+    };
+    validPreset.sequencer.pattern.voices[0].variations[0].triggers[5] = true;
+
+    // A corrupt custom preset: passes the kind/version gate, fails the schema.
+    const corruptPreset = {
+      kind: "drumhaus.preset",
+      version: 1,
+      meta: { id: "adopted-corrupt", name: "Corrupt Beat" },
+    };
+
+    const legacyEnvelope = {
+      state: {
+        currentPresetMeta: {
+          id: "adopted-current",
+          name: "Legacy Current",
+          createdAt: "2025-11-20T12:00:00.000Z",
+          updatedAt: "2025-11-20T12:00:00.000Z",
+        },
+        currentKitMeta: { id: "kit-0", name: "808" },
+        customPresets: [validPreset, corruptPreset],
+      },
+      version: 1,
+    };
+
+    await page.addInitScript(
+      ({ key, value }: { key: string; value: unknown }) => {
+        localStorage.setItem(key, JSON.stringify(value));
+      },
+      { key: LEGACY_PRESET_META_KEY, value: legacyEnvelope },
+    );
+
+    await page.goto("/");
+    await waitForAppReady(page);
+
+    // The valid legacy preset adopted into an entry and is selectable, and
+    // applying it restores its edit (step 5 of variation A).
+    expect(await presetOptionCount(page, "Adopted Beat")).toBe(1);
+    await selectPreset(page, "Adopted Beat");
+    await expect(step(page, 5)).toHaveAttribute("data-active", "true");
+
+    // Storage after adoption: backup written verbatim, corrupt entry
+    // quarantined per id, the legacy key retired.
+    const storage = await page.evaluate(
+      ({ legacyKey, backupKey, entryPrefix, quarantinePrefix, indexKey }) => {
+        const keys = Object.keys(localStorage);
+        return {
+          legacy: localStorage.getItem(legacyKey),
+          backup: localStorage.getItem(backupKey),
+          quarantineKeys: keys.filter((k) => k.startsWith(quarantinePrefix)),
+          // Entry keys, excluding the index and quarantine keys sharing the
+          // prefix.
+          entryKeys: keys.filter(
+            (k) =>
+              k.startsWith(entryPrefix) &&
+              k !== indexKey &&
+              !k.startsWith(quarantinePrefix),
+          ),
+        };
+      },
+      {
+        legacyKey: LEGACY_PRESET_META_KEY,
+        backupKey: LIBRARY_BACKUP_KEY,
+        entryPrefix: LIBRARY_ENTRY_PREFIX,
+        quarantinePrefix: QUARANTINE_PREFIX,
+        indexKey: LIBRARY_INDEX_KEY,
+      },
+    );
+
+    expect(storage.legacy).toBeNull();
+    expect(storage.backup).not.toBeNull();
+    expect(storage.quarantineKeys).toContain(
+      `${QUARANTINE_PREFIX}adopted-corrupt`,
+    );
+    expect(storage.entryKeys).toContain(`${LIBRARY_ENTRY_PREFIX}adopted-valid`);
+  });
+});

--- a/e2e/session-adoption.spec.ts
+++ b/e2e/session-adoption.spec.ts
@@ -29,6 +29,7 @@ const RETIRED_KEYS = [
   "drumhaus-master-chain-storage",
 ];
 const PRESET_META_KEY = "drumhaus-preset-meta-storage";
+const LIBRARY_BACKUP_KEY = "drumhaus-library-backup";
 
 /** A silent 16-step sequence, as every era of the store persisted it. */
 function emptySequence() {
@@ -158,17 +159,19 @@ test.describe("legacy session adoption", () => {
     expect(Number(swingKnobValue)).toBeCloseTo(80, 9);
 
     // Storage after adoption: one session document, the four retired keys
-    // deleted (only after the write landed), the preset-meta key kept for
-    // the library.
+    // deleted (only after the write landed). The legacy preset-meta key is
+    // consumed by the PR 6 library adoption, which preserves its raw payload
+    // under the backup key before retiring it.
     const storage = await page.evaluate(
       (keys: string[]) =>
         Object.fromEntries(keys.map((key) => [key, localStorage.getItem(key)])),
-      [SESSION_KEY, PRESET_META_KEY, ...RETIRED_KEYS],
+      [SESSION_KEY, PRESET_META_KEY, LIBRARY_BACKUP_KEY, ...RETIRED_KEYS],
     );
     for (const key of RETIRED_KEYS) {
       expect(storage[key], `${key} should be deleted`).toBeNull();
     }
-    expect(storage[PRESET_META_KEY]).not.toBeNull();
+    expect(storage[PRESET_META_KEY]).toBeNull();
+    expect(storage[LIBRARY_BACKUP_KEY]).not.toBeNull();
     expect(storage[SESSION_KEY]).not.toBeNull();
 
     // The written envelope is a v2 document carrying the adopted values in

--- a/src/core/providers/drumhaus-provider/drumhaus-context.ts
+++ b/src/core/providers/drumhaus-provider/drumhaus-context.ts
@@ -1,9 +1,11 @@
 import { createContext } from "react";
 
+import type { PresetDocument } from "@/features/preset/document";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
 
 interface DrumhausContextValue {
   loadPresetFile: (preset: PresetFileV1) => void;
+  loadPresetDocument: (document: PresetDocument) => void;
   importPresetFileText: (text: string) => void;
 }
 

--- a/src/core/providers/drumhaus-provider/drumhaus-provider.tsx
+++ b/src/core/providers/drumhaus-provider/drumhaus-provider.tsx
@@ -11,10 +11,12 @@ const DrumhausProvider = ({ children }: DrumhausProviderProps) => {
   // --- Audio Engine Bridge and Preset Loading ---
   useEngineBridge();
   useKitLoadFailureToast();
-  const { loadPresetFile, importPresetFileText } = usePresetLoading();
+  const { loadPresetFile, loadPresetDocument, importPresetFileText } =
+    usePresetLoading();
 
   const value: DrumhausContextValue = {
     loadPresetFile,
+    loadPresetDocument,
     importPresetFileText,
   };
 

--- a/src/features/preset/components/preset-control.tsx
+++ b/src/features/preset/components/preset-control.tsx
@@ -58,7 +58,8 @@ const ConfirmSelectPresetDialog = lazy(() =>
 );
 
 function PresetControl() {
-  const { loadPresetFile, importPresetFileText } = useDrumhaus();
+  const { loadPresetFile, loadPresetDocument, importPresetFileText } =
+    useDrumhaus();
   const {
     kits,
     defaultPresets,
@@ -68,7 +69,11 @@ function PresetControl() {
     importPreset,
     saveCurrentPreset,
     sharePreset,
-  } = usePresetManager({ loadPresetFile, importPresetFileText });
+  } = usePresetManager({
+    loadPresetFile,
+    loadPresetDocument,
+    importPresetFileText,
+  });
 
   // Store state
   const currentPresetMeta = usePresetMetaStore(

--- a/src/features/preset/components/preset-select.tsx
+++ b/src/features/preset/components/preset-select.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { MoreVertical } from "lucide-react";
 
 import { PresetActionsDialog } from "@/features/preset/dialogs/preset-actions-dialog";
-import type { PresetFileV1 } from "@/features/preset/types/preset";
+import type { PresetListItem } from "@/features/preset/types/preset";
 import {
   Button,
   Select,
@@ -17,8 +17,11 @@ import {
 
 interface PresetSelectProps {
   selectedPresetId: string;
-  defaultPresets: PresetFileV1[];
-  customPresets: PresetFileV1[];
+  // Both lists are read for identity only (meta.id/meta.name), so they take
+  // the minimal PresetListItem shape: factory presets (PresetFileV1) and
+  // library entries (PresetDocument) both satisfy it.
+  defaultPresets: PresetListItem[];
+  customPresets: PresetListItem[];
   onSelect: (value: string) => void;
   onRenamePreset?: (presetId: string, presetName: string) => void;
   onDuplicatePreset?: (presetId: string, presetName: string) => void;

--- a/src/features/preset/dialogs/duplicate-preset-dialog.tsx
+++ b/src/features/preset/dialogs/duplicate-preset-dialog.tsx
@@ -78,20 +78,16 @@ function DuplicatePresetDialog({
     trigger("presetName");
   }, [defaultValues, reset, trigger]);
 
-  const onSubmit = handleSubmit(({ presetName }) => {
+  const onSubmit = handleSubmit(async ({ presetName }) => {
     const trimmedName = presetName.trim();
 
     try {
-      // Duplicate the preset (with auto-generated name)
-      const duplicatedPreset = duplicateCustomPreset(presetId);
+      // Duplicate the preset (writes a library entry, so it can reject with
+      // StorageFullError; await before touching its meta).
+      const duplicatedPreset = await duplicateCustomPreset(presetId);
 
-      // If user changed the name, rename the duplicated preset
-      if (trimmedName !== suggestedName) {
-        renameCustomPreset(duplicatedPreset.meta.id, trimmedName);
-      } else {
-        // Use the suggested name
-        renameCustomPreset(duplicatedPreset.meta.id, trimmedName);
-      }
+      // Apply the (possibly edited) name to the duplicated preset.
+      await renameCustomPreset(duplicatedPreset.meta.id, trimmedName);
 
       toast({
         title: "Preset duplicated",

--- a/src/features/preset/document/apply.ts
+++ b/src/features/preset/document/apply.ts
@@ -51,10 +51,11 @@ function applyPresetDocument(document: PresetDocument): void {
     void transport.togglePlay();
   }
 
-  // Add to custom presets if not a default preset
+  // Register a non-factory preset in the library (dedupe by id; the entry
+  // write is best-effort, see addCustomPreset)
   const presetMeta = usePresetMetaStore.getState();
   if (isCustomPreset) {
-    presetMeta.addCustomPreset(file);
+    presetMeta.addCustomPreset(document);
   }
 
   // Update metadata (the clean dirty baseline is set post-commit below)

--- a/src/features/preset/document/errors.ts
+++ b/src/features/preset/document/errors.ts
@@ -1,15 +1,13 @@
 /**
- * Typed error taxonomy for preset document parsing.
- *
- * This taxonomy will grow in later PRs (e.g. StorageFullError for library
- * saves).
+ * Typed error taxonomy for preset document parsing and storage.
  */
 
 type PresetDocumentErrorCode =
   | "invalid-file"
   | "unsupported-version"
   | "corrupt-field"
-  | "unknown-kit";
+  | "unknown-kit"
+  | "storage-full";
 
 /**
  * Base class for all errors raised while parsing a preset document.
@@ -84,11 +82,29 @@ class UnknownKitError extends PresetDocumentError {
   }
 }
 
+/**
+ * Browser storage refused a library write (QuotaExceededError). The message
+ * is user-facing: the preset library is full and something must go before
+ * the save can land.
+ */
+class StorageFullError extends PresetDocumentError {
+  readonly code = "storage-full";
+
+  constructor() {
+    super(
+      "Browser storage is full, so the preset could not be saved. " +
+        "Delete some presets from the library, then try again.",
+    );
+    this.name = "StorageFullError";
+  }
+}
+
 export {
   PresetDocumentError,
   InvalidFileError,
   UnsupportedVersionError,
   CorruptFieldError,
   UnknownKitError,
+  StorageFullError,
 };
 export type { PresetDocumentErrorCode };

--- a/src/features/preset/document/index.ts
+++ b/src/features/preset/document/index.ts
@@ -16,6 +16,7 @@ export {
   CorruptFieldError,
   InvalidFileError,
   PresetDocumentError,
+  StorageFullError,
   UnknownKitError,
   UnsupportedVersionError,
 } from "./errors";

--- a/src/features/preset/hooks/use-preset-loading.ts
+++ b/src/features/preset/hooks/use-preset-loading.ts
@@ -53,12 +53,12 @@ function loadPresetDocument(
 }
 
 /**
- * Load a knob-space (v1-family) preset object: library selections, the
- * delete fallback, and post-save reloads (boot itself now flows through
- * features/preset/session/bootstrap.ts). Library entries are persisted
- * verbatim in localStorage (until PR 6) and can still be version 1 or
- * corrupt, so they run the same validate -> migrate ladder as imported file
- * text before apply.
+ * Load a knob-space (v1-family) preset object: factory-preset selections
+ * and the delete fallback (boot itself now flows through
+ * features/preset/session/bootstrap.ts, and library entries are documents
+ * that go through loadStoredPresetDocument). Bundled files are validated at
+ * import time, but the full validate -> migrate ladder keeps this ingress
+ * identical to imported file text.
  */
 function loadPresetFile(
   preset: PresetFileV1,
@@ -66,6 +66,23 @@ function loadPresetFile(
 ): PresetDocument | null {
   return loadPresetDocument(
     () => migrateV1ToDocument(validatePresetFileV1(preset)),
+    (error) => showPresetLoadErrorToast(toast, error),
+  );
+}
+
+/**
+ * Load an already-decoded preset document: library selections (entries are
+ * stored as documents since PR 6) and post-save reloads. The document went
+ * through the schema when it was decoded or snapshotted, so only apply's
+ * conversion (kit resolution, domain-to-knob) can fail here; it shares the
+ * ingress error boundary all the same.
+ */
+function loadStoredPresetDocument(
+  document: PresetDocument,
+  toast: ShowToast,
+): PresetDocument | null {
+  return loadPresetDocument(
+    () => document,
     (error) => showPresetLoadErrorToast(toast, error),
   );
 }
@@ -114,6 +131,7 @@ function importPresetFileText(text: string, toast: ShowToast): void {
 
 interface UsePresetLoadingResult {
   loadPresetFile: (preset: PresetFileV1) => void;
+  loadPresetDocument: (document: PresetDocument) => void;
   importPresetFileText: (text: string) => void;
 }
 
@@ -131,6 +149,13 @@ function usePresetLoading(): UsePresetLoadingResult {
   const loadFile = useCallback(
     (preset: PresetFileV1) => {
       loadPresetFile(preset, toast);
+    },
+    [toast],
+  );
+
+  const loadDocument = useCallback(
+    (document: PresetDocument) => {
+      loadStoredPresetDocument(document, toast);
     },
     [toast],
   );
@@ -232,7 +257,11 @@ function usePresetLoading(): UsePresetLoadingResult {
     void loadFromUrlOrDefault();
   }, [loadFromUrlOrDefault]);
 
-  return { loadPresetFile: loadFile, importPresetFileText: importFileText };
+  return {
+    loadPresetFile: loadFile,
+    loadPresetDocument: loadDocument,
+    importPresetFileText: importFileText,
+  };
 }
 
 export {
@@ -241,5 +270,6 @@ export {
   loadPresetDocument,
   loadPresetFile,
   loadPresetFileText,
+  loadStoredPresetDocument,
 };
 export type { UsePresetLoadingResult };

--- a/src/features/preset/hooks/use-preset-manager.ts
+++ b/src/features/preset/hooks/use-preset-manager.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo } from "react";
 
-import { init } from "@/core/dh";
 import { useInstrumentsStore } from "@/features/instrument/store/use-instruments-store";
 import { getAllKits } from "@/features/kit/lib/constants";
 import { KitFileV1 } from "@/features/kit/types/kit";
+import type { PresetDocument } from "@/features/preset/document";
 import { getDefaultPresets } from "@/features/preset/lib/constants";
 import { generateShareUrl } from "@/features/preset/lib/operations";
 import { requestGuardedPresetLoad } from "@/features/preset/store/use-pending-preset-load-store";
@@ -21,6 +21,7 @@ interface UsePresetManagerProps {
    * are defined in usePresetLoading hook.
    */
   loadPresetFile: (preset: PresetFileV1) => void;
+  loadPresetDocument: (document: PresetDocument) => void;
   importPresetFileText: (text: string) => void;
 }
 
@@ -28,8 +29,7 @@ interface UsePresetManagerResult {
   // Data
   kits: KitFileV1[];
   defaultPresets: PresetFileV1[];
-  customPresets: PresetFileV1[];
-  allPresets: PresetFileV1[];
+  customPresets: PresetDocument[];
 
   // Actions
   switchKit: (kitId: string) => void;
@@ -38,10 +38,7 @@ interface UsePresetManagerResult {
   sharePreset: (name: string) => Promise<string>;
 
   // Preset management
-  saveCurrentPreset: (name?: string) => void;
-  renamePreset: (id: string, newName: string) => void;
-  duplicatePreset: (id: string, newName?: string) => PresetFileV1;
-  deletePreset: (id: string) => void;
+  saveCurrentPreset: (name?: string) => Promise<void>;
   isCurrentPresetCustom: boolean;
   canAddMorePresets: boolean;
 }
@@ -51,11 +48,12 @@ interface UsePresetManagerResult {
  *
  * High-level: provides UI operations (import, export, share, switch)
  *
- * Depends on loadPreset from usePresetLoading hook, which manages
+ * Depends on the loaders from usePresetLoading hook, which manages
  * low level runtime updates
  */
 function usePresetManager({
   loadPresetFile,
+  loadPresetDocument,
   importPresetFileText,
 }: UsePresetManagerProps): UsePresetManagerResult {
   const { toast } = useToast();
@@ -67,9 +65,8 @@ function usePresetManager({
   const currentPresetMeta = usePresetMetaStore(
     (state) => state.currentPresetMeta,
   );
-  const currentKitMeta = usePresetMetaStore((state) => state.currentKitMeta);
   const setKitMeta = usePresetMetaStore((state) => state.setKitMeta);
-  const markPresetClean = usePresetMetaStore((state) => state.markPresetClean);
+  const currentKitMeta = usePresetMetaStore((state) => state.currentKitMeta);
   const customPresets = usePresetMetaStore((state) => state.customPresets);
 
   // Store actions for preset management
@@ -79,15 +76,6 @@ function usePresetManager({
   const updateCustomPreset = usePresetMetaStore(
     (state) => state.updateCustomPreset,
   );
-  const renameCustomPreset = usePresetMetaStore(
-    (state) => state.renameCustomPreset,
-  );
-  const duplicateCustomPreset = usePresetMetaStore(
-    (state) => state.duplicateCustomPreset,
-  );
-  const deleteCustomPreset = usePresetMetaStore(
-    (state) => state.deleteCustomPreset,
-  );
   const isCustomPreset = usePresetMetaStore((state) => state.isCustomPreset);
   const canAddCustomPreset = usePresetMetaStore(
     (state) => state.canAddCustomPreset,
@@ -95,10 +83,6 @@ function usePresetManager({
 
   const kits = useMemo(() => getAllKits(), []);
   const defaultPresets = useMemo(() => getDefaultPresets(), []);
-  const allPresets = useMemo(
-    () => [...defaultPresets, ...customPresets],
-    [defaultPresets, customPresets],
-  );
 
   // --- Core Operations ---
 
@@ -123,18 +107,26 @@ function usePresetManager({
    * Switch to a preset by ID, behind the unsaved-changes guard: a dirty
    * session stages the load and opens the confirm dialog
    * (use-pending-preset-load-store.ts); a clean one loads immediately.
+   * Library entries are documents and apply DIRECTLY through the pipeline;
+   * factory presets run the v1 validate -> migrate ladder.
    */
   const switchPreset = useCallback(
     (presetId: string) => {
-      const preset = allPresets.find((p) => p.meta.id === presetId);
-      if (!preset) {
+      const custom = customPresets.find((d) => d.meta.id === presetId);
+      if (custom) {
+        requestGuardedPresetLoad("library", () => loadPresetDocument(custom));
+        return;
+      }
+
+      const factory = defaultPresets.find((p) => p.meta.id === presetId);
+      if (!factory) {
         console.error(`Preset ${presetId} not found`);
         return;
       }
 
-      requestGuardedPresetLoad("library", () => loadPresetFile(preset));
+      requestGuardedPresetLoad("library", () => loadPresetFile(factory));
     },
-    [allPresets, loadPresetFile],
+    [customPresets, defaultPresets, loadPresetDocument, loadPresetFile],
   );
 
   // --- File Operations ---
@@ -214,39 +206,51 @@ function usePresetManager({
   // --- PRESET MANAGEMENT ---
 
   /**
-   * Save current state as a new preset or update existing custom preset
+   * Save current state as a new preset or update existing custom preset.
+   * A refused storage write (StorageFullError from the library) surfaces
+   * as an error toast, same pattern as the preset limit.
    */
   const saveCurrentPreset = useCallback(
-    (name?: string) => {
+    async (name?: string) => {
       const isCustom = isCustomPreset(currentPresetMeta.id);
 
-      if (isCustom) {
-        // Update existing custom preset
-        updateCustomPreset(currentPresetMeta.id);
-        toast({
-          title: "Preset updated",
-          description: currentPresetMeta.name,
-          duration: 3000,
-        });
-      } else if (name) {
-        // Save factory preset as new custom preset
-        const newPreset = saveCurrentAsNewPreset(name);
-        if (newPreset) {
-          markPresetClean();
-          loadPresetFile(newPreset);
+      try {
+        if (isCustom) {
+          // Update existing custom preset
+          await updateCustomPreset(currentPresetMeta.id);
           toast({
-            title: "Preset saved",
-            description: name,
+            title: "Preset updated",
+            description: currentPresetMeta.name,
             duration: 3000,
           });
-        } else {
-          toast({
-            title: "Preset limit reached",
-            description: "Delete some presets to continue (max 100)",
-            status: "error",
-            duration: 5000,
-          });
+        } else if (name) {
+          // Save factory preset as new custom preset
+          const newDocument = await saveCurrentAsNewPreset(name);
+          if (newDocument) {
+            loadPresetDocument(newDocument);
+            toast({
+              title: "Preset saved",
+              description: name,
+              duration: 3000,
+            });
+          } else {
+            toast({
+              title: "Preset limit reached",
+              description: "Delete some presets to continue (max 100)",
+              status: "error",
+              duration: 5000,
+            });
+          }
         }
+      } catch (error) {
+        console.error("Failed to save preset:", error);
+        toast({
+          title: "Couldn't save preset",
+          description:
+            error instanceof Error ? error.message : "Please try again",
+          status: "error",
+          duration: 5000,
+        });
       }
     },
     [
@@ -254,74 +258,9 @@ function usePresetManager({
       currentPresetMeta,
       updateCustomPreset,
       saveCurrentAsNewPreset,
-      markPresetClean,
-      loadPresetFile,
+      loadPresetDocument,
       toast,
     ],
-  );
-
-  /**
-   * Rename a custom preset
-   */
-  const renamePreset = useCallback(
-    (id: string, newName: string) => {
-      renameCustomPreset(id, newName);
-      toast({
-        title: "Preset renamed",
-        description: `Renamed to "${newName}"`,
-        duration: 3000,
-      });
-    },
-    [renameCustomPreset, toast],
-  );
-
-  /**
-   * Duplicate a custom preset
-   */
-  const duplicatePreset = useCallback(
-    (id: string, newName?: string): PresetFileV1 => {
-      const duplicated = duplicateCustomPreset(id);
-
-      if (newName && newName !== duplicated.meta.name) {
-        renameCustomPreset(duplicated.meta.id, newName);
-        duplicated.meta.name = newName;
-      }
-
-      toast({
-        title: "Preset duplicated",
-        description: `Created "${duplicated.meta.name}"`,
-        duration: 3000,
-      });
-
-      return duplicated;
-    },
-    [duplicateCustomPreset, renameCustomPreset, toast],
-  );
-
-  /**
-   * Delete a custom preset
-   */
-  const deletePreset = useCallback(
-    (id: string) => {
-      const isDeletingCurrent = id === currentPresetMeta.id;
-
-      deleteCustomPreset(id);
-
-      if (isDeletingCurrent) {
-        loadPresetFile(init());
-        toast({
-          title: "Preset deleted",
-          description: "Loaded default preset",
-          duration: 3000,
-        });
-      } else {
-        toast({
-          title: "Preset deleted",
-          duration: 3000,
-        });
-      }
-    },
-    [deleteCustomPreset, currentPresetMeta.id, loadPresetFile, toast],
   );
 
   // Computed values
@@ -356,7 +295,6 @@ function usePresetManager({
     kits,
     defaultPresets,
     customPresets,
-    allPresets,
 
     // Actions
     switchKit,
@@ -366,9 +304,6 @@ function usePresetManager({
 
     // Preset management
     saveCurrentPreset,
-    renamePreset,
-    duplicatePreset,
-    deletePreset,
     isCurrentPresetCustom,
     canAddMorePresets,
   };

--- a/src/features/preset/lib/helpers.ts
+++ b/src/features/preset/lib/helpers.ts
@@ -3,7 +3,10 @@ import { getMasterChainParams } from "@/features/master-bus/store/use-master-cha
 import { PRESET_FILE_VERSION } from "@/features/preset/document";
 import { getDefaultPresets } from "@/features/preset/lib/constants";
 import type { Meta } from "@/features/preset/types/meta";
-import type { PresetFileV1 } from "@/features/preset/types/preset";
+import type {
+  PresetFileV1,
+  PresetListItem,
+} from "@/features/preset/types/preset";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
 
@@ -60,7 +63,7 @@ function isFactoryPreset(presetId: string): boolean {
  */
 function generateDuplicateName(
   baseName: string,
-  existingPresets: PresetFileV1[],
+  existingPresets: PresetListItem[],
 ): string {
   const nameSet = new Set(existingPresets.map((p) => p.meta.name));
 

--- a/src/features/preset/library/adoption.test.ts
+++ b/src/features/preset/library/adoption.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for the one-time legacy library adoption
+ * (docs/preset-persistence.md, PR 6, decision 9): the retired
+ * drumhaus-preset-meta-storage array of PresetFileV1 objects migrates into
+ * per-preset document entries, with a verbatim pre-adoption backup, per-entry
+ * quarantine, delete-only-after-write ordering, and idempotent resume.
+ *
+ * The adoption reads globalThis.localStorage at call time, so an in-memory
+ * stub installed per test is enough. Adoption's imports are pure (schema,
+ * migrators, constants), so the node project runs this without an engine
+ * mock.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { init } from "@/core/dh";
+import type { PresetFileV1 } from "@/features/preset/types/preset";
+import { adoptLegacyPresetLibrary, LIBRARY_BACKUP_KEY } from "./adoption";
+import {
+  hydrateLibrarySync,
+  libraryEntryKey,
+  libraryQuarantineKey,
+  readLibraryIndexSync,
+} from "./library";
+
+const LEGACY_KEY = "drumhaus-preset-meta-storage";
+
+interface MemoryStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  key: (index: number) => string | null;
+  readonly length: number;
+  map: Map<string, string>;
+  /** When set, a setItem whose key matches throws QuotaExceededError. */
+  failWrite: ((key: string) => boolean) | null;
+}
+
+function quotaError(): Error {
+  const error = new Error("The quota has been exceeded.");
+  error.name = "QuotaExceededError";
+  return error;
+}
+
+function createMemoryStorage(seed: Record<string, string> = {}): MemoryStorage {
+  const map = new Map(Object.entries(seed));
+  const storage: MemoryStorage = {
+    map,
+    failWrite: null,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      if (storage.failWrite?.(key)) throw quotaError();
+      map.set(key, String(value));
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+    key: (index) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size;
+    },
+  };
+  return storage;
+}
+
+/** A full, valid v1 preset (embedded kit and all) under a custom identity. */
+function legacyPreset(id: string, name: string): PresetFileV1 {
+  const preset = init();
+  return { ...preset, meta: { ...preset.meta, id, name } };
+}
+
+/** The legacy preset-meta envelope shape (persist version 1). */
+function legacyEnvelope(customPresets: unknown[]): string {
+  const preset = init();
+  return JSON.stringify({
+    state: {
+      currentPresetMeta: preset.meta,
+      currentKitMeta: preset.kit.meta,
+      customPresets,
+    },
+    version: 1,
+  });
+}
+
+let storage: MemoryStorage;
+
+beforeEach(() => {
+  storage = createMemoryStorage();
+  vi.stubGlobal("localStorage", storage);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("happy path", () => {
+  it("adopts two presets into entries, backs up the raw payload, deletes the legacy key", () => {
+    const first = legacyPreset("preset-1", "First");
+    const second = legacyPreset("preset-2", "Second");
+    const raw = legacyEnvelope([first, second]);
+    storage.map.set(LEGACY_KEY, raw);
+
+    adoptLegacyPresetLibrary();
+
+    // Two entries, index in the legacy array's order.
+    expect(readLibraryIndexSync().map((r) => r.id)).toEqual([
+      "preset-1",
+      "preset-2",
+    ]);
+    const listed = hydrateLibrarySync();
+    expect(listed.map((d) => d.meta.id)).toEqual(["preset-1", "preset-2"]);
+    expect(listed.map((d) => d.meta.name)).toEqual(["First", "Second"]);
+
+    // The raw legacy payload is preserved verbatim under the backup key.
+    expect(storage.map.get(LIBRARY_BACKUP_KEY)).toBe(raw);
+
+    // The legacy key is gone (deleted only after every entry landed).
+    expect(storage.map.has(LEGACY_KEY)).toBe(false);
+  });
+});
+
+describe("corrupt entry", () => {
+  it("quarantines the invalid preset while the valid one adopts", () => {
+    const valid = legacyPreset("valid", "Valid");
+    // A v1 envelope that passes the kind/version gate but fails the schema.
+    const corrupt = {
+      kind: "drumhaus.preset",
+      version: 1,
+      meta: { id: "corrupt", name: "Corrupt" },
+    };
+    storage.map.set(LEGACY_KEY, legacyEnvelope([valid, corrupt]));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    adoptLegacyPresetLibrary();
+
+    // The valid one adopted.
+    expect(hydrateLibrarySync().map((d) => d.meta.id)).toEqual(["valid"]);
+    // The corrupt one quarantined verbatim, never an entry.
+    expect(storage.map.get(libraryQuarantineKey("corrupt"))).toBe(
+      JSON.stringify(corrupt),
+    );
+    expect(storage.map.has(libraryEntryKey("corrupt"))).toBe(false);
+    // Adoption still completes: the legacy key retires.
+    expect(storage.map.has(LEGACY_KEY)).toBe(false);
+    expect(consoleError).toHaveBeenCalled();
+  });
+});
+
+describe("storage-full mid-adoption", () => {
+  it("stops with the legacy key and backup intact, and resumes idempotently", () => {
+    const first = legacyPreset("preset-1", "First");
+    const second = legacyPreset("preset-2", "Second");
+    const raw = legacyEnvelope([first, second]);
+    storage.map.set(LEGACY_KEY, raw);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    // The second entry's write hits quota; the first lands.
+    storage.failWrite = (key) => key === libraryEntryKey("preset-2");
+    adoptLegacyPresetLibrary();
+
+    // First entry written, second not; legacy key and backup preserved.
+    expect(storage.map.has(libraryEntryKey("preset-1"))).toBe(true);
+    expect(storage.map.has(libraryEntryKey("preset-2"))).toBe(false);
+    expect(storage.map.get(LEGACY_KEY)).toBe(raw);
+    expect(storage.map.get(LIBRARY_BACKUP_KEY)).toBe(raw);
+    expect(consoleError).toHaveBeenCalled();
+
+    // Next boot: quota clears, adoption resumes without duplicating preset-1.
+    storage.failWrite = null;
+    adoptLegacyPresetLibrary();
+
+    expect(readLibraryIndexSync().map((r) => r.id)).toEqual([
+      "preset-1",
+      "preset-2",
+    ]);
+    expect(hydrateLibrarySync().map((d) => d.meta.id)).toEqual([
+      "preset-1",
+      "preset-2",
+    ]);
+    expect(storage.map.has(LEGACY_KEY)).toBe(false);
+  });
+});
+
+describe("no-op re-runs", () => {
+  it("returns immediately when no legacy key is present", () => {
+    adoptLegacyPresetLibrary();
+    expect(storage.map.size).toBe(0);
+  });
+
+  it("does not run again after a completed adoption", () => {
+    storage.map.set(LEGACY_KEY, legacyEnvelope([legacyPreset("p", "P")]));
+    adoptLegacyPresetLibrary();
+    expect(storage.map.has(LEGACY_KEY)).toBe(false);
+
+    const before = new Map(storage.map);
+    adoptLegacyPresetLibrary();
+    // Nothing changed: the legacy key is gone, so adoption is inert.
+    expect(storage.map).toEqual(before);
+  });
+});

--- a/src/features/preset/library/adoption.ts
+++ b/src/features/preset/library/adoption.ts
@@ -1,0 +1,206 @@
+/**
+ * One-time adoption of the legacy preset library (docs/preset-persistence.md,
+ * PR 6, decision 9): the retired preset-meta persist held every custom
+ * preset as one `customPresets: PresetFileV1[]` array under
+ * drumhaus-preset-meta-storage. This module migrates that array into
+ * per-preset document entries, eagerly and defensively:
+ *
+ * - The raw legacy payload is copied UNTOUCHED to drumhaus-library-backup
+ *   before anything else (the pre-adoption escape hatch; this PR never
+ *   deletes it).
+ * - Entries migrate individually through the standard
+ *   validate -> migrate pipeline; a failing entry quarantines to its own
+ *   key and never blocks the others.
+ * - The legacy key is deleted ONLY after every entry is written or
+ *   quarantined. Any quota failure stops adoption with the legacy key (and
+ *   backup) intact.
+ * - Re-running is idempotent: entries already written by an interrupted run
+ *   are recognized by id and not rewritten, so a quota failure mid-adoption
+ *   simply resumes on the next boot.
+ *
+ * This module also inherits the PR 5 capture duty: the legacy envelope
+ * still carries currentPresetMeta/currentKitMeta on machines that never ran
+ * the narrowing build, and the session adopter needs them. Adoption parses
+ * the envelope first (before the session ladder consumes the capture) and
+ * hands the meta fields to legacy-preset-meta-capture.ts on their way out.
+ */
+
+import {
+  migrateV1ToDocument,
+  StorageFullError,
+  validatePresetFileV1,
+} from "@/features/preset/document";
+import { LEGACY_PRESET_META_STORAGE_KEY } from "@/features/preset/session/legacy-adopter";
+import { captureLegacyPresetMeta } from "@/features/preset/session/legacy-preset-meta-capture";
+import {
+  libraryEntryKey,
+  libraryQuarantineKey,
+  putLibraryEntrySync,
+  readLibraryIndexSync,
+  writeLibraryIndexSync,
+  type LibraryIndexRow,
+} from "./library";
+import { getItemSync, putItemSync, removeItemSync } from "./storage";
+
+/** The raw legacy payload, preserved verbatim; never deleted by this PR. */
+const LIBRARY_BACKUP_KEY = "drumhaus-library-backup";
+
+/** Best-effort id/name extraction from a raw (unvalidated) legacy preset. */
+function rawPresetMeta(entry: unknown): { id?: string; name?: string } {
+  if (typeof entry !== "object" || entry === null) return {};
+  const meta = (entry as { meta?: unknown }).meta;
+  if (typeof meta !== "object" || meta === null) return {};
+  const { id, name } = meta as { id?: unknown; name?: unknown };
+  return {
+    ...(typeof id === "string" ? { id } : {}),
+    ...(typeof name === "string" ? { name } : {}),
+  };
+}
+
+/**
+ * Adopt the legacy customPresets array into per-preset entries. Runs inside
+ * bootstrapLibrary() on every boot and returns immediately once the legacy
+ * key is gone. Synchronous by design: it must complete before the in-memory
+ * library hydrates and before the session ladder applies any document.
+ */
+function adoptLegacyPresetLibrary(): void {
+  const raw = getItemSync(LEGACY_PRESET_META_STORAGE_KEY);
+  if (raw === null) return;
+
+  // The escape hatch comes first: whatever happens below, the user's raw
+  // data survives verbatim under the backup key.
+  try {
+    putItemSync(LIBRARY_BACKUP_KEY, raw);
+  } catch (error) {
+    console.error(
+      "Drumhaus library adoption: could not write the pre-adoption backup; " +
+        "keeping the legacy key and retrying next boot",
+      error,
+    );
+    return;
+  }
+
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(raw);
+  } catch (error) {
+    // The whole envelope is unreadable: there is nothing to migrate, but the
+    // payload is safe in the backup, so retire the legacy key.
+    console.error(
+      "Drumhaus library adoption: the legacy preset-meta envelope is not " +
+        `valid JSON; preserved verbatim under "${LIBRARY_BACKUP_KEY}"`,
+      error,
+    );
+    removeItemSync(LEGACY_PRESET_META_STORAGE_KEY);
+    return;
+  }
+
+  const state =
+    typeof envelope === "object" && envelope !== null
+      ? (envelope as { state?: unknown; version?: unknown }).state
+      : undefined;
+  const version =
+    typeof envelope === "object" &&
+    envelope !== null &&
+    typeof (envelope as { version?: unknown }).version === "number"
+      ? (envelope as { version: number }).version
+      : 0;
+
+  // PR 5 capture duty: pre-v2 envelopes still hold the current preset/kit
+  // meta the session adopter needs; hand them over before the key goes.
+  if (version < 2) captureLegacyPresetMeta(state);
+
+  const rawPresets =
+    typeof state === "object" && state !== null
+      ? (state as { customPresets?: unknown }).customPresets
+      : undefined;
+  const presets = Array.isArray(rawPresets) ? rawPresets : [];
+
+  const adoptedRows: LibraryIndexRow[] = [];
+  const adoptedIds = new Set<string>();
+
+  for (const [index, entry] of presets.entries()) {
+    const { id, name } = rawPresetMeta(entry);
+    if (id !== undefined && adoptedIds.has(id)) continue;
+
+    // Idempotent resume: an entry written by a previous interrupted run is
+    // recognized by id and kept as-is, never rewritten or duplicated.
+    if (id !== undefined && getItemSync(libraryEntryKey(id)) !== null) {
+      adoptedIds.add(id);
+      adoptedRows.push({ id, name: name ?? id });
+      continue;
+    }
+
+    try {
+      const document = migrateV1ToDocument(validatePresetFileV1(entry));
+      putLibraryEntrySync(document);
+      adoptedIds.add(document.meta.id);
+      adoptedRows.push({ id: document.meta.id, name: document.meta.name });
+    } catch (error) {
+      if (error instanceof StorageFullError) {
+        // Quota mid-adoption: stop here, keep the legacy key AND the
+        // backup, keep what was written. Idempotency covers the retry.
+        console.error(
+          "Drumhaus library adoption: storage is full; stopping with the " +
+            "legacy key intact and resuming on the next boot",
+          error,
+        );
+        return;
+      }
+
+      // A corrupt entry quarantines to its own key and never blocks the
+      // others. Best-effort: on failure the raw entry still lives in the
+      // backup (and in the legacy key until adoption completes).
+      const quarantineId = id ?? `entry-${index}`;
+      try {
+        putItemSync(libraryQuarantineKey(quarantineId), JSON.stringify(entry));
+      } catch (quarantineError) {
+        if (quarantineError instanceof StorageFullError) {
+          console.error(
+            "Drumhaus library adoption: storage is full; stopping with the " +
+              "legacy key intact and resuming on the next boot",
+            quarantineError,
+          );
+          return;
+        }
+        console.error(
+          "Drumhaus library adoption: failed to quarantine corrupt entry " +
+            `"${quarantineId}"`,
+          quarantineError,
+        );
+      }
+      console.error(
+        `Drumhaus library adoption: legacy preset "${quarantineId}" failed ` +
+          `to migrate and was quarantined to ` +
+          `"${libraryQuarantineKey(quarantineId)}"`,
+        error,
+      );
+    }
+  }
+
+  // The final index: adopted rows in the legacy array's order, preceded by
+  // any rows an interrupted first run's saves created in the meantime.
+  const preservedRows = readLibraryIndexSync().filter(
+    (row) => !adoptedIds.has(row.id),
+  );
+  try {
+    writeLibraryIndexSync([...preservedRows, ...adoptedRows]);
+  } catch (error) {
+    if (error instanceof StorageFullError) {
+      console.error(
+        "Drumhaus library adoption: storage is full writing the index; " +
+          "stopping with the legacy key intact and resuming on the next boot",
+        error,
+      );
+      return;
+    }
+    throw error;
+  }
+
+  // Every entry is written or quarantined and the index landed: the legacy
+  // key retires. Deletion cannot fail for quota, so from here adoption is
+  // complete and never runs again.
+  removeItemSync(LEGACY_PRESET_META_STORAGE_KEY);
+}
+
+export { LIBRARY_BACKUP_KEY, adoptLegacyPresetLibrary };

--- a/src/features/preset/library/library.test.ts
+++ b/src/features/preset/library/library.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the per-preset library storage (docs/preset-persistence.md,
+ * "Library storage: documents under per-preset keys", decision 14): CRUD
+ * round-trips through the document schema, index self-heal against the
+ * entries, per-entry quarantine of corrupt payloads, and the typed
+ * StorageFullError on a quota-refused write.
+ *
+ * The library sync/async functions read globalThis.localStorage at call time,
+ * so an in-memory stub installed per test is enough; no module reset is
+ * needed. The stub carries length/key() because listKeysSync scans them.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { init } from "@/core/dh";
+import {
+  migrateV1ToDocument,
+  StorageFullError,
+  type PresetDocument,
+} from "@/features/preset/document";
+import {
+  decodeLibraryEntry,
+  hydrateLibrarySync,
+  LIBRARY_INDEX_KEY,
+  libraryEntryKey,
+  libraryQuarantineKey,
+  putLibraryEntry,
+  putLibraryEntrySync,
+  readLibraryIndexSync,
+  removeLibraryEntry,
+  writeLibraryIndex,
+  writeLibraryIndexSync,
+  type LibraryIndexRow,
+} from "./library";
+import { getItemSync } from "./storage";
+
+interface MemoryStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  key: (index: number) => string | null;
+  readonly length: number;
+  map: Map<string, string>;
+  /** When set, a setItem whose key matches throws QuotaExceededError. */
+  failWrite: ((key: string) => boolean) | null;
+}
+
+function quotaError(): Error {
+  const error = new Error("The quota has been exceeded.");
+  error.name = "QuotaExceededError";
+  return error;
+}
+
+function createMemoryStorage(seed: Record<string, string> = {}): MemoryStorage {
+  const map = new Map(Object.entries(seed));
+  const storage: MemoryStorage = {
+    map,
+    failWrite: null,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      if (storage.failWrite?.(key)) throw quotaError();
+      map.set(key, String(value));
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+    key: (index) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size;
+    },
+  };
+  return storage;
+}
+
+function makeDocument(id: string, name: string): PresetDocument {
+  const document = migrateV1ToDocument(init());
+  return { ...document, meta: { ...document.meta, id, name } };
+}
+
+/** The index rows implied by a set of documents, in the given order. */
+function rowsFor(...documents: PresetDocument[]): LibraryIndexRow[] {
+  return documents.map((document) => ({
+    id: document.meta.id,
+    name: document.meta.name,
+  }));
+}
+
+let storage: MemoryStorage;
+
+beforeEach(() => {
+  storage = createMemoryStorage();
+  vi.stubGlobal("localStorage", storage);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("library CRUD", () => {
+  it("round-trips a document through put -> list -> get -> remove", async () => {
+    const document = makeDocument("preset-a", "Alpha");
+
+    await putLibraryEntry(document);
+    await writeLibraryIndex(rowsFor(document));
+
+    // list (hydrate reads every entry through the schema).
+    const listed = hydrateLibrarySync();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toEqual(document);
+
+    // get (one entry decoded through the standard schema).
+    const raw = getItemSync(libraryEntryKey("preset-a"));
+    expect(raw).not.toBeNull();
+    const decoded = decodeLibraryEntry(raw!);
+    expect(decoded.status).toBe("ok");
+    if (decoded.status === "ok") expect(decoded.document).toEqual(document);
+
+    // remove.
+    await removeLibraryEntry("preset-a");
+    expect(getItemSync(libraryEntryKey("preset-a"))).toBeNull();
+    await writeLibraryIndex([]);
+    expect(hydrateLibrarySync()).toEqual([]);
+  });
+
+  it("keeps multiple entries in index order", () => {
+    const first = makeDocument("preset-1", "One");
+    const second = makeDocument("preset-2", "Two");
+    putLibraryEntrySync(first);
+    putLibraryEntrySync(second);
+    writeLibraryIndexSync(rowsFor(second, first));
+
+    const listed = hydrateLibrarySync();
+    expect(listed.map((d) => d.meta.id)).toEqual(["preset-2", "preset-1"]);
+  });
+});
+
+describe("index self-heal on hydrate", () => {
+  it("drops an index row whose entry is missing", () => {
+    const present = makeDocument("present", "Present");
+    putLibraryEntrySync(present);
+    // The index also names an entry that was never written.
+    writeLibraryIndexSync([
+      { id: "present", name: "Present" },
+      { id: "ghost", name: "Ghost" },
+    ]);
+
+    const listed = hydrateLibrarySync();
+    expect(listed.map((d) => d.meta.id)).toEqual(["present"]);
+    // The index was rewritten without the ghost row.
+    expect(readLibraryIndexSync()).toEqual([
+      { id: "present", name: "Present" },
+    ]);
+  });
+
+  it("appends an orphan entry that the index does not know about", () => {
+    const known = makeDocument("known", "Known");
+    const orphan = makeDocument("orphan", "Orphan");
+    putLibraryEntrySync(known);
+    putLibraryEntrySync(orphan);
+    // The index only knows the first one.
+    writeLibraryIndexSync(rowsFor(known));
+
+    const listed = hydrateLibrarySync();
+    expect(listed.map((d) => d.meta.id).sort()).toEqual(["known", "orphan"]);
+    // The healed index now carries both, orphan appended after the known row.
+    expect(readLibraryIndexSync().map((r) => r.id)).toEqual([
+      "known",
+      "orphan",
+    ]);
+  });
+
+  it("heals a stale name in the index from the entry meta (truth)", () => {
+    const document = makeDocument("preset", "Real Name");
+    putLibraryEntrySync(document);
+    writeLibraryIndexSync([{ id: "preset", name: "Stale Name" }]);
+
+    hydrateLibrarySync();
+    expect(readLibraryIndexSync()).toEqual([
+      { id: "preset", name: "Real Name" },
+    ]);
+  });
+});
+
+describe("corrupt-entry quarantine", () => {
+  it("quarantines a corrupt entry and hydrates the others", () => {
+    const good = makeDocument("good", "Good");
+    putLibraryEntrySync(good);
+    // A syntactically-broken entry directly in storage under the entry prefix.
+    storage.map.set(libraryEntryKey("bad"), "{ not json");
+    writeLibraryIndexSync([
+      { id: "good", name: "Good" },
+      { id: "bad", name: "Bad" },
+    ]);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const listed = hydrateLibrarySync();
+
+    // The good entry survives; the bad one is gone from the live set.
+    expect(listed.map((d) => d.meta.id)).toEqual(["good"]);
+    // Copied verbatim to its quarantine key, removed from the live key.
+    expect(storage.map.get(libraryQuarantineKey("bad"))).toBe("{ not json");
+    expect(storage.map.has(libraryEntryKey("bad"))).toBe(false);
+    // Dropped from the index.
+    expect(readLibraryIndexSync().map((r) => r.id)).toEqual(["good"]);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it("quarantines a schema-invalid (well-formed JSON) entry", () => {
+    storage.map.set(
+      libraryEntryKey("wrong"),
+      JSON.stringify({ kind: "drumhaus.preset", version: 2, nope: true }),
+    );
+    writeLibraryIndexSync([{ id: "wrong", name: "Wrong" }]);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    expect(hydrateLibrarySync()).toEqual([]);
+    expect(storage.map.has(libraryQuarantineKey("wrong"))).toBe(true);
+    expect(storage.map.has(libraryEntryKey("wrong"))).toBe(false);
+    expect(consoleError).toHaveBeenCalled();
+  });
+});
+
+describe("StorageFullError on quota", () => {
+  it("putLibraryEntrySync throws StorageFullError on a quota-refused write", () => {
+    const document = makeDocument("preset", "Preset");
+    storage.failWrite = (key) => key === libraryEntryKey("preset");
+
+    expect(() => putLibraryEntrySync(document)).toThrow(StorageFullError);
+  });
+
+  it("putLibraryEntry (async) rejects with StorageFullError on quota", async () => {
+    const document = makeDocument("preset", "Preset");
+    storage.failWrite = () => true;
+
+    await expect(putLibraryEntry(document)).rejects.toBeInstanceOf(
+      StorageFullError,
+    );
+  });
+
+  it("writeLibraryIndex rejects with StorageFullError on quota", async () => {
+    storage.failWrite = (key) => key === LIBRARY_INDEX_KEY;
+    await expect(writeLibraryIndex([])).rejects.toBeInstanceOf(
+      StorageFullError,
+    );
+  });
+});

--- a/src/features/preset/library/library.ts
+++ b/src/features/preset/library/library.ts
@@ -1,0 +1,314 @@
+/**
+ * The preset library: each saved preset is its own storage entry holding the
+ * MINIFIED preset document, plus a small index key for ordering
+ * (docs/preset-persistence.md, "Library storage: documents under per-preset
+ * keys", decision 14). The design doc writes the entry keys with dots
+ * (`drumhaus.preset.<id>`); this module follows the repo's established dash
+ * convention (`drumhaus-session`, `drumhaus-session-ui`) instead.
+ *
+ * The index is a cache and entry meta is truth: boot self-heals by dropping
+ * index rows whose entry is missing and appending entries the index does not
+ * know about. A corrupt entry is quarantined (copied to its quarantine key,
+ * then removed from live, never destroyed) and dropped from the index with a
+ * console.error.
+ *
+ * Two access levels, mirroring storage.ts: the async CRUD functions the
+ * store mutations use (through the LibraryStorage facade), and the sync
+ * hydrate for bootstrapLibrary(), which must fill the in-memory library
+ * before React's first paint.
+ */
+
+import {
+  CorruptFieldError,
+  InvalidFileError,
+  presetDocumentSchema,
+  type PresetDocument,
+  type PresetDocumentError,
+} from "@/features/preset/document";
+import {
+  getItemSync,
+  libraryStorage,
+  listKeysSync,
+  putItemSync,
+  removeItemSync,
+} from "./storage";
+
+const LIBRARY_ENTRY_KEY_PREFIX = "drumhaus-preset-";
+const LIBRARY_INDEX_KEY = "drumhaus-preset-index";
+const LIBRARY_QUARANTINE_KEY_PREFIX = "drumhaus-preset-quarantine-";
+
+/** One ordered index row; everything list-shaped in the UI reads these. */
+interface LibraryIndexRow {
+  id: string;
+  name: string;
+}
+
+function libraryEntryKey(id: string): string {
+  return `${LIBRARY_ENTRY_KEY_PREFIX}${id}`;
+}
+
+function libraryQuarantineKey(id: string): string {
+  return `${LIBRARY_QUARANTINE_KEY_PREFIX}${id}`;
+}
+
+/**
+ * The index and quarantine keys live under the entry prefix (their spelling
+ * is fixed by the design doc), so both entry scans and entry writes must
+ * exclude them. An id that would collide is refused at write time.
+ */
+function isReservedLibraryId(id: string): boolean {
+  const key = libraryEntryKey(id);
+  return (
+    key === LIBRARY_INDEX_KEY || key.startsWith(LIBRARY_QUARANTINE_KEY_PREFIX)
+  );
+}
+
+function isLibraryEntryKey(key: string): boolean {
+  return (
+    key.startsWith(LIBRARY_ENTRY_KEY_PREFIX) &&
+    key !== LIBRARY_INDEX_KEY &&
+    !key.startsWith(LIBRARY_QUARANTINE_KEY_PREFIX)
+  );
+}
+
+/**
+ * Serialize a document for an entry: the storage encoding is minified JSON
+ * of the schema-parsed document, so an out-of-range value fails loudly at
+ * write time (same posture as encodePresetDocument) and key order is
+ * deterministic.
+ */
+function encodeLibraryEntry(document: PresetDocument): string {
+  return JSON.stringify(presetDocumentSchema.parse(document));
+}
+
+type LibraryEntryDecodeResult =
+  | { status: "ok"; document: PresetDocument }
+  | { status: "corrupt"; error: PresetDocumentError };
+
+/** Decode one entry payload through the standard document schema. */
+function decodeLibraryEntry(raw: string): LibraryEntryDecodeResult {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return {
+      status: "corrupt",
+      error: new InvalidFileError("Library entry is not valid JSON"),
+    };
+  }
+
+  const result = presetDocumentSchema.safeParse(data);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    return {
+      status: "corrupt",
+      error: new CorruptFieldError(issue.path.join("."), issue.message),
+    };
+  }
+
+  return { status: "ok", document: result.data };
+}
+
+// --- Sync internals (boot + adoption) ----------------------------------------
+
+/**
+ * Read the index rows. The index is a cache, so an unreadable or misshapen
+ * index degrades to empty and the entry scan in hydrateLibrarySync rebuilds
+ * it; no data is at risk.
+ */
+function readLibraryIndexSync(): LibraryIndexRow[] {
+  const raw = getItemSync(LIBRARY_INDEX_KEY);
+  if (raw === null) return [];
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+
+  return data.filter(
+    (row): row is LibraryIndexRow =>
+      typeof row === "object" &&
+      row !== null &&
+      typeof (row as { id?: unknown }).id === "string" &&
+      typeof (row as { name?: unknown }).name === "string",
+  );
+}
+
+/**
+ * Write the index rows.
+ *
+ * @throws {StorageFullError} If the browser refused the write for quota
+ */
+function writeLibraryIndexSync(rows: LibraryIndexRow[]): void {
+  putItemSync(LIBRARY_INDEX_KEY, JSON.stringify(rows));
+}
+
+/**
+ * Write one entry.
+ *
+ * @throws {StorageFullError} If the browser refused the write for quota
+ * @throws {z.ZodError} If the document violates presetDocumentSchema
+ */
+function putLibraryEntrySync(document: PresetDocument): void {
+  if (isReservedLibraryId(document.meta.id)) {
+    throw new Error(
+      `Preset id "${document.meta.id}" collides with a reserved library key`,
+    );
+  }
+  putItemSync(libraryEntryKey(document.meta.id), encodeLibraryEntry(document));
+}
+
+/**
+ * Move a corrupt entry payload to its quarantine key: copy first, remove
+ * from live only after the copy landed, never destroy. Best-effort - a
+ * failed quarantine write leaves the corrupt entry in place, and the next
+ * boot tries again.
+ */
+function quarantineLibraryEntrySync(id: string, raw: string): void {
+  try {
+    putItemSync(libraryQuarantineKey(id), raw);
+    removeItemSync(libraryEntryKey(id));
+  } catch (error) {
+    console.error(
+      `Drumhaus library: failed to quarantine corrupt entry "${id}"; ` +
+        "leaving it in place",
+      error,
+    );
+  }
+}
+
+/**
+ * Hydrate the library from storage, self-healing the index against the
+ * entries (entry meta is truth):
+ *
+ * - index rows whose entry is missing are dropped,
+ * - entries the index does not know are appended in scan order,
+ * - corrupt entries are quarantined and dropped, with a console.error.
+ *
+ * Returns the documents in final index order. The index is rewritten only
+ * when healing changed it (best-effort: an unwritable index just self-heals
+ * again next boot).
+ */
+function hydrateLibrarySync(): PresetDocument[] {
+  const indexRows = readLibraryIndexSync();
+  const documents: PresetDocument[] = [];
+  const healedRows: LibraryIndexRow[] = [];
+  const seen = new Set<string>();
+  let changed = false;
+
+  const readEntry = (id: string): PresetDocument | null => {
+    const raw = getItemSync(libraryEntryKey(id));
+    if (raw === null) return null;
+    const decoded = decodeLibraryEntry(raw);
+    if (decoded.status === "corrupt") {
+      console.error(
+        `Drumhaus library: entry "${id}" is corrupt; quarantining it`,
+        decoded.error,
+      );
+      quarantineLibraryEntrySync(id, raw);
+      return null;
+    }
+    return decoded.document;
+  };
+
+  for (const row of indexRows) {
+    if (seen.has(row.id)) {
+      changed = true;
+      continue;
+    }
+    seen.add(row.id);
+
+    const document = readEntry(row.id);
+    if (document === null) {
+      changed = true;
+      continue;
+    }
+
+    documents.push(document);
+    healedRows.push({ id: document.meta.id, name: document.meta.name });
+    if (document.meta.name !== row.name) changed = true;
+  }
+
+  // Entries the index does not know about (e.g. an interrupted write whose
+  // entry landed but whose index update did not) are appended.
+  for (const key of listKeysSync(LIBRARY_ENTRY_KEY_PREFIX)) {
+    if (!isLibraryEntryKey(key)) continue;
+    const id = key.slice(LIBRARY_ENTRY_KEY_PREFIX.length);
+    if (seen.has(id)) continue;
+    seen.add(id);
+
+    const document = readEntry(id);
+    if (document === null) {
+      changed = true;
+      continue;
+    }
+
+    documents.push(document);
+    healedRows.push({ id: document.meta.id, name: document.meta.name });
+    changed = true;
+  }
+
+  if (changed) {
+    try {
+      writeLibraryIndexSync(healedRows);
+    } catch (error) {
+      console.error("Drumhaus library: failed to rewrite the index", error);
+    }
+  }
+
+  return documents;
+}
+
+// --- Async CRUD (store mutations) ---------------------------------------------
+
+/**
+ * Write one entry through the async facade.
+ *
+ * @throws {StorageFullError} If the browser refused the write for quota
+ */
+async function putLibraryEntry(document: PresetDocument): Promise<void> {
+  if (isReservedLibraryId(document.meta.id)) {
+    throw new Error(
+      `Preset id "${document.meta.id}" collides with a reserved library key`,
+    );
+  }
+  await libraryStorage.put(
+    libraryEntryKey(document.meta.id),
+    encodeLibraryEntry(document),
+  );
+}
+
+async function removeLibraryEntry(id: string): Promise<void> {
+  await libraryStorage.remove(libraryEntryKey(id));
+}
+
+/**
+ * Write the index rows through the async facade.
+ *
+ * @throws {StorageFullError} If the browser refused the write for quota
+ */
+async function writeLibraryIndex(rows: LibraryIndexRow[]): Promise<void> {
+  await libraryStorage.put(LIBRARY_INDEX_KEY, JSON.stringify(rows));
+}
+
+export {
+  LIBRARY_ENTRY_KEY_PREFIX,
+  LIBRARY_INDEX_KEY,
+  LIBRARY_QUARANTINE_KEY_PREFIX,
+  decodeLibraryEntry,
+  hydrateLibrarySync,
+  isReservedLibraryId,
+  libraryEntryKey,
+  libraryQuarantineKey,
+  putLibraryEntry,
+  putLibraryEntrySync,
+  quarantineLibraryEntrySync,
+  readLibraryIndexSync,
+  removeLibraryEntry,
+  writeLibraryIndex,
+  writeLibraryIndexSync,
+};
+export type { LibraryIndexRow };

--- a/src/features/preset/library/storage.ts
+++ b/src/features/preset/library/storage.ts
@@ -1,0 +1,115 @@
+/**
+ * The library's storage backend (docs/preset-persistence.md, "Library
+ * storage: documents under per-preset keys", decision 14): a thin ASYNC
+ * key-value interface so IndexedDB can slot in behind the same contract if
+ * sample blobs ever ship, over the localStorage backend that is the right
+ * choice today (entries are a few KB after kit-by-reference).
+ *
+ * The sync functions are the backend's internals, exported for the two
+ * callers that legitimately need synchronous storage: bootstrapLibrary()
+ * (the in-memory library must be populated before React's first paint, so a
+ * saved preset is in the select immediately after reload) and the one-time
+ * legacy adoption that runs inside it. Everything after boot goes through
+ * the async facade.
+ *
+ * Access is guarded like session-storage.ts: private-browsing/storage-denied
+ * modes degrade reads to "nothing stored" and removals to no-ops rather
+ * than break boot. Writes are the exception: a failed write must surface to
+ * the caller (a save the user asked for did not land), so quota failures
+ * throw the typed StorageFullError and anything else propagates as-is.
+ */
+
+import { StorageFullError } from "@/features/preset/document";
+
+/** Quota failures across engines; everything modern uses the first name. */
+function isQuotaExceededError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "QuotaExceededError" ||
+      error.name === "NS_ERROR_DOM_QUOTA_REACHED")
+  );
+}
+
+/** Read one key; storage denial reads as missing. */
+function getItemSync(key: string): string | null {
+  try {
+    return globalThis.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write one key.
+ *
+ * @throws {StorageFullError} If the browser refused the write for quota
+ * @throws {Error} As thrown by the storage layer for any other failure
+ * (e.g. storage denied entirely)
+ */
+function putItemSync(key: string, value: string): void {
+  try {
+    globalThis.localStorage.setItem(key, value);
+  } catch (error) {
+    if (isQuotaExceededError(error)) throw new StorageFullError();
+    throw error;
+  }
+}
+
+/** Remove one key; storage denial is a no-op (there is nothing to remove). */
+function removeItemSync(key: string): void {
+  try {
+    globalThis.localStorage.removeItem(key);
+  } catch {
+    // Nothing readable means nothing removable.
+  }
+}
+
+/** All stored keys starting with `prefix`; storage denial reads as none. */
+function listKeysSync(prefix: string): string[] {
+  const keys: string[] = [];
+  try {
+    const storage = globalThis.localStorage;
+    for (let index = 0; index < storage.length; index++) {
+      const key = storage.key(index);
+      if (key !== null && key.startsWith(prefix)) keys.push(key);
+    }
+  } catch {
+    return [];
+  }
+  return keys;
+}
+
+/**
+ * The async storage interface the library is written against
+ * (decision 14). `put` rejects with StorageFullError on quota.
+ */
+interface LibraryStorage {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+  remove(key: string): Promise<void>;
+  list(prefix: string): Promise<string[]>;
+}
+
+/** The localStorage backend behind the async facade. */
+const libraryStorage: LibraryStorage = {
+  get: (key) => Promise.resolve(getItemSync(key)),
+  put: (key, value) => {
+    putItemSync(key, value);
+    return Promise.resolve();
+  },
+  remove: (key) => {
+    removeItemSync(key);
+    return Promise.resolve();
+  },
+  list: (prefix) => Promise.resolve(listKeysSync(prefix)),
+};
+
+export {
+  getItemSync,
+  isQuotaExceededError,
+  libraryStorage,
+  listKeysSync,
+  putItemSync,
+  removeItemSync,
+};
+export type { LibraryStorage };

--- a/src/features/preset/session/bootstrap.test.ts
+++ b/src/features/preset/session/bootstrap.test.ts
@@ -40,6 +40,7 @@ const SEQUENCER_KEY = "drumhaus-sequencer-storage";
 const TRANSPORT_KEY = "drumhaus-transport-storage";
 const MASTER_KEY = "drumhaus-master-chain-storage";
 const PRESET_META_KEY = "drumhaus-preset-meta-storage";
+const LIBRARY_BACKUP_KEY = "drumhaus-library-backup";
 const MUSICAL_LEGACY_KEYS = [
   INSTRUMENTS_KEY,
   SEQUENCER_KEY,
@@ -331,7 +332,8 @@ describe("bootstrapSession: corrupt session", () => {
 
 describe("bootstrapSession: one-time legacy adoption", () => {
   it("replays the five envelopes into the state the old rehydration produced", async () => {
-    const ctx = await boot(createMemoryStorage(legacySeed()));
+    const seed = legacySeed();
+    const ctx = await boot(createMemoryStorage(seed));
 
     // Transport: bpm verbatim, pre-#269 swing knob rescaled 48 -> 64.
     expect(ctx.useTransportStore.getState().bpm).toBe(128);
@@ -366,7 +368,8 @@ describe("bootstrapSession: one-time legacy adoption", () => {
     expect(meta.currentKitMeta.id).toBe("kit-0");
 
     // Session written; the four retired keys deleted; the selection seeded
-    // into the session-UI key; the library key survives (narrowed to v2).
+    // into the session-UI key; the legacy preset-meta key is consumed by the
+    // PR 6 library adoption (backed up verbatim, then retired).
     const envelopeRaw = ctx.storage.map.get(SESSION_KEY);
     expect(envelopeRaw).toBeDefined();
     const envelope = JSON.parse(envelopeRaw!) as {
@@ -389,11 +392,10 @@ describe("bootstrapSession: one-time legacy adoption", () => {
     };
     expect(sessionUi.state.variation).toBe(2);
 
-    const presetMetaEnvelope = JSON.parse(
-      ctx.storage.map.get(PRESET_META_KEY)!,
-    ) as { state: Record<string, unknown>; version: number };
-    expect(presetMetaEnvelope.version).toBe(2);
-    expect(Object.keys(presetMetaEnvelope.state)).toEqual(["customPresets"]);
+    // The library adoption retired the legacy preset-meta key, preserving
+    // its raw payload verbatim under the backup key (never destroyed).
+    expect(ctx.storage.map.has(PRESET_META_KEY)).toBe(false);
+    expect(ctx.storage.map.get(LIBRARY_BACKUP_KEY)).toBe(seed[PRESET_META_KEY]);
 
     // The adopted session reads clean.
     expect(ctx.usePresetMetaStore.getState().hasUnsavedChanges()).toBe(false);

--- a/src/features/preset/session/bootstrap.ts
+++ b/src/features/preset/session/bootstrap.ts
@@ -11,7 +11,7 @@
  * the retired transport onRehydrateStorage proved the engine tolerates
  * pre-init tempo/swing commands for years.
  *
- * Boot decision ladder:
+ * Boot decision ladder (after the library phase, see bootstrapLibrary):
  * 1. Session envelope present  -> apply it, restore the clean hash from the
  *    envelope (a session that was closed dirty must reload dirty).
  * 2. Session envelope corrupt  -> quarantine the payload (never destroy
@@ -30,6 +30,8 @@ import {
 } from "@/features/preset/document";
 import { applyPresetDocument } from "@/features/preset/document/apply";
 import { snapshotPresetDocument } from "@/features/preset/document/snapshot";
+import { adoptLegacyPresetLibrary } from "@/features/preset/library/adoption";
+import { hydrateLibrarySync } from "@/features/preset/library/library";
 import { usePresetMetaStore } from "@/features/preset/store/use-preset-meta-store";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import {
@@ -106,10 +108,48 @@ function adoptLegacySession(): void {
 }
 
 /**
+ * Adopt the legacy library once and hydrate the in-memory library from the
+ * per-preset entries (features/preset/library). Runs BEFORE the session
+ * ladder, deliberately, for two reasons:
+ *
+ * - applyPresetDocument registers a restored non-factory session preset via
+ *   addCustomPreset, whose dedupe (and best-effort index write) must see
+ *   the real library, not an empty one;
+ * - the legacy library adoption is what stashes the retired preset-meta
+ *   fields (legacy-preset-meta-capture.ts) that the session adopter reads.
+ *
+ * Hydration is synchronous through the storage backend's sync internals
+ * (the public library interface stays async, decision 14): the e2e contract
+ * is that a saved preset is in the select immediately after reload, and a
+ * post-mount async fill would race first paint.
+ */
+function bootstrapLibrary(): void {
+  try {
+    adoptLegacyPresetLibrary();
+  } catch (error) {
+    // Adoption failure preserves the legacy key (and its backup) for the
+    // next attempt; the library simply hydrates whatever entries exist.
+    console.error(
+      "Drumhaus boot: legacy library adoption failed; " +
+        "the legacy preset storage is preserved",
+      error,
+    );
+  }
+
+  try {
+    usePresetMetaStore.getState().hydrateLibrary(hydrateLibrarySync());
+  } catch (error) {
+    console.error("Drumhaus boot: failed to hydrate the preset library", error);
+  }
+}
+
+/**
  * Restore the working session into the stores. Must run before React
  * mounts; see the module comment.
  */
 function bootstrapSession(): void {
+  bootstrapLibrary();
+
   const session = readSessionEnvelope();
 
   if (session.status === "ok") {

--- a/src/features/preset/session/legacy-adopter.ts
+++ b/src/features/preset/session/legacy-adopter.ts
@@ -21,8 +21,8 @@
  * - master chain (unversioned): persisted fields over the store defaults,
  *   mirroring zustand's shallow merge.
  * - preset-meta: currentPresetMeta/currentKitMeta arrive via
- *   legacy-preset-meta-capture.ts (the store's own v2 migrate drops them
- *   from the envelope before this module runs).
+ *   legacy-preset-meta-capture.ts (the library adoption consumes and
+ *   deletes the envelope before this module runs).
  *
  * The assembled file is version 1.5 (current knob space - the swing replay
  * already happened), so the standard validate -> migrate -> apply pipeline
@@ -68,7 +68,12 @@ const LEGACY_INSTRUMENTS_STORAGE_KEY = "drumhaus-instruments-storage";
 const LEGACY_SEQUENCER_STORAGE_KEY = "drumhaus-sequencer-storage";
 const LEGACY_TRANSPORT_STORAGE_KEY = "drumhaus-transport-storage";
 const LEGACY_MASTER_CHAIN_STORAGE_KEY = "drumhaus-master-chain-storage";
-/** Stays alive for the library (customPresets, PR 6's territory). */
+/**
+ * Consumed and deleted by the library adoption
+ * (features/preset/library/adoption.ts), which runs before the session
+ * ladder and stashes the meta fields this adopter needs in
+ * legacy-preset-meta-capture.ts.
+ */
 const LEGACY_PRESET_META_STORAGE_KEY = "drumhaus-preset-meta-storage";
 
 /** The four keys the adopter deletes after a successful session write. */
@@ -113,8 +118,14 @@ function readLegacyPersistEnvelope(
   };
 }
 
-/** True when any of the five legacy persist keys is present. */
+/**
+ * True when any of the five legacy persist keys is present. The preset-meta
+ * key is usually gone by the time this runs (the library adoption consumes
+ * it earlier in the same boot), so its presence is read from the capture it
+ * leaves behind.
+ */
 function hasLegacySessionData(): boolean {
+  if (getCapturedLegacyPresetMeta() !== null) return true;
   try {
     return [
       ...RETIRED_LEGACY_STORAGE_KEYS,

--- a/src/features/preset/session/legacy-preset-meta-capture.ts
+++ b/src/features/preset/session/legacy-preset-meta-capture.ts
@@ -3,17 +3,19 @@
  * PR 5 (currentPresetMeta/currentKitMeta now restore via the session
  * document).
  *
- * WHY THIS EXISTS: zustand's persist middleware writes the migrated state
- * back to storage as soon as a version-bumped store hydrates, which happens
- * synchronously at module import - BEFORE bootstrapSession() runs. That
- * write-back narrows the drumhaus-preset-meta-storage envelope to
- * { customPresets }, destroying the very meta fields the one-time legacy
- * adopter needs to know which preset and kit the user had loaded. The
- * store's migrate function therefore hands the dropped fields to this
- * module on their way out, and the adopter reads them from here instead of
- * from storage.
+ * WHY THIS EXISTS: the legacy drumhaus-preset-meta-storage envelope is
+ * consumed and DELETED by the library adoption
+ * (features/preset/library/adoption.ts), which runs at the top of
+ * bootstrapSession - before the session ladder decides whether the one-time
+ * legacy SESSION adoption needs the currentPresetMeta/currentKitMeta fields
+ * that pre-PR 5 envelopes still carry. The library adoption therefore hands
+ * those fields to this module on their way out, and the session adopter
+ * reads them from here instead of from storage. (In PR 5 the same duty was
+ * performed by the store's persist migrate, which narrowed the envelope to
+ * { customPresets }; the persist is gone now that the library owns its own
+ * storage.)
  *
- * Deliberately import-free of stores so both the preset-meta store and the
+ * Deliberately import-free of stores so the library adoption and the
  * session bootstrap can depend on it without cycles.
  */
 
@@ -47,9 +49,9 @@ function asMeta(value: unknown): Meta | undefined {
 }
 
 /**
- * Called by the preset-meta store's persist migrate with the pre-narrowing
- * persisted state. Malformed fields capture as undefined; the adopter then
- * falls back to init()'s meta.
+ * Called by the library adoption with the legacy envelope's state, before
+ * the envelope is retired. Malformed fields capture as undefined; the
+ * session adopter then falls back to init()'s meta.
  */
 function captureLegacyPresetMeta(persistedState: unknown): void {
   if (typeof persistedState !== "object" || persistedState === null) return;

--- a/src/features/preset/store/use-preset-meta-store.test.ts
+++ b/src/features/preset/store/use-preset-meta-store.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Store-level tests for the library mutations on usePresetMetaStore: the real
+ * store drives the real per-preset library storage against an in-memory
+ * localStorage, and every mutation must leave the storage entry, the index,
+ * and the in-memory list coherent (docs/preset-persistence.md, PR 6).
+ *
+ * The engine is mocked so the suite runs in the node project; the store's
+ * snapshot path reaches the musical stores but never a live AudioContext.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { init } from "@/core/dh";
+import {
+  migrateV1ToDocument,
+  StorageFullError,
+  type PresetDocument,
+} from "@/features/preset/document";
+import {
+  hydrateLibrarySync,
+  libraryEntryKey,
+  readLibraryIndexSync,
+} from "@/features/preset/library/library";
+import { getItemSync } from "@/features/preset/library/storage";
+import { usePresetMetaStore } from "./use-preset-meta-store";
+
+vi.mock("@/core/audio/engine", () => ({
+  getAudioEngine: () => ({
+    play: vi.fn(() => Promise.resolve()),
+    stop: vi.fn(),
+    setTempo: vi.fn(),
+    setSwing: vi.fn(),
+  }),
+}));
+
+interface MemoryStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  key: (index: number) => string | null;
+  readonly length: number;
+  map: Map<string, string>;
+  failWrite: ((key: string) => boolean) | null;
+}
+
+function quotaError(): Error {
+  const error = new Error("The quota has been exceeded.");
+  error.name = "QuotaExceededError";
+  return error;
+}
+
+function createMemoryStorage(): MemoryStorage {
+  const map = new Map<string, string>();
+  const storage: MemoryStorage = {
+    map,
+    failWrite: null,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      if (storage.failWrite?.(key)) throw quotaError();
+      map.set(key, String(value));
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+    key: (index) => [...map.keys()][index] ?? null,
+    get length() {
+      return map.size;
+    },
+  };
+  return storage;
+}
+
+function makeDocument(id: string, name: string): PresetDocument {
+  const document = migrateV1ToDocument(init());
+  return { ...document, meta: { ...document.meta, id, name } };
+}
+
+/** Flush the fire-and-forget index write scheduled by addCustomPreset. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+let storage: MemoryStorage;
+
+beforeEach(() => {
+  storage = createMemoryStorage();
+  vi.stubGlobal("localStorage", storage);
+  usePresetMetaStore.setState({
+    customPresets: [],
+    currentPresetMeta: init().meta,
+    currentKitMeta: init().kit.meta,
+    cleanHash: null,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** Assert that memory, the entry, and the index agree for a document id. */
+function expectCoherent(id: string, name: string): void {
+  const store = usePresetMetaStore.getState();
+  const inMemory = store.customPresets.find((d) => d.meta.id === id);
+  expect(inMemory?.meta.name).toBe(name);
+
+  const entry = getItemSync(libraryEntryKey(id));
+  expect(entry).not.toBeNull();
+
+  const indexRow = readLibraryIndexSync().find((r) => r.id === id);
+  expect(indexRow?.name).toBe(name);
+
+  const hydrated = hydrateLibrarySync().find((d) => d.meta.id === id);
+  expect(hydrated?.meta.name).toBe(name);
+}
+
+describe("saveCurrentAsNewPreset", () => {
+  it("writes entry + index + memory coherently", async () => {
+    const saved = await usePresetMetaStore
+      .getState()
+      .saveCurrentAsNewPreset("My Beat");
+
+    expect(saved).not.toBeNull();
+    expect(saved!.meta.name).toBe("My Beat");
+    expectCoherent(saved!.meta.id, "My Beat");
+    // Newest first.
+    expect(usePresetMetaStore.getState().customPresets[0].meta.id).toBe(
+      saved!.meta.id,
+    );
+  });
+
+  it("returns null at the preset limit without writing", async () => {
+    const full = Array.from({ length: 100 }, (_, i) =>
+      makeDocument(`preset-${i}`, `Preset ${i}`),
+    );
+    usePresetMetaStore.getState().hydrateLibrary(full);
+
+    const saved = await usePresetMetaStore
+      .getState()
+      .saveCurrentAsNewPreset("Overflow");
+
+    expect(saved).toBeNull();
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(100);
+  });
+
+  it("surfaces StorageFullError and does not touch memory", async () => {
+    storage.failWrite = () => true;
+
+    await expect(
+      usePresetMetaStore.getState().saveCurrentAsNewPreset("Nope"),
+    ).rejects.toBeInstanceOf(StorageFullError);
+
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(0);
+  });
+});
+
+describe("updateCustomPreset", () => {
+  it("rewrites the entry under the same id", async () => {
+    const saved = await usePresetMetaStore
+      .getState()
+      .saveCurrentAsNewPreset("Original");
+    const id = saved!.meta.id;
+
+    // Edit the live transport so the snapshot differs, then update.
+    usePresetMetaStore.setState((state) => ({
+      currentPresetMeta: { ...state.currentPresetMeta },
+    }));
+    await usePresetMetaStore.getState().updateCustomPreset(id);
+
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(1);
+    expectCoherent(id, "Original");
+  });
+
+  it("does nothing for an unknown id", async () => {
+    await usePresetMetaStore.getState().updateCustomPreset("ghost");
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(0);
+  });
+});
+
+describe("renameCustomPreset", () => {
+  it("rewrites the entry meta and the index row", async () => {
+    const saved = await usePresetMetaStore
+      .getState()
+      .saveCurrentAsNewPreset("Before");
+    const id = saved!.meta.id;
+
+    await usePresetMetaStore.getState().renameCustomPreset(id, "After");
+
+    expectCoherent(id, "After");
+  });
+});
+
+describe("duplicateCustomPreset", () => {
+  it("creates a distinct entry copied from the source", async () => {
+    const saved = await usePresetMetaStore
+      .getState()
+      .saveCurrentAsNewPreset("Source");
+    const sourceId = saved!.meta.id;
+
+    const dupe = await usePresetMetaStore
+      .getState()
+      .duplicateCustomPreset(sourceId);
+
+    expect(dupe.meta.id).not.toBe(sourceId);
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(2);
+    // Newest (the duplicate) is unshifted to the front.
+    expect(usePresetMetaStore.getState().customPresets[0].meta.id).toBe(
+      dupe.meta.id,
+    );
+    expectCoherent(dupe.meta.id, dupe.meta.name);
+    expectCoherent(sourceId, "Source");
+  });
+
+  it("rejects for an unknown id", async () => {
+    await expect(
+      usePresetMetaStore.getState().duplicateCustomPreset("ghost"),
+    ).rejects.toThrow();
+  });
+});
+
+describe("deleteCustomPreset", () => {
+  it("removes entry, index row, and memory together", async () => {
+    const saved = await usePresetMetaStore
+      .getState()
+      .saveCurrentAsNewPreset("Doomed");
+    const id = saved!.meta.id;
+
+    await usePresetMetaStore.getState().deleteCustomPreset(id);
+
+    expect(usePresetMetaStore.getState().customPresets).toHaveLength(0);
+    expect(getItemSync(libraryEntryKey(id))).toBeNull();
+    expect(readLibraryIndexSync().find((r) => r.id === id)).toBeUndefined();
+  });
+});
+
+describe("addCustomPreset (import path)", () => {
+  it("dedupes by id and unshifts the newest to the front", async () => {
+    const first = makeDocument("import-1", "First");
+    const second = makeDocument("import-2", "Second");
+
+    usePresetMetaStore.getState().addCustomPreset(first);
+    usePresetMetaStore.getState().addCustomPreset(second);
+    // A duplicate id is ignored.
+    usePresetMetaStore
+      .getState()
+      .addCustomPreset(makeDocument("import-1", "Dup"));
+
+    const ids = usePresetMetaStore
+      .getState()
+      .customPresets.map((d) => d.meta.id);
+    expect(ids).toEqual(["import-2", "import-1"]);
+
+    // The best-effort entry + index writes eventually land.
+    await flushMicrotasks();
+    expectCoherent("import-1", "First");
+    expectCoherent("import-2", "Second");
+  });
+});

--- a/src/features/preset/store/use-preset-meta-store.ts
+++ b/src/features/preset/store/use-preset-meta-store.ts
@@ -1,13 +1,17 @@
 import { create } from "zustand";
-import { devtools, persist } from "zustand/middleware";
+import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { init } from "@/core/dh";
+import type { PresetDocument } from "@/features/preset/document";
 import { snapshotPresetDocument } from "@/features/preset/document/snapshot";
 import { getDefaultPresets } from "@/features/preset/lib/constants";
-import { getCurrentPreset } from "@/features/preset/lib/helpers";
+import {
+  putLibraryEntry,
+  removeLibraryEntry,
+  writeLibraryIndex,
+} from "@/features/preset/library/library";
 import { hashPresetDocument } from "@/features/preset/session/canonical-hash";
-import { captureLegacyPresetMeta } from "@/features/preset/session/legacy-preset-meta-capture";
 import type { Meta } from "@/features/preset/types/meta";
 import type { PresetFileV1 } from "@/features/preset/types/preset";
 
@@ -29,8 +33,14 @@ interface PresetMetaState {
    */
   cleanHash: string | null;
 
-  // Custom presets (loaded from files or URLs)
-  customPresets: PresetFileV1[];
+  /**
+   * The in-memory preset library: full documents in index order, hydrated
+   * from per-preset storage entries at boot (features/preset/library).
+   * This store is no longer persisted; storage entries and the index are
+   * written per mutation, and the index self-heals against entry meta at
+   * boot, so memory and storage cannot version-skew.
+   */
+  customPresets: PresetDocument[];
 
   // Actions
   setPresetMeta: (meta: Meta) => void;
@@ -65,45 +75,63 @@ interface PresetMetaState {
   hasUnsavedChanges: () => boolean;
 
   /**
-   * Add a custom preset if not already in default or custom presets
-   * Prevents duplicates when loading from URLs or files
+   * Replace the in-memory library with the boot-hydrated documents
+   * (bootstrapLibrary; must run before any preset document is applied so
+   * addCustomPreset's dedupe sees the real library).
    */
-  addCustomPreset: (preset: PresetFileV1) => void;
+  hydrateLibrary: (documents: PresetDocument[]) => void;
 
   /**
-   * Save current state as a new custom preset
-   * Returns the created preset or null if limit reached
+   * Add a preset document to the library if not already present (dedupe by
+   * id, most recent first). Called synchronously from applyPresetDocument
+   * when a non-factory preset loads (file import, share link), so the
+   * storage write is best-effort: a failure keeps the preset in memory for
+   * this session and logs.
    */
-  saveCurrentAsNewPreset: (name: string) => PresetFileV1 | null;
+  addCustomPreset: (document: PresetDocument) => void;
 
   /**
-   * Update an existing custom preset with current state
-   * Does nothing if preset is not found or is a factory preset
+   * Save current state as a new custom preset: snapshot -> entry write ->
+   * index -> memory. Returns the created document, or null if the library
+   * limit is reached.
+   *
+   * @throws {StorageFullError} If the browser refused the entry write
    */
-  updateCustomPreset: (id: string) => void;
+  saveCurrentAsNewPreset: (name: string) => Promise<PresetDocument | null>;
 
   /**
-   * Rename a custom preset
-   * Does nothing if preset is not found or is a factory preset
+   * Update an existing custom preset with current state.
+   * Does nothing if the preset is not in the library.
+   *
+   * @throws {StorageFullError} If the browser refused the entry write
    */
-  renameCustomPreset: (id: string, newName: string) => void;
+  updateCustomPreset: (id: string) => Promise<void>;
 
   /**
-   * Duplicate a custom preset
-   * Returns the duplicated preset
+   * Rename a custom preset: rewrites the entry's meta AND the index row.
+   * Does nothing if the preset is not in the library.
+   *
+   * @throws {StorageFullError} If the browser refused the entry write
    */
-  duplicateCustomPreset: (id: string) => PresetFileV1;
+  renameCustomPreset: (id: string, newName: string) => Promise<void>;
 
   /**
-   * Delete a custom preset
-   * Does nothing if preset is not found
+   * Duplicate a custom preset. Returns the duplicated document.
+   *
+   * @throws {StorageFullError} If the browser refused the entry write
    */
-  deleteCustomPreset: (id: string) => void;
+  duplicateCustomPreset: (id: string) => Promise<PresetDocument>;
+
+  /**
+   * Delete a custom preset (entry, index row, and memory).
+   * Does nothing if preset is not found.
+   */
+  deleteCustomPreset: (id: string) => Promise<void>;
 
   /**
    * Get a custom preset by ID
    */
-  getCustomPresetById: (id: string) => PresetFileV1 | undefined;
+  getCustomPresetById: (id: string) => PresetDocument | undefined;
 
   /**
    * Check if a preset ID is a custom preset (not factory)
@@ -118,11 +146,31 @@ interface PresetMetaState {
 
 const usePresetMetaStore = create<PresetMetaState>()(
   devtools(
-    persist(
-      immer((set, get) => ({
+    immer((set, get) => {
+      /**
+       * Rewrite the index from the in-memory order. The entry write is the
+       * one that must succeed (entry meta is truth); the index is a cache,
+       * so its write is best-effort and boot self-heal repairs a miss.
+       */
+      const persistIndexFromMemory = () => {
+        const rows = get().customPresets.map((document) => ({
+          id: document.meta.id,
+          name: document.meta.name,
+        }));
+        void writeLibraryIndex(rows).catch((error: unknown) => {
+          console.error(
+            "Drumhaus library: failed to write the index; " +
+              "the next boot rebuilds it from the entries",
+            error,
+          );
+        });
+      };
+
+      return {
         // Initial state - init preset "init.dh". The clean baseline starts
         // null (nothing to compare against); bootstrapSession always applies
-        // a document before React mounts, which sets it.
+        // a document before React mounts, which sets it. The library starts
+        // empty and hydrates in the same boot pass.
         currentPresetMeta: init().meta,
         currentKitMeta: init().kit.meta,
         cleanHash: null,
@@ -179,136 +227,179 @@ const usePresetMetaStore = create<PresetMetaState>()(
           return currentHash !== cleanHash;
         },
 
-        addCustomPreset: (preset) => {
+        hydrateLibrary: (documents) => {
           set((state) => {
-            // Check if already in custom presets
-            const exists = state.customPresets.some(
-              (p) => p.meta.id === preset.meta.id,
-            );
-            if (!exists) {
-              // Insert at front so most recent shows first
-              state.customPresets.unshift(preset);
-            }
+            state.customPresets = documents;
           });
         },
 
-        saveCurrentAsNewPreset: (name) => {
-          const { customPresets, currentPresetMeta, currentKitMeta } = get();
+        addCustomPreset: (document) => {
+          const exists = get().customPresets.some(
+            (preset) => preset.meta.id === document.meta.id,
+          );
+          if (exists) return;
+
+          // Insert at front so most recent shows first
+          set((state) => {
+            state.customPresets.unshift(document);
+          });
+
+          // Best-effort persistence (see the interface doc): entry first,
+          // then the index, mirroring the awaited mutations.
+          void putLibraryEntry(document)
+            .then(() => {
+              persistIndexFromMemory();
+            })
+            .catch((error: unknown) => {
+              console.error(
+                "Drumhaus library: failed to persist the imported preset " +
+                  `"${document.meta.name}"; it stays available this session`,
+                error,
+              );
+            });
+        },
+
+        saveCurrentAsNewPreset: async (name) => {
+          const { customPresets, currentKitMeta } = get();
 
           // Check limit
           if (customPresets.length >= MAX_CUSTOM_PRESETS) {
             return null;
           }
 
-          // Get current state from all stores
-          const currentState = getCurrentPreset(
-            currentPresetMeta,
+          // Snapshot the live stores as a document under fresh identity.
+          const now = new Date().toISOString();
+          const document = snapshotPresetDocument(
+            {
+              id: crypto.randomUUID(),
+              name,
+              createdAt: now,
+              updatedAt: now,
+            },
             currentKitMeta,
           );
 
-          // Create new preset with new ID and metadata
-          const newPreset: PresetFileV1 = {
-            ...currentState,
-            meta: {
-              id: crypto.randomUUID(),
-              name,
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-            },
-          };
+          // Entry write first: a quota failure throws before memory changes,
+          // so the store never claims a save that did not land.
+          await putLibraryEntry(document);
 
-          // Add to custom presets
           set((state) => {
-            state.customPresets.unshift(newPreset);
+            state.customPresets.unshift(document);
           });
+          persistIndexFromMemory();
 
-          return newPreset;
+          return document;
         },
 
-        updateCustomPreset: (id) => {
-          let saved = false;
+        updateCustomPreset: async (id) => {
+          const { customPresets, currentKitMeta } = get();
+          const index = customPresets.findIndex(
+            (preset) => preset.meta.id === id,
+          );
+          if (index === -1) return;
+
+          // Snapshot current state under the entry's identity; the snapshot
+          // mints a fresh updatedAt.
+          const document = snapshotPresetDocument(
+            customPresets[index].meta,
+            currentKitMeta,
+          );
+
+          await putLibraryEntry(document);
+
           set((state) => {
-            const index = state.customPresets.findIndex(
-              (p) => p.meta.id === id,
-            );
-            if (index === -1) return;
-
-            // Get current state
-            const currentState = getCurrentPreset(
-              state.currentPresetMeta,
-              state.currentKitMeta,
-            );
-
-            // Update preset in place, preserving original ID and metadata
-            state.customPresets[index] = {
-              ...currentState,
-              meta: {
-                ...state.customPresets[index].meta,
-                updatedAt: new Date().toISOString(),
-              },
-            };
-
-            saved = true;
+            state.customPresets[index] = document;
           });
+          persistIndexFromMemory();
 
           // The saved state IS the current state, so reset the clean
           // baseline from the live snapshot.
-          if (saved) get().markPresetClean();
+          get().markPresetClean();
         },
 
-        renameCustomPreset: (id, newName) => {
+        renameCustomPreset: async (id, newName) => {
+          const { customPresets, currentPresetMeta, hasUnsavedChanges } = get();
+          const index = customPresets.findIndex(
+            (preset) => preset.meta.id === id,
+          );
+          if (index === -1) return;
+
+          // When renaming the CURRENT preset, a clean session must stay
+          // clean: the baseline hash includes meta.name, so it is
+          // recomputed after the rename. A dirty session stays dirty (the
+          // baseline keeps pointing at the last saved content).
+          const isCurrent = currentPresetMeta.id === id;
+          const wasClean = isCurrent && !hasUnsavedChanges();
+
+          const now = new Date().toISOString();
+          const renamed: PresetDocument = {
+            ...customPresets[index],
+            meta: {
+              ...customPresets[index].meta,
+              name: newName,
+              updatedAt: now,
+            },
+          };
+
+          // Rename rewrites the entry's meta AND the index row.
+          await putLibraryEntry(renamed);
+
           set((state) => {
-            const preset = state.customPresets.find((p) => p.meta.id === id);
-            if (!preset) return;
-
-            preset.meta.name = newName;
-            preset.meta.updatedAt = new Date().toISOString();
-
-            // If this is the current preset, update current meta too
-            if (state.currentPresetMeta.id === id) {
+            state.customPresets[index] = renamed;
+            if (isCurrent) {
               state.currentPresetMeta.name = newName;
-              state.currentPresetMeta.updatedAt = new Date().toISOString();
+              state.currentPresetMeta.updatedAt = now;
             }
           });
+          persistIndexFromMemory();
+
+          if (wasClean) get().markPresetClean();
         },
 
-        duplicateCustomPreset: (id) => {
-          const { customPresets } = get();
-          const sourcePreset = customPresets.find((p) => p.meta.id === id);
+        duplicateCustomPreset: async (id) => {
+          const sourcePreset = get().customPresets.find(
+            (preset) => preset.meta.id === id,
+          );
 
           if (!sourcePreset) {
             throw new Error(`Preset with id ${id} not found`);
           }
 
           // Create duplicate with new ID and timestamps
-          const duplicatedPreset: PresetFileV1 = {
+          const now = new Date().toISOString();
+          const duplicatedPreset: PresetDocument = {
             ...sourcePreset,
             meta: {
               ...sourcePreset.meta,
               id: crypto.randomUUID(),
-              createdAt: new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
+              createdAt: now,
+              updatedAt: now,
             },
           };
 
-          // Add to custom presets
+          await putLibraryEntry(duplicatedPreset);
+
           set((state) => {
             state.customPresets.unshift(duplicatedPreset);
           });
+          persistIndexFromMemory();
 
           return duplicatedPreset;
         },
 
-        deleteCustomPreset: (id) => {
+        deleteCustomPreset: async (id) => {
+          await removeLibraryEntry(id);
+
           set((state) => {
             state.customPresets = state.customPresets.filter(
-              (p) => p.meta.id !== id,
+              (preset) => preset.meta.id !== id,
             );
           });
+          persistIndexFromMemory();
         },
 
         getCustomPresetById: (id) => {
-          return get().customPresets.find((p) => p.meta.id === id);
+          return get().customPresets.find((preset) => preset.meta.id === id);
         },
 
         isCustomPreset: (id) => {
@@ -320,32 +411,8 @@ const usePresetMetaStore = create<PresetMetaState>()(
         canAddCustomPreset: () => {
           return get().customPresets.length < MAX_CUSTOM_PRESETS;
         },
-      })),
-      {
-        name: "drumhaus-preset-meta-storage",
-        // v2 (PR 5): currentPresetMeta/currentKitMeta moved into the session
-        // document (features/preset/session); only the library remains here
-        // (PR 6's territory). cleanHash is runtime state persisted in the
-        // session envelope, never here.
-        version: 2,
-        partialize: (state) => ({
-          customPresets: state.customPresets,
-        }),
-        migrate: (persistedState: unknown, version: number) => {
-          if (version < 2) {
-            // Hand the dropped meta fields to the legacy session adopter
-            // before zustand's post-migration write-back narrows the
-            // envelope (see legacy-preset-meta-capture.ts).
-            captureLegacyPresetMeta(persistedState);
-            const state = persistedState as {
-              customPresets?: PresetFileV1[];
-            } | null;
-            return { customPresets: state?.customPresets ?? [] };
-          }
-          return persistedState;
-        },
-      },
-    ),
+      };
+    }),
     {
       name: "PresetMetaStore",
     },

--- a/src/features/preset/types/preset.ts
+++ b/src/features/preset/types/preset.ts
@@ -2,7 +2,7 @@ import { MasterChainParams } from "@/core/audio/bridge/knob-to-domain";
 import { KitFileV1 } from "@/features/kit/types/kit";
 import { SequencerData } from "@/features/sequencer/types/sequencer";
 import { TransportParams } from "@/features/transport/types/transport";
-import { Meta } from "./meta";
+import { InlineMeta, Meta } from "./meta";
 
 // Presets hold all serializable data for a project
 // They are always deconstructed at runtime into their respective stores
@@ -22,4 +22,12 @@ interface PresetFileV1 {
   masterChain: MasterChainParams;
 }
 
-export type { PresetFileV1 };
+// The minimal shape a preset list needs: identity meta only. Both
+// PresetFileV1 (factory presets) and PresetDocument (library entries) satisfy
+// it, so list UIs and name helpers can take either without caring which
+// serialization family they hold.
+interface PresetListItem {
+  meta: InlineMeta;
+}
+
+export type { PresetFileV1, PresetListItem };


### PR DESCRIPTION
PR 6 of the preset-persistence plan (docs/preset-persistence.md, #329) - the highest user-data-sensitivity PR: the preset library stops being one array in a store's persist blob and becomes per-preset document entries behind an async storage facade (decision 14). Completes PR 3's deferred half - save flows finally go through snapshot().

The library (features/preset/library):

- An async storage interface with a localStorage backend (so IndexedDB can slot in if sample blobs ever ship). Each saved preset is its own entry drumhaus-preset-<id> holding the minified document; a small self-healing drumhaus-preset-index of { id, name } gives cheap listing (index is a cache, entries are truth - boot drops index rows with no entry and appends orphan entries).
- Writes touch one entry, not the whole array. QuotaExceededError becomes the typed StorageFullError the taxonomy reserved, surfaced as a toast. A corrupt entry quarantines to its own key and drops from the index without breaking the rest - a single bad preset can no longer poison the library.
- Save flows switch to snapshotPresetDocument() (safe now that dirty tracking is hash-based, not JSON-equality); library select applies the document directly with no per-select migration.

Adoption (in bootstrap, quarantine-never-destroy):

- The legacy customPresets array is migrated once: the raw JSON is copied verbatim to drumhaus-library-backup FIRST (the escape hatch), then each entry migrates individually (validate -> migrateV1ToDocument -> put), a failing entry quarantines to its own key without blocking the others, and the legacy key is deleted only after every entry is written or quarantined. A quota hit mid-adoption stops with the legacy key and backup intact and resumes idempotently next boot (entries already written are recognized by id, never duplicated).

Boot hydration is synchronous inside bootstrapSession (the public interface stays async per decision 14), so a saved preset is in the select immediately on reload with no flash - proven by e2e.

Verification: 1146 vitest tests green (unit + browser), 22/22 e2e against a production build including library CRUD-across-reload and a mixed valid/corrupt legacy adoption run, oxlint clean, tsc clean, build clean.

Two existing adoption assertions were updated (not loosened): PR 5 kept the legacy preset-meta key; PR 6 legitimately consumes it, so the specs now assert the key is gone and the backup holds its verbatim raw payload.

Out of scope, noted for follow-up: opening the per-preset Manage dialog from inside the open preset Select leaves a Radix trigger stuck (pointer-events blocked until reload) - pre-existing, unrelated to storage.