### PR TITLE
feat(param-control): descriptor-driven knob primitive (standalone, additive)

### DIFF
--- a/src/core/audio/canonical/filter.ts
+++ b/src/core/audio/canonical/filter.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical split-filter value.
+ *
+ * Per docs/data-representation.md (Principle P2), the split filter is stored
+ * as `{ side, cutoffHz }` - the musical intent - rather than a UI position or
+ * two raw node frequencies. This is one of the two principled musical
+ * exceptions to "canonical equals engine-native".
+ *
+ * This type is the SHARED seam between two epics:
+ *   - the knob primitive (Epic 2) maps a normalized position to and from this
+ *     value inside the filter descriptor's custom taper, and
+ *   - the engine refactor (Epic 1 PR B) will consume this same type when the
+ *     split filter becomes Tone-native (the engine takes derived frequencies).
+ *
+ * Keep both consumers pointed at THIS definition so the widget and the engine
+ * cannot drift.
+ */
+
+type FilterSide = "lowpass" | "highpass";
+
+interface CanonicalFilter {
+  side: FilterSide;
+  cutoffHz: number;
+}
+
+export type { FilterSide, CanonicalFilter };

--- a/src/shared/param-control/__tests__/descriptor.test.ts
+++ b/src/shared/param-control/__tests__/descriptor.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalToNormalized,
+  clampValue,
+  endpointValue,
+  isDiscrete,
+  normalizedToCanonical,
+  parseValue,
+  resetValue,
+  stepValue,
+} from "../lib/descriptor";
+import type { ParamDescriptor } from "../types";
+
+const linear = (
+  min: number,
+  max: number,
+  extra: Partial<ParamDescriptor<number>> = {},
+): ParamDescriptor<number> => ({
+  min,
+  max,
+  taper: { kind: "linear" },
+  default: min,
+  format: (v) => String(v),
+  ...extra,
+});
+
+describe("clamping", () => {
+  const d = linear(-46, 4);
+
+  it("clamps canonical values to [min, max]", () => {
+    expect(clampValue(d, -100)).toBe(-46);
+    expect(clampValue(d, 100)).toBe(4);
+    expect(clampValue(d, -10)).toBe(-10);
+  });
+
+  it("clamps out-of-range positions at both ends", () => {
+    expect(normalizedToCanonical(d, -1)).toBe(-46);
+    expect(normalizedToCanonical(d, 2)).toBe(4);
+  });
+});
+
+describe("interval quantization", () => {
+  const ratio = linear(1, 8, { interval: 1, default: 4 });
+
+  it("snaps to the interval grid offset from min", () => {
+    expect(normalizedToCanonical(ratio, 0)).toBe(1);
+    expect(normalizedToCanonical(ratio, 1)).toBe(8);
+    // position ~0.3 -> raw 3.1 -> snaps to 3
+    expect(normalizedToCanonical(ratio, 0.3)).toBe(3);
+    // position ~0.55 -> raw 4.85 -> snaps to 5
+    expect(normalizedToCanonical(ratio, 0.55)).toBe(5);
+  });
+
+  it("reports as discrete", () => {
+    expect(isDiscrete(ratio)).toBe(true);
+    expect(isDiscrete(linear(0, 1))).toBe(false);
+  });
+});
+
+describe("stepCount quantization", () => {
+  const stepped = linear(0, 100, { stepCount: 5 }); // positions 0,.25,.5,.75,1
+
+  it("snaps the position onto the stepCount grid", () => {
+    expect(normalizedToCanonical(stepped, 0.3)).toBe(25);
+    expect(normalizedToCanonical(stepped, 0.4)).toBe(50);
+    expect(normalizedToCanonical(stepped, 0.9)).toBe(100);
+  });
+});
+
+describe("detent snapping", () => {
+  const pan = linear(-1, 1, {
+    default: 0,
+    polarity: "bipolar",
+    detents: [{ value: 0, radiusPct: 0.05 }],
+  });
+
+  it("snaps within the detent radius", () => {
+    // position 0.52 is within 0.05 of centre (0.5) -> snaps to 0
+    expect(normalizedToCanonical(pan, 0.52)).toBe(0);
+  });
+
+  it("does not snap outside the radius", () => {
+    // position 0.6 is 0.1 from centre -> no snap
+    expect(normalizedToCanonical(pan, 0.6)).toBeCloseTo(0.2, 9);
+  });
+
+  it("is auto-disabled under fine drag", () => {
+    expect(normalizedToCanonical(pan, 0.52, { fine: true })).toBeCloseTo(
+      0.04,
+      9,
+    );
+  });
+});
+
+describe("keyboard step math", () => {
+  it("continuous params step by keyStep in normalized space", () => {
+    // volume: span 50 dB, default keyStep 0.01 -> 0.5 dB per arrow
+    const vol = linear(-46, 4, { default: 0 });
+    expect(stepValue(vol, 0, 1, false)).toBeCloseTo(0.5, 9);
+    expect(stepValue(vol, 0, -1, false)).toBeCloseTo(-0.5, 9);
+  });
+
+  it("continuous params step by keyStepLarge on Page", () => {
+    const vol = linear(-46, 4, { default: 0 });
+    // span 50 dB, keyStepLarge default 0.1 -> 5 dB; start mid-range (-21 = pos 0.5)
+    expect(stepValue(vol, -21, 1, true)).toBeCloseTo(-16, 9);
+  });
+
+  it("respects custom keyStep", () => {
+    const d = linear(0, 100, { keyStep: 0.05 });
+    expect(stepValue(d, 0, 1, false)).toBeCloseTo(5, 9);
+  });
+
+  it("discrete params step by one interval", () => {
+    const ratio = linear(1, 8, { interval: 1, default: 4 });
+    expect(stepValue(ratio, 4, 1, false)).toBe(5);
+    expect(stepValue(ratio, 4, -1, false)).toBe(3);
+  });
+
+  it("discrete Page moves ten intervals, clamped", () => {
+    const ratio = linear(1, 8, { interval: 1, default: 4 });
+    expect(stepValue(ratio, 4, 1, true)).toBe(8);
+    expect(stepValue(ratio, 4, -1, true)).toBe(1);
+  });
+
+  it("stepping bypasses detents so a step near centre still moves", () => {
+    const pan = linear(-1, 1, {
+      default: 0,
+      detents: [{ value: 0, radiusPct: 0.2 }],
+    });
+    // from centre, one arrow moves off the detent instead of being swallowed
+    expect(stepValue(pan, 0, 1, false)).toBeCloseTo(0.02, 9);
+  });
+
+  it("endpoints resolve to min and max", () => {
+    const d = linear(-46, 4);
+    expect(endpointValue(d, "min")).toBe(-46);
+    expect(endpointValue(d, "max")).toBe(4);
+  });
+});
+
+describe("reset", () => {
+  it("returns the clamped default", () => {
+    expect(resetValue(linear(-1, 1, { default: 0 }))).toBe(0);
+    expect(resetValue(linear(-1, 1, { default: 5 }))).toBe(1);
+  });
+});
+
+describe("parse rejects when unparseable or descriptor lacks parse", () => {
+  it("returns null without a parse fn", () => {
+    expect(parseValue(linear(0, 1), "0.5")).toBeNull();
+  });
+
+  it("clamps parsed values", () => {
+    const d = linear(0, 1, { parse: (t) => Number(t) });
+    expect(parseValue(d, "2")).toBe(1);
+    expect(parseValue(d, "-2")).toBe(0);
+  });
+});
+
+describe("position round-trip is identity for continuous params", () => {
+  it("canonical -> position -> canonical", () => {
+    const vol = linear(-46, 4, { default: 0 });
+    for (const v of [-46, -30, -6, 0, 4]) {
+      const pos = canonicalToNormalized(vol, v);
+      expect(normalizedToCanonical(vol, pos)).toBeCloseTo(v, 9);
+    }
+  });
+});

--- a/src/shared/param-control/__tests__/descriptors.test.ts
+++ b/src/shared/param-control/__tests__/descriptors.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanonicalFilter } from "@/core/audio/canonical/filter";
+import {
+  instrumentDecayDescriptor,
+  instrumentPanDescriptor,
+  instrumentTuneDescriptor,
+  instrumentVolumeDescriptor,
+  masterCompRatioDescriptor,
+  masterVolumeDescriptor,
+  transportSwingDescriptor,
+} from "../descriptors/canonical-scalars";
+import {
+  filterToPosition,
+  positionToFilter,
+  splitFilterDescriptor,
+} from "../descriptors/filter";
+import {
+  canonicalToNormalized,
+  normalizedToCanonical,
+} from "../lib/descriptor";
+
+describe("volume descriptor", () => {
+  it("formats dB with -infinity at the floor", () => {
+    expect(instrumentVolumeDescriptor.format(-46)).toBe("-∞ dB");
+    expect(instrumentVolumeDescriptor.format(0)).toBe("0.0 dB");
+    expect(instrumentVolumeDescriptor.format(4)).toBe("+4.0 dB");
+  });
+
+  it("parses dB, including the silence sentinel", () => {
+    expect(instrumentVolumeDescriptor.parse?.("-6.0 dB")).toBeCloseTo(-6, 9);
+    expect(instrumentVolumeDescriptor.parse?.("-∞ dB")).toBe(-46);
+    expect(masterVolumeDescriptor.parse?.("-inf")).toBe(-46);
+  });
+
+  it("round-trips format -> parse for finite values", () => {
+    for (const v of [-30, -12, -6, 0, 4]) {
+      const text = instrumentVolumeDescriptor.format(v);
+      expect(instrumentVolumeDescriptor.parse?.(text)).toBeCloseTo(v, 1);
+    }
+  });
+});
+
+describe("pan descriptor", () => {
+  it("formats L / C / R", () => {
+    expect(instrumentPanDescriptor.format(0)).toBe("C");
+    expect(instrumentPanDescriptor.format(-0.5)).toBe("L50");
+    expect(instrumentPanDescriptor.format(0.5)).toBe("R50");
+  });
+
+  it("parses L / C / R and bare numbers", () => {
+    expect(instrumentPanDescriptor.parse?.("C")).toBe(0);
+    expect(instrumentPanDescriptor.parse?.("L50")).toBeCloseTo(-0.5, 9);
+    expect(instrumentPanDescriptor.parse?.("R25")).toBeCloseTo(0.25, 9);
+    expect(instrumentPanDescriptor.parse?.("0.3")).toBeCloseTo(0.3, 9);
+  });
+
+  it("keeps centre at knob-centre (bipolar linear)", () => {
+    expect(canonicalToNormalized(instrumentPanDescriptor, 0)).toBeCloseTo(
+      0.5,
+      9,
+    );
+  });
+});
+
+describe("tune descriptor (canonical semitones)", () => {
+  it("formats a signed semitone offset", () => {
+    expect(instrumentTuneDescriptor.format(0)).toBe("0.0 st");
+    expect(instrumentTuneDescriptor.format(3.5)).toBe("+3.5 st");
+    expect(instrumentTuneDescriptor.format(-2)).toBe("-2.0 st");
+  });
+
+  it("is bipolar and centred", () => {
+    expect(canonicalToNormalized(instrumentTuneDescriptor, 0)).toBeCloseTo(
+      0.5,
+      9,
+    );
+  });
+});
+
+describe("decay descriptor", () => {
+  it("formats ms and s", () => {
+    expect(instrumentDecayDescriptor.format(0.25)).toBe("250 ms");
+    expect(instrumentDecayDescriptor.format(2.5)).toBe("2.50 s");
+  });
+
+  it("parses ms and s", () => {
+    expect(instrumentDecayDescriptor.parse?.("250 ms")).toBeCloseTo(0.25, 9);
+    expect(instrumentDecayDescriptor.parse?.("2.5 s")).toBeCloseTo(2.5, 9);
+  });
+});
+
+describe("compressor ratio descriptor", () => {
+  it("quantizes to integer ratios", () => {
+    expect(normalizedToCanonical(masterCompRatioDescriptor, 0)).toBe(1);
+    expect(normalizedToCanonical(masterCompRatioDescriptor, 1)).toBe(8);
+    expect(masterCompRatioDescriptor.format(4)).toBe("4:1");
+  });
+});
+
+describe("swing descriptor", () => {
+  it("displays MPC percent from the Tone swing fraction", () => {
+    expect(transportSwingDescriptor.format(0)).toBe("50%");
+    expect(transportSwingDescriptor.format(0.375)).toBe("62.5%");
+  });
+
+  it("round-trips MPC display back to the swing fraction", () => {
+    expect(transportSwingDescriptor.parse?.("62.5%")).toBeCloseTo(0.375, 9);
+    expect(transportSwingDescriptor.parse?.("50%")).toBeCloseTo(0, 9);
+  });
+});
+
+describe("split-filter descriptor (generic-T custom taper)", () => {
+  it("round-trips { side, cutoffHz } through the custom taper", () => {
+    const samples: CanonicalFilter[] = [
+      { side: "lowpass", cutoffHz: 15000 },
+      { side: "lowpass", cutoffHz: 2000 },
+      { side: "lowpass", cutoffHz: 200 },
+      // NB: cutoff == min is the shared open extreme (== centre == fully open),
+      // which resolves to the low-pass-open side, so keep HP samples above min.
+      { side: "highpass", cutoffHz: 100 },
+      { side: "highpass", cutoffHz: 800 },
+      { side: "highpass", cutoffHz: 12000 },
+    ];
+    for (const filter of samples) {
+      const pos = filterToPosition(filter);
+      const back = positionToFilter(pos);
+      expect(back.side).toBe(filter.side);
+      expect(back.cutoffHz).toBeCloseTo(filter.cutoffHz, 3);
+    }
+  });
+
+  it("places the open extreme (fully open LP) at knob-centre", () => {
+    const centre = positionToFilter(0.5);
+    expect(centre.side).toBe("lowpass");
+    expect(centre.cutoffHz).toBeCloseTo(15000, 6);
+  });
+
+  it("selects the low-pass side left of centre and high-pass right", () => {
+    expect(positionToFilter(0.25).side).toBe("lowpass");
+    expect(positionToFilter(0.75).side).toBe("highpass");
+  });
+
+  it("round-trips through the descriptor's canonical <-> position ops", () => {
+    const filter: CanonicalFilter = { side: "highpass", cutoffHz: 500 };
+    const pos = canonicalToNormalized(splitFilterDescriptor, filter);
+    const back = normalizedToCanonical(splitFilterDescriptor, pos);
+    expect(back.side).toBe("highpass");
+    expect(back.cutoffHz).toBeCloseTo(500, 3);
+  });
+
+  it("formats with the side prefix", () => {
+    expect(
+      splitFilterDescriptor.format({ side: "lowpass", cutoffHz: 2500 }),
+    ).toBe("LP 2.5 kHz");
+    expect(
+      splitFilterDescriptor.format({ side: "highpass", cutoffHz: 800 }),
+    ).toBe("HP 800 Hz");
+  });
+});

--- a/src/shared/param-control/__tests__/rotary-knob.browser.test.ts
+++ b/src/shared/param-control/__tests__/rotary-knob.browser.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Browser tests for the descriptor-driven RotaryKnob.
+ *
+ * Mounts the real component in Chromium and drives real pointer, keyboard, and
+ * input events. The public contract is canonical-only: every assertion is on
+ * the CANONICAL value emitted through onChange, never a normalized position.
+ */
+
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { RotaryKnob } from "../components/rotary-knob";
+import type { ParamDescriptor } from "../types";
+
+declare global {
+  // Required by React so act() can flush effects in tests.
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Linear 0..100, display carries a unit so aria-valuetext != the raw number. */
+const testDescriptor: ParamDescriptor<number> = {
+  min: 0,
+  max: 100,
+  taper: { kind: "linear" },
+  default: 50,
+  format: (v) => `${v.toFixed(0)} u`,
+  parse: (t) => {
+    const n = Number.parseFloat(t);
+    return Number.isNaN(n) ? null : n;
+  },
+};
+
+type Recorded = {
+  changes: number[];
+  gestureStarts: number;
+  gestureEnds: number;
+};
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+let recorded: Recorded;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  recorded = { changes: [], gestureStarts: 0, gestureEnds: 0 };
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+async function mount(initial = 50) {
+  function Host() {
+    const [value, setValue] = useState(initial);
+    return createElement(RotaryKnob<number>, {
+      descriptor: testDescriptor,
+      value,
+      label: "Test",
+      onChange: (v: number) => {
+        recorded.changes.push(v);
+        setValue(v);
+      },
+      onGestureStart: () => {
+        recorded.gestureStarts += 1;
+      },
+      onGestureEnd: () => {
+        recorded.gestureEnds += 1;
+      },
+    });
+  }
+  await act(async () => {
+    root?.render(createElement(Host));
+  });
+}
+
+function slider(): HTMLElement {
+  const el = container?.querySelector('[role="slider"]');
+  if (!(el instanceof HTMLElement)) throw new Error("slider not found");
+  return el;
+}
+
+function last(): number {
+  return recorded.changes[recorded.changes.length - 1];
+}
+
+async function pointer(type: string, clientY: number, shiftKey = false) {
+  await act(async () => {
+    const target = type === "pointerdown" ? slider() : window;
+    target.dispatchEvent(
+      new PointerEvent(type, {
+        clientY,
+        clientX: 0,
+        pointerId: 1,
+        bubbles: true,
+        cancelable: true,
+        shiftKey,
+      }),
+    );
+  });
+}
+
+async function keydown(key: string) {
+  await act(async () => {
+    slider().dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+describe("RotaryKnob interactions (canonical-only public API)", () => {
+  it("drags in normalized space and emits canonical values", async () => {
+    await mount(50); // pos 0.5
+    await pointer("pointerdown", 100);
+    // drag up 20px: default sensitivity 1/200 -> +0.1 pos -> 60
+    await pointer("pointermove", 80);
+    await pointer("pointerup", 80);
+    expect(last()).toBeCloseTo(60, 6);
+  });
+
+  it("halves the delta while Shift (fine) is held", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    // shift-drag up 20px: +0.1 * 0.25 fine factor -> +0.025 pos -> 52.5
+    await pointer("pointermove", 80, true);
+    await pointer("pointerup", 80, true);
+    expect(last()).toBeCloseTo(52.5, 6);
+  });
+
+  it("fires onGestureStart / onGestureEnd exactly once per drag", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 90);
+    await pointer("pointermove", 80);
+    await pointer("pointerup", 80);
+    expect(recorded.gestureStarts).toBe(1);
+    expect(recorded.gestureEnds).toBe(1);
+  });
+
+  it("resets to default on double-click", async () => {
+    await mount(20);
+    await act(async () => {
+      slider().dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+    expect(last()).toBe(50);
+  });
+
+  it("steps by keyStep on arrows and keyStepLarge on Page", async () => {
+    await mount(50);
+    await keydown("ArrowUp"); // +0.01 pos -> +1 -> 51
+    expect(last()).toBeCloseTo(51, 6);
+    await keydown("PageUp"); // +0.1 pos -> +10 -> 61
+    expect(last()).toBeCloseTo(61, 6);
+  });
+
+  it("jumps to endpoints on Home / End", async () => {
+    await mount(50);
+    await keydown("End");
+    expect(last()).toBe(100);
+    await keydown("Home");
+    expect(last()).toBe(0);
+  });
+
+  it("exposes the display string as aria-valuetext, not the raw number", async () => {
+    await mount(42);
+    expect(slider().getAttribute("aria-valuetext")).toBe("42 u");
+    expect(slider().getAttribute("aria-valuenow")).toBe("42");
+    expect(slider().getAttribute("role")).toBe("slider");
+  });
+
+  it("accepts type-in entry parsed through the descriptor", async () => {
+    await mount(50);
+    const valueButton = container?.querySelector(
+      '[data-slot="rotary-knob-value"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      valueButton.click();
+    });
+    const input = container?.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      // Defeat React's controlled-input value tracker so onChange fires.
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setValue?.call(input, "75");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(last()).toBe(75);
+  });
+});

--- a/src/shared/param-control/__tests__/taper.test.ts
+++ b/src/shared/param-control/__tests__/taper.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  setSkewForCentre,
+  taperFromNormalized,
+  taperToNormalized,
+} from "../lib/taper";
+import type { Taper } from "../types";
+
+const TOL = 1e-9;
+
+/** Round-trip a set of positions through fromNormalized -> toNormalized. */
+function expectPositionRoundTrip(taper: Taper, min: number, max: number) {
+  for (const pos of [0, 0.1, 0.25, 0.5, 0.75, 0.9, 1]) {
+    const value = taperFromNormalized(taper, pos, min, max);
+    const back = taperToNormalized(taper, value, min, max);
+    expect(back).toBeCloseTo(pos, 9);
+  }
+}
+
+describe("linear taper", () => {
+  const taper: Taper = { kind: "linear" };
+
+  it("maps position to value proportionally", () => {
+    expect(taperFromNormalized(taper, 0, -46, 4)).toBeCloseTo(-46, 9);
+    expect(taperFromNormalized(taper, 1, -46, 4)).toBeCloseTo(4, 9);
+    expect(taperFromNormalized(taper, 0.5, -46, 4)).toBeCloseTo(-21, 9);
+  });
+
+  it("round-trips", () => {
+    expectPositionRoundTrip(taper, -46, 4);
+  });
+});
+
+describe("exponential taper", () => {
+  const taper: Taper = { kind: "exponential", skew: 0.5 };
+
+  it("is monotonic and hits the endpoints", () => {
+    expect(taperFromNormalized(taper, 0, 0.005, 5)).toBeCloseTo(0.005, 9);
+    expect(taperFromNormalized(taper, 1, 0.005, 5)).toBeCloseTo(5, 9);
+  });
+
+  it("round-trips within tolerance", () => {
+    expectPositionRoundTrip(taper, 0.005, 5);
+    expectPositionRoundTrip({ kind: "exponential", skew: 0.23 }, 20, 20000);
+  });
+});
+
+describe("symmetric skew (bipolar)", () => {
+  const taper: Taper = { kind: "exponential", skew: 2, symmetric: true };
+
+  it("pins the centre value at position 0.5", () => {
+    expect(taperToNormalized(taper, 0, -1, 1)).toBeCloseTo(0.5, TOL);
+    expect(taperFromNormalized(taper, 0.5, -1, 1)).toBeCloseTo(0, TOL);
+  });
+
+  it("stays symmetric about the centre", () => {
+    const below = taperFromNormalized(taper, 0.25, -1, 1);
+    const above = taperFromNormalized(taper, 0.75, -1, 1);
+    expect(below).toBeCloseTo(-above, 9);
+  });
+
+  it("round-trips", () => {
+    expectPositionRoundTrip(taper, -1, 1);
+  });
+});
+
+describe("setSkewForCentre", () => {
+  it("derives a skew that lands the centre value at 0.5", () => {
+    const skew = setSkewForCentre(20, 20000, 1000);
+    const taper: Taper = { kind: "exponential", skew };
+    expect(taperToNormalized(taper, 1000, 20, 20000)).toBeCloseTo(0.5, 9);
+  });
+
+  it("works for an arbitrary centre", () => {
+    const skew = setSkewForCentre(0, 100, 25);
+    const taper: Taper = { kind: "exponential", skew };
+    expect(taperToNormalized(taper, 25, 0, 100)).toBeCloseTo(0.5, 9);
+  });
+
+  it("throws when the centre is not strictly inside the range", () => {
+    expect(() => setSkewForCentre(0, 100, 0)).toThrow();
+    expect(() => setSkewForCentre(0, 100, 100)).toThrow();
+  });
+});

--- a/src/shared/param-control/components/rotary-knob.tsx
+++ b/src/shared/param-control/components/rotary-knob.tsx
@@ -1,0 +1,198 @@
+import { cn } from "@/shared/lib/utils";
+import { useParamControl } from "../hooks/use-param-control";
+import type { ParamDescriptor, RotaryKnobFutureSeams } from "../types";
+
+/** Sweep of the dial, in degrees, centred on 12 o'clock. */
+const ROTATION_RANGE_DEG = 270;
+const START_ANGLE_DEG = -ROTATION_RANGE_DEG / 2;
+
+type RotaryKnobProps<T> = {
+  descriptor: ParamDescriptor<T>;
+  /** Value in CANONICAL units. */
+  value: T;
+  /** Emits the next value in CANONICAL units. */
+  onChange: (value: T) => void;
+  onGestureStart?: () => void;
+  onGestureEnd?: () => void;
+  disabled?: boolean;
+  label: string;
+  /** Opt-in tab order (default true). */
+  tabbable?: boolean;
+  id?: string;
+  /** Diameter in pixels. */
+  size?: number;
+  /** Hide the caption label under the dial. */
+  hideLabel?: boolean;
+  /** Hide the value readout. */
+  hideValue?: boolean;
+  className?: string;
+} & RotaryKnobFutureSeams;
+
+/** Point on the dial circle for a normalized [0,1] position. */
+function polarToXY(cx: number, cy: number, r: number, position: number) {
+  const angleDeg = START_ANGLE_DEG + position * ROTATION_RANGE_DEG;
+  const angleRad = (angleDeg * Math.PI) / 180;
+  return {
+    x: cx + r * Math.sin(angleRad),
+    y: cy - r * Math.cos(angleRad),
+    angleDeg,
+  };
+}
+
+/** SVG arc path between two normalized positions along the dial circle. */
+function describeArc(
+  cx: number,
+  cy: number,
+  r: number,
+  from: number,
+  to: number,
+) {
+  const lo = Math.min(from, to);
+  const hi = Math.max(from, to);
+  const start = polarToXY(cx, cy, r, lo);
+  const end = polarToXY(cx, cy, r, hi);
+  const largeArc = (hi - lo) * ROTATION_RANGE_DEG > 180 ? 1 : 0;
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 1 ${end.x} ${end.y}`;
+}
+
+/**
+ * The rotary presentation of the descriptor-driven control. A thin skin over
+ * `useParamControl`: it owns look only (track, fill, indicator, readout), while
+ * all behavior and the canonical-only contract live in the hook.
+ *
+ * FUTURE seams (modulation-range arc, circular drag mode, context menu) are
+ * declared on the props but intentionally not implemented (see
+ * docs/knob-primitive.md).
+ */
+function RotaryKnob<T>({
+  descriptor,
+  value,
+  onChange,
+  onGestureStart,
+  onGestureEnd,
+  disabled = false,
+  label,
+  tabbable = true,
+  id,
+  size = 72,
+  hideLabel = false,
+  hideValue = false,
+  className,
+  // Declared future seams; not wired yet.
+  modulationRange: _modulationRange,
+  dragMode: _dragMode,
+  onContextMenuRequest: _onContextMenuRequest,
+}: RotaryKnobProps<T>) {
+  const control = useParamControl({
+    descriptor,
+    value,
+    onChange,
+    onGestureStart,
+    onGestureEnd,
+    disabled,
+    label,
+    tabbable,
+    id,
+  });
+
+  const { position, bipolar } = control;
+
+  const stroke = size * 0.09;
+  const r = (size - stroke) / 2;
+  const cx = size / 2;
+  const cy = size / 2;
+  const fillStart = bipolar ? 0.5 : 0;
+  const indicator = polarToXY(cx, cy, r, position);
+  const indicatorInner = polarToXY(cx, cy, r * 0.42, position);
+
+  return (
+    <div
+      data-slot="rotary-knob"
+      data-disabled={disabled || undefined}
+      data-dragging={control.isDragging || undefined}
+      className={cn(
+        "flex flex-col items-center gap-1 select-none",
+        disabled && "opacity-50",
+        className,
+      )}
+    >
+      <div
+        {...control.handlers}
+        {...control.ariaProps}
+        aria-labelledby={hideLabel ? undefined : `${control.id}-label`}
+        className={cn(
+          "relative touch-none rounded-full outline-none",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2",
+        )}
+        style={{ width: size, height: size, touchAction: "none" }}
+      >
+        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+          {/* Track */}
+          <path
+            d={describeArc(cx, cy, r, 0, 1)}
+            fill="none"
+            className="stroke-border"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+          />
+          {/* Fill */}
+          <path
+            d={describeArc(cx, cy, r, fillStart, position)}
+            fill="none"
+            className="stroke-primary"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+          />
+          {/* Indicator */}
+          <line
+            x1={indicatorInner.x}
+            y1={indicatorInner.y}
+            x2={indicator.x}
+            y2={indicator.y}
+            className="stroke-foreground"
+            strokeWidth={stroke * 0.6}
+            strokeLinecap="round"
+          />
+        </svg>
+      </div>
+
+      {!hideValue &&
+        (control.isEditing ? (
+          <input
+            {...control.editProps}
+            aria-label={`${label} value`}
+            className={cn(
+              "bg-surface text-foreground w-16 rounded-sm px-1 text-center text-xs",
+              "outline-none",
+            )}
+          />
+        ) : (
+          <button
+            type="button"
+            data-slot="rotary-knob-value"
+            disabled={disabled || !descriptor.parse}
+            onClick={control.beginEdit}
+            className={cn(
+              "text-foreground-muted text-xs tabular-nums",
+              descriptor.parse && "hover:text-foreground cursor-text",
+            )}
+          >
+            {control.displayValue}
+          </button>
+        ))}
+
+      {!hideLabel && (
+        <span
+          id={`${control.id}-label`}
+          data-slot="rotary-knob-label"
+          className="text-foreground-muted text-xs"
+        >
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export { RotaryKnob };
+export type { RotaryKnobProps };

--- a/src/shared/param-control/descriptors/canonical-scalars.ts
+++ b/src/shared/param-control/descriptors/canonical-scalars.ts
@@ -1,0 +1,257 @@
+/**
+ * Canonical-unit descriptors for the scalar parameters, ported from the
+ * existing knob mappings (src/shared/knob/lib/mapping.ts). Each speaks the
+ * canonical unit the app stores and the engine hears: seconds, dB, a -1..1 pan,
+ * semitone offset, 0..1 macro fractions, and the Tone swing fraction.
+ *
+ * These live ALONGSIDE the legacy mappings; nothing here is wired into the app
+ * yet (that is a later PR). They are `ParamDescriptor<number>`.
+ */
+
+import {
+  INSTRUMENT_DECAY_RANGE,
+  INSTRUMENT_PAN_RANGE,
+  INSTRUMENT_TUNE_SEMITONE_RANGE,
+  INSTRUMENT_VOLUME_RANGE,
+  MASTER_COMP_ATTACK_RANGE,
+  MASTER_COMP_MIX_RANGE,
+  MASTER_COMP_RATIO_RANGE,
+  MASTER_COMP_THRESHOLD_RANGE,
+  MASTER_PHASER_WET_RANGE,
+  MASTER_REVERB_WET_RANGE,
+  MASTER_SATURATION_WET_RANGE,
+  MASTER_VOLUME_RANGE,
+  TRANSPORT_SWING_MAX,
+} from "@/core/audio/engine/constants";
+import type { ParamDescriptor } from "../types";
+
+/**
+ * Skew equivalent to the legacy `t^2` exponential knob curve. The legacy
+ * forward map is `value = lerp(t^power, ...)`; JUCE's inverse skew relates by
+ * `skew = 1 / power`, so a power-2 curve is `skew = 0.5`.
+ */
+const LEGACY_EXP_SKEW = 0.5;
+
+// --- Formatting / parsing helpers ---
+
+function parseNumber(text: string): number | null {
+  const match = text.replace(",", ".").match(/-?\d*\.?\d+/);
+  if (!match) return null;
+  const n = Number(match[0]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatDb(value: number, floor: number): string {
+  if (value <= floor) return "-∞ dB";
+  return `${value > 0 ? "+" : ""}${value.toFixed(1)} dB`;
+}
+
+function parseDb(text: string, floor: number): number | null {
+  if (/[-−]?\s*(∞|inf)/i.test(text)) return floor;
+  return parseNumber(text);
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function parsePercent(text: string): number | null {
+  const n = parseNumber(text);
+  return n === null ? null : n / 100;
+}
+
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0 ms";
+  if (seconds < 1) return `${Math.round(seconds * 1000)} ms`;
+  if (seconds < 10) return `${seconds.toFixed(2)} s`;
+  return `${seconds.toFixed(1)} s`;
+}
+
+function parseDuration(text: string): number | null {
+  const n = parseNumber(text);
+  if (n === null) return null;
+  return /ms/i.test(text) ? n / 1000 : n;
+}
+
+// --- Instrument descriptors ---
+
+const instrumentDecayDescriptor: ParamDescriptor<number> = {
+  min: INSTRUMENT_DECAY_RANGE[0],
+  max: INSTRUMENT_DECAY_RANGE[1],
+  taper: { kind: "exponential", skew: LEGACY_EXP_SKEW },
+  default: INSTRUMENT_DECAY_RANGE[1],
+  unit: "s",
+  format: formatDuration,
+  parse: parseDuration,
+};
+
+const instrumentVolumeDescriptor: ParamDescriptor<number> = {
+  min: INSTRUMENT_VOLUME_RANGE[0],
+  max: INSTRUMENT_VOLUME_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  unit: "dB",
+  format: (v) => formatDb(v, INSTRUMENT_VOLUME_RANGE[0]),
+  parse: (t) => parseDb(t, INSTRUMENT_VOLUME_RANGE[0]),
+};
+
+const instrumentPanDescriptor: ParamDescriptor<number> = {
+  min: INSTRUMENT_PAN_RANGE[0],
+  max: INSTRUMENT_PAN_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  polarity: "bipolar",
+  detents: [{ value: 0, radiusPct: 0.05 }],
+  format: formatPan,
+  parse: parsePan,
+};
+
+const instrumentTuneDescriptor: ParamDescriptor<number> = {
+  min: -INSTRUMENT_TUNE_SEMITONE_RANGE,
+  max: INSTRUMENT_TUNE_SEMITONE_RANGE,
+  taper: { kind: "linear" },
+  default: 0,
+  polarity: "bipolar",
+  unit: "st",
+  detents: [{ value: 0, radiusPct: 0.05 }],
+  format: (v) => `${v > 0 ? "+" : ""}${v.toFixed(1)} st`,
+  parse: parseNumber,
+};
+
+function formatPan(value: number): string {
+  if (Math.abs(value) < 0.005) return "C";
+  const side = value < 0 ? "L" : "R";
+  return `${side}${Math.round(Math.abs(value) * 100)}`;
+}
+
+function parsePan(text: string): number | null {
+  const t = text.trim().toUpperCase();
+  if (t.startsWith("C")) return 0;
+  const n = parseNumber(t);
+  if (n === null) return null;
+  if (t.startsWith("L")) return -Math.abs(n) / 100;
+  if (t.startsWith("R")) return Math.abs(n) / 100;
+  return Math.abs(n) <= 1 ? n : n / 100;
+}
+
+// --- Master descriptors (nine params; `filter` is the generic-T descriptor) ---
+
+const masterVolumeDescriptor: ParamDescriptor<number> = {
+  min: MASTER_VOLUME_RANGE[0],
+  max: MASTER_VOLUME_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  unit: "dB",
+  format: (v) => formatDb(v, MASTER_VOLUME_RANGE[0]),
+  parse: (t) => parseDb(t, MASTER_VOLUME_RANGE[0]),
+};
+
+const masterSaturationDescriptor: ParamDescriptor<number> = {
+  min: MASTER_SATURATION_WET_RANGE[0],
+  max: MASTER_SATURATION_WET_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  format: formatPercent,
+  parse: parsePercent,
+};
+
+const masterPhaserDescriptor: ParamDescriptor<number> = {
+  min: MASTER_PHASER_WET_RANGE[0],
+  max: MASTER_PHASER_WET_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  format: formatPercent,
+  parse: parsePercent,
+};
+
+const masterReverbDescriptor: ParamDescriptor<number> = {
+  min: MASTER_REVERB_WET_RANGE[0],
+  max: MASTER_REVERB_WET_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  format: formatPercent,
+  parse: parsePercent,
+};
+
+const masterCompThresholdDescriptor: ParamDescriptor<number> = {
+  min: MASTER_COMP_THRESHOLD_RANGE[0],
+  max: MASTER_COMP_THRESHOLD_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0,
+  unit: "dB",
+  format: (v) => `${v.toFixed(1)} dB`,
+  parse: parseNumber,
+};
+
+const masterCompRatioDescriptor: ParamDescriptor<number> = {
+  min: MASTER_COMP_RATIO_RANGE[0],
+  max: MASTER_COMP_RATIO_RANGE[1],
+  taper: { kind: "linear" },
+  default: 4,
+  interval: 1,
+  format: (v) => `${Math.round(v)}:1`,
+  parse: parseNumber,
+};
+
+const masterCompAttackDescriptor: ParamDescriptor<number> = {
+  min: MASTER_COMP_ATTACK_RANGE[0],
+  max: MASTER_COMP_ATTACK_RANGE[1],
+  taper: { kind: "exponential", skew: LEGACY_EXP_SKEW },
+  default: 0.01,
+  unit: "ms",
+  format: (v) => `${(v * 1000).toFixed(v < 0.01 ? 1 : 0)} ms`,
+  parse: (t) => {
+    const n = parseNumber(t);
+    return n === null ? null : n / 1000;
+  },
+};
+
+const masterCompMixDescriptor: ParamDescriptor<number> = {
+  min: MASTER_COMP_MIX_RANGE[0],
+  max: MASTER_COMP_MIX_RANGE[1],
+  taper: { kind: "linear" },
+  default: 0.7,
+  format: formatPercent,
+  parse: parsePercent,
+};
+
+// --- Transport ---
+
+/**
+ * Swing as the canonical Tone.Transport swing fraction (0..0.375). Display is
+ * MPC swing percent: MPC% = 50 + (100/3) * swing, so 0 -> 50.0%, 0.375 -> 62.5%.
+ */
+const MPC_PER_SWING = 100 / 3;
+
+const transportSwingDescriptor: ParamDescriptor<number> = {
+  min: 0,
+  max: TRANSPORT_SWING_MAX,
+  taper: { kind: "linear" },
+  default: 0,
+  format: (swing) => {
+    const mpc = 50 + MPC_PER_SWING * swing;
+    return `${mpc.toFixed(1).replace(/\.0$/, "")}%`;
+  },
+  parse: (text) => {
+    const n = parseNumber(text);
+    if (n === null) return null;
+    return (n - 50) / MPC_PER_SWING;
+  },
+};
+
+export {
+  LEGACY_EXP_SKEW,
+  instrumentDecayDescriptor,
+  instrumentVolumeDescriptor,
+  instrumentPanDescriptor,
+  instrumentTuneDescriptor,
+  masterVolumeDescriptor,
+  masterSaturationDescriptor,
+  masterPhaserDescriptor,
+  masterReverbDescriptor,
+  masterCompThresholdDescriptor,
+  masterCompRatioDescriptor,
+  masterCompAttackDescriptor,
+  masterCompMixDescriptor,
+  transportSwingDescriptor,
+};

--- a/src/shared/param-control/descriptors/filter.ts
+++ b/src/shared/param-control/descriptors/filter.ts
@@ -1,0 +1,79 @@
+/**
+ * The split-filter descriptor: the exemplar NON-number `ParamDescriptor`.
+ *
+ * Canonical value is `{ side, cutoffHz }` (docs/data-representation.md P2),
+ * defined in the shared seam `@/core/audio/canonical/filter` so the engine
+ * epic (PR B) consumes the SAME type. Position maps to and from the canonical
+ * value through a `custom` taper - the escape hatch for curves that are not a
+ * single exponent.
+ *
+ * Geometry: knob-centre (0.5) is the open extreme of each side (no filtering);
+ * left of centre closes a low-pass down, right of centre opens a high-pass up.
+ * There is no explicit bypass state - the centre IS the open extreme.
+ *
+ * Not wired into the engine or a store here; the model is unit-tested only.
+ */
+
+import type { CanonicalFilter } from "@/core/audio/canonical/filter";
+import type { ParamDescriptor } from "../types";
+
+/** Audible sweep bounds for the split filter, in Hz. */
+const FILTER_MIN_HZ = 20;
+const FILTER_MAX_HZ = 15000;
+
+const LOG_SPAN = Math.log(FILTER_MAX_HZ / FILTER_MIN_HZ);
+
+/** Position [0,1] -> `{ side, cutoffHz }`. Centre (0.5) = fully open. */
+function positionToFilter(position: number): CanonicalFilter {
+  if (position <= 0.5) {
+    // Low-pass side: open (max) at centre, closing toward min at position 0.
+    const t = (0.5 - position) / 0.5; // 0 at centre -> 1 at far left
+    const cutoffHz = FILTER_MAX_HZ * Math.exp(-t * LOG_SPAN);
+    return { side: "lowpass", cutoffHz };
+  }
+  // High-pass side: open (min) at centre, closing toward max at position 1.
+  const t = (position - 0.5) / 0.5; // 0 at centre -> 1 at far right
+  const cutoffHz = FILTER_MIN_HZ * Math.exp(t * LOG_SPAN);
+  return { side: "highpass", cutoffHz };
+}
+
+/** `{ side, cutoffHz }` -> position [0,1]. Inverse of `positionToFilter`. */
+function filterToPosition({ side, cutoffHz }: CanonicalFilter): number {
+  const clamped = Math.min(FILTER_MAX_HZ, Math.max(FILTER_MIN_HZ, cutoffHz));
+  if (side === "lowpass") {
+    const t = Math.log(FILTER_MAX_HZ / clamped) / LOG_SPAN; // 0 open -> 1 closed
+    return 0.5 - 0.5 * t;
+  }
+  const t = Math.log(clamped / FILTER_MIN_HZ) / LOG_SPAN; // 0 open -> 1 closed
+  return 0.5 + 0.5 * t;
+}
+
+function formatFrequency(cutoffHz: number): string {
+  if (cutoffHz >= 1000) return `${(cutoffHz / 1000).toFixed(1)} kHz`;
+  return `${Math.round(cutoffHz)} Hz`;
+}
+
+const splitFilterDescriptor: ParamDescriptor<CanonicalFilter> = {
+  min: { side: "lowpass", cutoffHz: FILTER_MIN_HZ },
+  max: { side: "highpass", cutoffHz: FILTER_MAX_HZ },
+  taper: {
+    kind: "custom",
+    to01: filterToPosition,
+    from01: positionToFilter,
+  },
+  default: { side: "lowpass", cutoffHz: FILTER_MAX_HZ },
+  polarity: "bipolar",
+  detents: [
+    { value: { side: "lowpass", cutoffHz: FILTER_MAX_HZ }, radiusPct: 0.04 },
+  ],
+  format: ({ side, cutoffHz }) =>
+    `${side === "lowpass" ? "LP" : "HP"} ${formatFrequency(cutoffHz)}`,
+};
+
+export {
+  FILTER_MIN_HZ,
+  FILTER_MAX_HZ,
+  positionToFilter,
+  filterToPosition,
+  splitFilterDescriptor,
+};

--- a/src/shared/param-control/hooks/use-param-control.ts
+++ b/src/shared/param-control/hooks/use-param-control.ts
@@ -1,0 +1,344 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  canonicalToNormalized,
+  DEFAULT_DRAG_SENSITIVITY,
+  DEFAULT_FINE_DRAG_FACTOR,
+  endpointValue,
+  formatValue,
+  normalizedToCanonical,
+  parseValue,
+  resetValue,
+  stepValue,
+} from "../lib/descriptor";
+import { clamp01 } from "../lib/taper";
+import type { ParamDescriptor } from "../types";
+
+interface UseParamControlProps<T> {
+  descriptor: ParamDescriptor<T>;
+  /** Current value, in CANONICAL units. */
+  value: T;
+  /** Emits a new value, in CANONICAL units. */
+  onChange: (value: T) => void;
+  /** Fired once when a gesture begins (drag start, edit open, discrete commit). */
+  onGestureStart?: () => void;
+  /** Fired once when a gesture ends. Distinct from onChange. */
+  onGestureEnd?: () => void;
+  disabled?: boolean;
+  label: string;
+  /** Opt-in tab order: false removes the control from the tab sequence. */
+  tabbable?: boolean;
+  id?: string;
+}
+
+interface SliderAriaProps {
+  role: "slider";
+  tabIndex: number;
+  "aria-label": string;
+  "aria-valuemin": number;
+  "aria-valuemax": number;
+  "aria-valuenow": number;
+  /** The display string ("2.5 kHz"), never the raw number. */
+  "aria-valuetext": string;
+  "aria-disabled": boolean | undefined;
+}
+
+interface EditInputProps {
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+  autoFocus: boolean;
+}
+
+interface UseParamControlResult {
+  /** Normalized [0, 1] position for rendering (rotation, fill). Never public API. */
+  position: number;
+  /** Display string projected from the canonical value. */
+  displayValue: string;
+  isDragging: boolean;
+  isEditing: boolean;
+  ariaProps: SliderAriaProps;
+  /** Spread onto the interactive slider element. */
+  handlers: {
+    onPointerDown: (event: React.PointerEvent) => void;
+    onKeyDown: (event: React.KeyboardEvent) => void;
+    onDoubleClick: (event: React.MouseEvent) => void;
+    onWheel: (event: React.WheelEvent) => void;
+  };
+  /** Open the type-in editor (no-op when the descriptor has no `parse`). */
+  beginEdit: () => void;
+  /** Spread onto the type-in <input> while `isEditing`. */
+  editProps: EditInputProps;
+  /** Reset to the descriptor default, as its own bracketed gesture. */
+  reset: () => void;
+  /** Stable id for wiring aria-labelledby / htmlFor. */
+  id: string;
+  /** Whether this descriptor is bipolar (center-origin fill). */
+  bipolar: boolean;
+}
+
+/**
+ * Headless core for the descriptor-driven parameter control.
+ *
+ * Public API speaks CANONICAL units only; the normalized [0, 1] position is a
+ * strictly-internal transport. A gesture holds a raw, unrounded position and
+ * rounds only at commit, so stepped params never accumulate drift and fine
+ * drag can move sub-step amounts (docs/knob-primitive.md).
+ */
+function useParamControl<T>({
+  descriptor,
+  value,
+  onChange,
+  onGestureStart,
+  onGestureEnd,
+  disabled = false,
+  label,
+  tabbable = true,
+  id,
+}: UseParamControlProps<T>): UseParamControlResult {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+
+  const [isDragging, setIsDragging] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState("");
+
+  // Raw, unrounded position held through a drag gesture.
+  const rawPositionRef = useRef(0);
+  const lastYRef = useRef(0);
+
+  // Latest props referenced by window listeners without re-subscribing.
+  const latest = useRef({ descriptor, onChange });
+  latest.current = { descriptor, onChange };
+
+  const position = canonicalToNormalized(descriptor, value);
+  const displayValue = formatValue(descriptor, value);
+  const bipolar = descriptor.polarity === "bipolar";
+
+  const numeric = typeof descriptor.min === "number";
+  const descriptorMin = numeric ? (descriptor.min as unknown as number) : 0;
+  const descriptorMax = numeric ? (descriptor.max as unknown as number) : 1;
+  const descriptorNow = numeric ? (value as unknown as number) : position;
+
+  /** Commit a discrete change as its own bracketed gesture (own undo unit). */
+  const commitDiscrete = useCallback(
+    (next: T) => {
+      onGestureStart?.();
+      onChange(next);
+      onGestureEnd?.();
+    },
+    [onChange, onGestureStart, onGestureEnd],
+  );
+
+  const reset = useCallback(() => {
+    if (disabled) return;
+    commitDiscrete(resetValue(descriptor));
+  }, [disabled, commitDiscrete, descriptor]);
+
+  // --- Type-in editor ---
+
+  const beginEdit = useCallback(() => {
+    if (disabled || !descriptor.parse) return;
+    setEditText(displayValue);
+    setIsEditing(true);
+    onGestureStart?.();
+  }, [disabled, descriptor, displayValue, onGestureStart]);
+
+  const commitEdit = useCallback(() => {
+    const parsed = parseValue(descriptor, editText);
+    if (parsed !== null) onChange(parsed);
+    setIsEditing(false);
+    onGestureEnd?.();
+  }, [descriptor, editText, onChange, onGestureEnd]);
+
+  const cancelEdit = useCallback(() => {
+    setIsEditing(false);
+    onGestureEnd?.();
+  }, [onGestureEnd]);
+
+  const editProps: EditInputProps = useMemo(
+    () => ({
+      value: editText,
+      onChange: (event) => setEditText(event.target.value),
+      onKeyDown: (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commitEdit();
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          cancelEdit();
+        }
+      },
+      onBlur: () => commitEdit(),
+      autoFocus: true,
+    }),
+    [editText, commitEdit, cancelEdit],
+  );
+
+  // --- Drag ---
+
+  const handlePointerMove = useCallback((event: PointerEvent) => {
+    event.preventDefault();
+    const { descriptor: d, onChange: emit } = latest.current;
+
+    const dyIncrement = lastYRef.current - event.clientY; // up = positive
+    lastYRef.current = event.clientY;
+
+    const sensitivity = d.dragSensitivity ?? DEFAULT_DRAG_SENSITIVITY;
+    const fine = event.shiftKey;
+    const factor = fine ? (d.fineDragFactor ?? DEFAULT_FINE_DRAG_FACTOR) : 1;
+
+    rawPositionRef.current = clamp01(
+      rawPositionRef.current + dyIncrement * sensitivity * factor,
+    );
+    emit(normalizedToCanonical(d, rawPositionRef.current, { fine }));
+  }, []);
+
+  const endDrag = useCallback(() => {
+    setIsDragging(false);
+    onGestureEnd?.();
+  }, [onGestureEnd]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      if (disabled) return;
+      event.preventDefault();
+      rawPositionRef.current = canonicalToNormalized(descriptor, value);
+      lastYRef.current = event.clientY;
+      setIsDragging(true);
+      onGestureStart?.();
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // best-effort capture
+      }
+    },
+    [disabled, descriptor, value, onGestureStart],
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const onMove = (event: PointerEvent) => handlePointerMove(event);
+    const onUp = () => endDrag();
+    const options: AddEventListenerOptions = { passive: false };
+
+    window.addEventListener("pointermove", onMove, options);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+  }, [isDragging, handlePointerMove, endDrag]);
+
+  // --- Keyboard, wheel, double-click ---
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (disabled || isEditing) return;
+
+      switch (event.key) {
+        case "ArrowUp":
+        case "ArrowRight":
+          event.preventDefault();
+          commitDiscrete(stepValue(descriptor, value, 1, false));
+          break;
+        case "ArrowDown":
+        case "ArrowLeft":
+          event.preventDefault();
+          commitDiscrete(stepValue(descriptor, value, -1, false));
+          break;
+        case "PageUp":
+          event.preventDefault();
+          commitDiscrete(stepValue(descriptor, value, 1, true));
+          break;
+        case "PageDown":
+          event.preventDefault();
+          commitDiscrete(stepValue(descriptor, value, -1, true));
+          break;
+        case "Home":
+          event.preventDefault();
+          commitDiscrete(endpointValue(descriptor, "min"));
+          break;
+        case "End":
+          event.preventDefault();
+          commitDiscrete(endpointValue(descriptor, "max"));
+          break;
+        case "Delete":
+        case "Backspace":
+          event.preventDefault();
+          commitDiscrete(resetValue(descriptor));
+          break;
+        case "Enter":
+          if (descriptor.parse) {
+            event.preventDefault();
+            beginEdit();
+          }
+          break;
+      }
+    },
+    [disabled, isEditing, descriptor, value, commitDiscrete, beginEdit],
+  );
+
+  const handleDoubleClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (disabled) return;
+      event.preventDefault();
+      commitDiscrete(resetValue(descriptor));
+    },
+    [disabled, commitDiscrete, descriptor],
+  );
+
+  const handleWheel = useCallback(
+    (event: React.WheelEvent) => {
+      if (disabled) return;
+      // No smooth-wheel: one notch per event, honoring interval/stepCount.
+      const direction = event.deltaY < 0 ? 1 : -1;
+      commitDiscrete(stepValue(descriptor, value, direction, false));
+    },
+    [disabled, commitDiscrete, descriptor, value],
+  );
+
+  const ariaProps: SliderAriaProps = {
+    role: "slider",
+    tabIndex: disabled || !tabbable ? -1 : 0,
+    "aria-label": label,
+    "aria-valuemin": descriptorMin,
+    "aria-valuemax": descriptorMax,
+    "aria-valuenow": descriptorNow,
+    "aria-valuetext": displayValue,
+    "aria-disabled": disabled || undefined,
+  };
+
+  return {
+    position,
+    displayValue,
+    isDragging,
+    isEditing,
+    ariaProps,
+    handlers: {
+      onPointerDown: handlePointerDown,
+      onKeyDown: handleKeyDown,
+      onDoubleClick: handleDoubleClick,
+      onWheel: handleWheel,
+    },
+    beginEdit,
+    editProps,
+    reset,
+    id: controlId,
+    bipolar,
+  };
+}
+
+export { useParamControl };
+export type { UseParamControlProps, UseParamControlResult };

--- a/src/shared/param-control/index.ts
+++ b/src/shared/param-control/index.ts
@@ -1,0 +1,42 @@
+export type {
+  Taper,
+  Detent,
+  ParamDescriptor,
+  RotaryKnobFutureSeams,
+} from "./types";
+export {
+  clamp01,
+  setSkewForCentre,
+  taperToNormalized,
+  taperFromNormalized,
+} from "./lib/taper";
+export {
+  canonicalToNormalized,
+  normalizedToCanonical,
+  formatValue,
+  parseValue,
+  resetValue,
+  stepValue,
+  endpointValue,
+  isDiscrete,
+  clampValue,
+  DEFAULT_DRAG_SENSITIVITY,
+  DEFAULT_FINE_DRAG_FACTOR,
+  DEFAULT_KEY_STEP,
+  DEFAULT_KEY_STEP_LARGE,
+} from "./lib/descriptor";
+export { useParamControl } from "./hooks/use-param-control";
+export type {
+  UseParamControlProps,
+  UseParamControlResult,
+} from "./hooks/use-param-control";
+export { RotaryKnob } from "./components/rotary-knob";
+export type { RotaryKnobProps } from "./components/rotary-knob";
+export * from "./descriptors/canonical-scalars";
+export {
+  FILTER_MIN_HZ,
+  FILTER_MAX_HZ,
+  positionToFilter,
+  filterToPosition,
+  splitFilterDescriptor,
+} from "./descriptors/filter";

--- a/src/shared/param-control/lib/descriptor.ts
+++ b/src/shared/param-control/lib/descriptor.ts
@@ -1,0 +1,230 @@
+import { clamp } from "@/shared/lib/utils";
+import type { ParamDescriptor } from "../types";
+import { clamp01, taperFromNormalized, taperToNormalized } from "./taper";
+
+/** Default interaction tuning, used when a descriptor omits a field. */
+const DEFAULT_DRAG_SENSITIVITY = 1 / 200; // normalized units per pixel (~200px full sweep)
+const DEFAULT_FINE_DRAG_FACTOR = 0.25;
+const DEFAULT_KEY_STEP = 0.01; // normalized, for continuous params
+const DEFAULT_KEY_STEP_LARGE = 0.1; // normalized, for continuous params
+const PAGE_STEP_INTERVALS = 10; // Page moves this many discrete steps
+
+/** True when the descriptor works over plain numbers (linear/exponential taper). */
+function isNumericDescriptor<T>(
+  descriptor: ParamDescriptor<T>,
+): descriptor is ParamDescriptor<T> & {
+  min: number & T;
+  max: number & T;
+} {
+  return typeof descriptor.min === "number";
+}
+
+/** Clamp a canonical value to [min, max] (numeric params only; no-op otherwise). */
+function clampValue<T>(descriptor: ParamDescriptor<T>, value: T): T {
+  if (typeof value === "number" && isNumericDescriptor(descriptor)) {
+    return clamp(value, descriptor.min, descriptor.max) as unknown as T;
+  }
+  return value;
+}
+
+/** Whether the descriptor is discrete (stepped or enumerated). */
+function isDiscrete<T>(descriptor: ParamDescriptor<T>): boolean {
+  return (
+    (descriptor.interval !== undefined && descriptor.interval > 0) ||
+    (descriptor.stepCount !== undefined && descriptor.stepCount > 1)
+  );
+}
+
+/** Snap a canonical number to the descriptor's interval grid, offset from min. */
+function snapToInterval<T>(
+  descriptor: ParamDescriptor<T>,
+  value: number,
+): number {
+  const { interval } = descriptor;
+  if (!interval || interval <= 0 || !isNumericDescriptor(descriptor)) {
+    return value;
+  }
+  const min = descriptor.min;
+  const snapped = min + Math.round((value - min) / interval) * interval;
+  return clamp(snapped, descriptor.min, descriptor.max);
+}
+
+/** Snap a normalized position to the descriptor's `stepCount` grid. */
+function snapToStepCount<T>(
+  descriptor: ParamDescriptor<T>,
+  position: number,
+): number {
+  const { stepCount } = descriptor;
+  if (!stepCount || stepCount < 2) return position;
+  return Math.round(position * (stepCount - 1)) / (stepCount - 1);
+}
+
+/**
+ * Snap a normalized position to the nearest detent within its radius. Detent
+ * values are given in canonical units and projected into position space, so
+ * snapping is taper-correct. Disabled under fine drag by the caller.
+ */
+function snapToDetents<T>(
+  descriptor: ParamDescriptor<T>,
+  position: number,
+): number {
+  if (!descriptor.detents || descriptor.detents.length === 0) return position;
+
+  let best = position;
+  let bestDistance = Infinity;
+  for (const detent of descriptor.detents) {
+    const detentPos = taperToNormalized(
+      descriptor.taper,
+      detent.value,
+      descriptor.min,
+      descriptor.max,
+    );
+    const distance = Math.abs(position - detentPos);
+    if (distance <= detent.radiusPct && distance < bestDistance) {
+      best = detentPos;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
+
+/** Canonical value -> normalized [0, 1] position. */
+function canonicalToNormalized<T>(
+  descriptor: ParamDescriptor<T>,
+  value: T,
+): number {
+  return taperToNormalized(
+    descriptor.taper,
+    clampValue(descriptor, value),
+    descriptor.min,
+    descriptor.max,
+  );
+}
+
+interface ResolveOptions {
+  /** Fine drag suppresses detent snapping (docs/knob-primitive.md). */
+  fine?: boolean;
+}
+
+/**
+ * Normalized [0, 1] position -> canonical value, applying (in order) detent
+ * snapping, stepCount quantization, the taper, interval quantization, and
+ * range clamping. This is the single place a raw drag position becomes a
+ * committable canonical value.
+ */
+function normalizedToCanonical<T>(
+  descriptor: ParamDescriptor<T>,
+  position: number,
+  options: ResolveOptions = {},
+): T {
+  let p = clamp01(position);
+  if (!options.fine) p = snapToDetents(descriptor, p);
+  p = snapToStepCount(descriptor, p);
+
+  let value = taperFromNormalized(
+    descriptor.taper,
+    p,
+    descriptor.min,
+    descriptor.max,
+  );
+  if (typeof value === "number") {
+    value = snapToInterval(descriptor, value) as unknown as T;
+  }
+  return clampValue(descriptor, value);
+}
+
+/** The reset target (default), clamped for safety. */
+function resetValue<T>(descriptor: ParamDescriptor<T>): T {
+  return clampValue(descriptor, descriptor.default);
+}
+
+/**
+ * The canonical value one keyboard step from `value`.
+ *
+ * Discrete params (interval or stepCount) move by whole steps; continuous
+ * params move by `keyStep` / `keyStepLarge` in normalized space so the feel is
+ * range- and taper-independent. `Home`/`End` are handled by the caller as the
+ * endpoints. Stepping bypasses magnetic detents (`fine`): keyboard and wheel
+ * are precise, detents are a drag-only affordance.
+ */
+function stepValue<T>(
+  descriptor: ParamDescriptor<T>,
+  value: T,
+  direction: 1 | -1,
+  large: boolean,
+): T {
+  // Discrete numeric: step by whole intervals.
+  if (
+    descriptor.interval &&
+    descriptor.interval > 0 &&
+    typeof value === "number"
+  ) {
+    const stepCountMultiple = large ? PAGE_STEP_INTERVALS : 1;
+    const next = value + direction * descriptor.interval * stepCountMultiple;
+    return normalizedToCanonical(
+      descriptor,
+      canonicalToNormalized(descriptor, next as unknown as T),
+      { fine: true },
+    );
+  }
+
+  // Discrete via stepCount: step by whole positions.
+  if (descriptor.stepCount && descriptor.stepCount > 1) {
+    const steps = descriptor.stepCount - 1;
+    const currentPos = canonicalToNormalized(descriptor, value);
+    const currentIndex = Math.round(currentPos * steps);
+    const delta = large
+      ? Math.max(1, Math.round(steps / PAGE_STEP_INTERVALS))
+      : 1;
+    const nextIndex = clamp(currentIndex + direction * delta, 0, steps);
+    return normalizedToCanonical(descriptor, nextIndex / steps, { fine: true });
+  }
+
+  // Continuous: step in normalized space.
+  const step = large
+    ? (descriptor.keyStepLarge ?? DEFAULT_KEY_STEP_LARGE)
+    : (descriptor.keyStep ?? DEFAULT_KEY_STEP);
+  const nextPos = clamp01(
+    canonicalToNormalized(descriptor, value) + direction * step,
+  );
+  return normalizedToCanonical(descriptor, nextPos, { fine: true });
+}
+
+/** The value at the requested endpoint. */
+function endpointValue<T>(
+  descriptor: ParamDescriptor<T>,
+  end: "min" | "max",
+): T {
+  return normalizedToCanonical(descriptor, end === "min" ? 0 : 1);
+}
+
+/** Display string for a canonical value (pure projection). */
+function formatValue<T>(descriptor: ParamDescriptor<T>, value: T): string {
+  return descriptor.format(value);
+}
+
+/** Parse type-in text to a clamped canonical value, or null if rejected. */
+function parseValue<T>(descriptor: ParamDescriptor<T>, text: string): T | null {
+  if (!descriptor.parse) return null;
+  const parsed = descriptor.parse(text);
+  if (parsed === null || parsed === undefined) return null;
+  return clampValue(descriptor, parsed);
+}
+
+export {
+  DEFAULT_DRAG_SENSITIVITY,
+  DEFAULT_FINE_DRAG_FACTOR,
+  DEFAULT_KEY_STEP,
+  DEFAULT_KEY_STEP_LARGE,
+  isNumericDescriptor,
+  isDiscrete,
+  clampValue,
+  canonicalToNormalized,
+  normalizedToCanonical,
+  resetValue,
+  stepValue,
+  endpointValue,
+  formatValue,
+  parseValue,
+};
+export type { ResolveOptions };

--- a/src/shared/param-control/lib/taper.ts
+++ b/src/shared/param-control/lib/taper.ts
@@ -1,0 +1,120 @@
+import { clamp } from "@/shared/lib/utils";
+import type { Taper } from "../types";
+
+/** Clamp a raw position into the normalized [0, 1] transport range. */
+function clamp01(position: number): number {
+  return clamp(position, 0, 1);
+}
+
+/**
+ * Derive the JUCE-style skew exponent that places `centre` at knob-centre
+ * (normalized position 0.5).
+ *
+ * With the non-symmetric skew, `to01(centre) = proportion ^ skew`, so
+ * `skew = ln(0.5) / ln(proportion)` where `proportion` is `centre`'s linear
+ * position. Lets an author say "1 kHz sits at knob-centre" instead of scattering
+ * magic exponents (see docs/knob-primitive.md).
+ */
+function setSkewForCentre(min: number, max: number, centre: number): number {
+  const proportion = (centre - min) / (max - min);
+  if (proportion <= 0 || proportion >= 1) {
+    throw new Error(
+      `setSkewForCentre: centre ${centre} must lie strictly inside (${min}, ${max})`,
+    );
+  }
+  return Math.log(0.5) / Math.log(proportion);
+}
+
+/**
+ * Apply a skew to a linear proportion (JUCE NormalisableRange, forward).
+ * With `symmetric`, the skew is applied from the middle outward so the centre
+ * stays pinned at 0.5 (used by bipolar params: pan, tune).
+ */
+function skewProportionTo01(
+  proportion: number,
+  skew: number,
+  symmetric: boolean,
+): number {
+  const p = clamp01(proportion);
+  if (skew === 1) return p;
+  if (!symmetric) return Math.pow(p, skew);
+
+  const distanceFromMiddle = 2 * p - 1;
+  const skewed =
+    Math.sign(distanceFromMiddle) *
+    Math.pow(Math.abs(distanceFromMiddle), skew);
+  return (1 + skewed) / 2;
+}
+
+/**
+ * Invert a skew back to a linear proportion (JUCE NormalisableRange, inverse).
+ */
+function skewProportionFrom01(
+  position: number,
+  skew: number,
+  symmetric: boolean,
+): number {
+  const p = clamp01(position);
+  if (skew === 1) return p;
+  if (!symmetric) {
+    return p > 0 ? Math.exp(Math.log(p) / skew) : p;
+  }
+
+  let distanceFromMiddle = 2 * p - 1;
+  if (distanceFromMiddle !== 0) {
+    distanceFromMiddle =
+      Math.sign(distanceFromMiddle) *
+      Math.exp(Math.log(Math.abs(distanceFromMiddle)) / skew);
+  }
+  return (distanceFromMiddle + 1) / 2;
+}
+
+/** Canonical value -> normalized [0, 1] position, via the descriptor's taper. */
+function taperToNormalized<T>(
+  taper: Taper<T>,
+  value: T,
+  min: T,
+  max: T,
+): number {
+  if (taper.kind === "custom") return clamp01(taper.to01(value));
+
+  const v = value as unknown as number;
+  const lo = min as unknown as number;
+  const hi = max as unknown as number;
+  const proportion = clamp01((v - lo) / (hi - lo));
+
+  if (taper.kind === "linear") return proportion;
+  return skewProportionTo01(proportion, taper.skew, taper.symmetric ?? false);
+}
+
+/** Normalized [0, 1] position -> canonical value, via the descriptor's taper. */
+function taperFromNormalized<T>(
+  taper: Taper<T>,
+  position: number,
+  min: T,
+  max: T,
+): T {
+  if (taper.kind === "custom") return taper.from01(clamp01(position));
+
+  const lo = min as unknown as number;
+  const hi = max as unknown as number;
+
+  let proportion = clamp01(position);
+  if (taper.kind === "exponential") {
+    proportion = skewProportionFrom01(
+      proportion,
+      taper.skew,
+      taper.symmetric ?? false,
+    );
+  }
+  return (lo + (hi - lo) * proportion) as unknown as T;
+}
+
+export {
+  clamp01,
+  setSkewForCentre,
+  skewProportionTo01,
+  skewProportionFrom01,
+  taperToNormalized,
+  taperFromNormalized,
+};

--- a/src/shared/param-control/types.ts
+++ b/src/shared/param-control/types.ts
@@ -1,0 +1,104 @@
+/**
+ * The descriptor-driven parameter-control model.
+ *
+ * Full design: docs/knob-primitive.md. In short: a `ParamDescriptor<T>` fully
+ * specifies a parameter's range, curve, stepping, polarity, default, and
+ * formatting, and one control renders and edits any descriptor.
+ *
+ * Three representations are cleanly separated (docs/data-representation.md):
+ *   - canonical (plain) value `T` - the entire public API speaks this,
+ *   - normalized [0, 1] position - the control's private transport,
+ *   - display string - a pure projection of canonical, computed at render.
+ *
+ * 0-100 appears nowhere.
+ */
+
+/**
+ * Maps the normalized [0, 1] position to and from a canonical value.
+ *
+ *  - `linear`: proportion is the position.
+ *  - `exponential`: a single JUCE-style `skew` scalar (serializable,
+ *    comparable, interpolatable). `symmetric` applies the skew from the centre
+ *    outward, pinning knob-centre to the parameter's centre for bipolar params.
+ *    Derive `skew` with `setSkewForCentre` instead of writing magic exponents.
+ *  - `custom`: the escape hatch for curves that are not a single exponent, such
+ *    as the split filter's position to `{ side, cutoffHz }`.
+ */
+type Taper<T = number> =
+  | { kind: "linear" }
+  | { kind: "exponential"; skew: number; symmetric?: boolean }
+  | {
+      kind: "custom";
+      to01: (value: T) => number;
+      from01: (position: number) => T;
+    };
+
+/** A magnetic notch: `value` in canonical units, `radiusPct` in position [0,1]. */
+interface Detent<T = number> {
+  value: T;
+  radiusPct: number;
+}
+
+interface ParamDescriptor<T = number> {
+  min: T;
+  max: T;
+
+  /** normalized [0,1] <-> canonical */
+  taper: Taper<T>;
+
+  /** reset target; centre value for bipolar params */
+  default: T;
+
+  /** snap step in canonical units (0 or undefined = continuous); numeric params only */
+  interval?: number;
+  /** discrete/enum params: number of positions (VST3 model) */
+  stepCount?: number;
+  /** names for discrete steps */
+  valueLabels?: string[] | ((v: T) => string);
+
+  /** center-origin fill + centre detent affordance */
+  polarity?: "unipolar" | "bipolar";
+  /** magnetic notches, auto-disabled under fine drag */
+  detents?: Detent<T>[];
+
+  /** canonical -> display string, e.g. "2.5 kHz" */
+  format: (canonical: T) => string;
+  /** display string -> canonical, for type-in entry; return null to reject */
+  parse?: (text: string) => T | null;
+  unit?: string;
+  precision?: number;
+
+  /** normalized delta per pixel of vertical drag (one value across all ranges) */
+  dragSensitivity?: number;
+  /** multiplier applied to the drag delta while the fine modifier is held */
+  fineDragFactor?: number;
+  /** arrow-key increment (normalized units for continuous params) */
+  keyStep?: number;
+  /** Page-key increment (normalized units for continuous params) */
+  keyStepLarge?: number;
+}
+
+/**
+ * FUTURE render seams (docs/knob-primitive.md "Future").
+ *
+ * These are declared so the presentation can grow into them without reworking
+ * the primitive. They are intentionally NOT implemented yet.
+ */
+interface RotaryKnobFutureSeams {
+  /**
+   * FUTURE: a modulation-range arc, rendered decoupled from the value
+   * indicator so it can layer in later. Not rendered.
+   */
+  modulationRange?: { min: number; max: number };
+  /**
+   * FUTURE: an optional circular / relative drag mode as a user preference.
+   * Only "vertical" is implemented.
+   */
+  dragMode?: "vertical" | "circular";
+  /**
+   * FUTURE: a right-click context menu (assign, copy/paste, clear). Not built.
+   */
+  onContextMenuRequest?: () => void;
+}
+
+export type { Taper, Detent, ParamDescriptor, RotaryKnobFutureSeams };


### PR DESCRIPTION
Builds the descriptor-driven knob primitive from `docs/knob-primitive.md` as a tested, standalone, **additive** component set. Epic 2 of #358.

This PR builds the primitive but does **not** adopt it into the app: no feature param control is rewired, no store is flipped to canonical units, and the existing `src/shared/knob/*` code is untouched. Adoption is a later PR (Epic 1 PR C/F). All existing suites still pass unchanged.

## What landed

New module `src/shared/param-control/` (alongside the existing `src/shared/knob/`):

- **Model** (`types.ts`): `ParamDescriptor<T = number>` with the taper union - `linear`; `exponential` with a JUCE-style scalar `skew` (+ `symmetric` for bipolar); `custom` with a `to01`/`from01` pair. Plus `interval`/`stepCount`/`valueLabels`, `polarity`, `detents`, `format`/`parse`/`unit`/`precision`, and interaction tuning (`dragSensitivity`, `fineDragFactor`, `keyStep`, `keyStepLarge`). Future render seams (modulation-range arc, circular drag, context menu) are declared but not built.
- **Taper math** (`lib/taper.ts`): JUCE-faithful skew forward/inverse (symmetric variant included) and `setSkewForCentre(min, max, centre)` that derives the exponent so an author can say "1 kHz sits at knob-centre."
- **Core ops** (`lib/descriptor.ts`): normalized<->canonical mapping, interval + stepCount quantization, taper-correct detent snapping, range clamping everywhere, and keyboard/step math.
- **Headless hook** (`hooks/use-param-control.ts`): canonical-only public API - `value`/`onChange` in canonical units, `onGestureStart`/`onGestureEnd` distinct from `onChange`, normalized [0,1] strictly internal. Absolute vertical drag with the delta in normalized space (one sensitivity across all ranges/tapers), Shift-fine, double-click/Delete reset, type-in via `parse` (Enter/Esc), keyboard + ARIA (`role="slider"`, arrows/Page/Home/End, `aria-valuetext` = display string), mouse-wheel stepping, and a raw unrounded value held through the gesture, rounded only at commit.
- **Presentation** (`components/rotary-knob.tsx`): a thin skin over the hook with bipolar center-origin fill.
- **Descriptors** (`descriptors/`): canonical-unit descriptors ported from the existing mappings (decay seconds, volume dB with silence at the floor, pan, tune semitones, the nine master params, swing fraction), plus the split filter as the generic-T exemplar: `ParamDescriptor<CanonicalFilter>` with a custom taper mapping position to/from `{ side, cutoffHz }`.

## Shared seam for PR B

The canonical filter type lives at **`src/core/audio/canonical/filter.ts`** (`CanonicalFilter = { side: "lowpass" | "highpass"; cutoffHz: number }`). It is minimal (type only, no store/engine imports). The parallel engine split-filter refactor (PR B) should import this exact module so the widget and engine cannot drift.

## Validation

- **Unit** (node project): taper round-trips (linear/exponential/skew/symmetric), `setSkewForCentre` centering, interval/stepCount quantization, detent snapping (and its fine-drag disable), clamping, parse/format round-trips, keyboard step math, and the `{ side, cutoffHz }` custom-taper round-trip.
- **Browser** (chromium project): the real `RotaryKnob` under drag (canonical value changes, Shift halves the delta), double-click reset, type-in parse, keyboard step + Page, `aria-valuetext` = display string, and gesture start/end firing exactly once each.

Gates: `pnpm vitest run` (both projects, 1201 passed), `pnpm lint`, `npx tsc --noEmit`, `pnpm build` all green.
