### PR TITLE
feat(param-control): slider and clickable value presentations (Epic 2, BC)

### DIFF
--- a/src/shared/param-control/__tests__/linear-slider.browser.test.ts
+++ b/src/shared/param-control/__tests__/linear-slider.browser.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Browser tests for the descriptor-driven LinearSlider (fader).
+ *
+ * Mounts the real component in Chromium and drives real pointer, keyboard, and
+ * input events. The public contract is canonical-only: every assertion is on
+ * the CANONICAL value emitted through onChange, never a normalized position.
+ */
+
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LinearSlider } from "../components/linear-slider";
+import type { ParamDescriptor } from "../types";
+
+declare global {
+  // Required by React so act() can flush effects in tests.
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Linear 0..100, display carries a unit so aria-valuetext != the raw number. */
+const testDescriptor: ParamDescriptor<number> = {
+  min: 0,
+  max: 100,
+  taper: { kind: "linear" },
+  default: 50,
+  format: (v) => `${v.toFixed(0)} u`,
+  parse: (t) => {
+    const n = Number.parseFloat(t);
+    return Number.isNaN(n) ? null : n;
+  },
+};
+
+/** Bipolar -1..1 with a centre detent, for the centre-origin fill assertions. */
+const panDescriptor: ParamDescriptor<number> = {
+  min: -1,
+  max: 1,
+  taper: { kind: "linear" },
+  default: 0,
+  polarity: "bipolar",
+  detents: [{ value: 0, radiusPct: 0.05 }],
+  format: (v) => v.toFixed(2),
+};
+
+type Recorded = {
+  changes: number[];
+  gestureStarts: number;
+  gestureEnds: number;
+};
+
+type Orientation = "horizontal" | "vertical";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+let recorded: Recorded;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  recorded = { changes: [], gestureStarts: 0, gestureEnds: 0 };
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+async function mount(
+  initial = 50,
+  orientation: Orientation = "horizontal",
+  descriptor: ParamDescriptor<number> = testDescriptor,
+) {
+  function Host() {
+    const [value, setValue] = useState(initial);
+    return createElement(LinearSlider<number>, {
+      descriptor,
+      value,
+      label: "Test",
+      orientation,
+      onChange: (v: number) => {
+        recorded.changes.push(v);
+        setValue(v);
+      },
+      onGestureStart: () => {
+        recorded.gestureStarts += 1;
+      },
+      onGestureEnd: () => {
+        recorded.gestureEnds += 1;
+      },
+    });
+  }
+  await act(async () => {
+    root?.render(createElement(Host));
+  });
+}
+
+function slider(): HTMLElement {
+  const el = container?.querySelector('[role="slider"]');
+  if (!(el instanceof HTMLElement)) throw new Error("slider not found");
+  return el;
+}
+
+function last(): number {
+  return recorded.changes[recorded.changes.length - 1];
+}
+
+async function pointer(
+  type: string,
+  coord: { x?: number; y?: number },
+  shiftKey = false,
+) {
+  await act(async () => {
+    const target = type === "pointerdown" ? slider() : window;
+    target.dispatchEvent(
+      new PointerEvent(type, {
+        clientX: coord.x ?? 0,
+        clientY: coord.y ?? 0,
+        pointerId: 1,
+        bubbles: true,
+        cancelable: true,
+        shiftKey,
+      }),
+    );
+  });
+}
+
+async function keydown(key: string) {
+  await act(async () => {
+    slider().dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+describe("LinearSlider interactions (canonical-only public API)", () => {
+  it("horizontal drag: right increases, in normalized space", async () => {
+    await mount(50, "horizontal");
+    await pointer("pointerdown", { x: 0 });
+    // drag right 20px: default sensitivity 1/200 -> +0.1 pos -> 60
+    await pointer("pointermove", { x: 20 });
+    await pointer("pointerup", { x: 20 });
+    expect(last()).toBeCloseTo(60, 6);
+  });
+
+  it("vertical drag: up increases, in normalized space", async () => {
+    await mount(50, "vertical");
+    await pointer("pointerdown", { y: 100 });
+    // drag up 20px -> +0.1 pos -> 60
+    await pointer("pointermove", { y: 80 });
+    await pointer("pointerup", { y: 80 });
+    expect(last()).toBeCloseTo(60, 6);
+  });
+
+  it("halves the delta while Shift (fine) is held", async () => {
+    await mount(50, "horizontal");
+    await pointer("pointerdown", { x: 0 });
+    // shift-drag right 20px: +0.1 * 0.25 fine factor -> +0.025 pos -> 52.5
+    await pointer("pointermove", { x: 20 }, true);
+    await pointer("pointerup", { x: 20 }, true);
+    expect(last()).toBeCloseTo(52.5, 6);
+  });
+
+  it("fires onGestureStart / onGestureEnd exactly once per drag", async () => {
+    await mount(50, "horizontal");
+    await pointer("pointerdown", { x: 0 });
+    await pointer("pointermove", { x: 10 });
+    await pointer("pointermove", { x: 20 });
+    await pointer("pointerup", { x: 20 });
+    expect(recorded.gestureStarts).toBe(1);
+    expect(recorded.gestureEnds).toBe(1);
+  });
+
+  it("resets to default on double-click", async () => {
+    await mount(20, "horizontal");
+    await act(async () => {
+      slider().dispatchEvent(
+        new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+      );
+    });
+    expect(last()).toBe(50);
+  });
+
+  it("snaps to the centre detent under a coarse drag, bipolar", async () => {
+    await mount(0, "horizontal", panDescriptor);
+    // nudge just off centre; within the 0.05 detent radius -> snaps back to 0
+    await pointer("pointerdown", { x: 0 });
+    await pointer("pointermove", { x: 4 }); // +0.02 pos, inside radius
+    await pointer("pointerup", { x: 4 });
+    expect(last()).toBe(0);
+  });
+
+  it("steps by keyStep on arrows and keyStepLarge on Page", async () => {
+    await mount(50, "horizontal");
+    await keydown("ArrowUp"); // +0.01 pos -> 51
+    expect(last()).toBeCloseTo(51, 6);
+    await keydown("PageUp"); // +0.1 pos -> 61
+    expect(last()).toBeCloseTo(61, 6);
+  });
+
+  it("jumps to endpoints on Home / End", async () => {
+    await mount(50, "horizontal");
+    await keydown("End");
+    expect(last()).toBe(100);
+    await keydown("Home");
+    expect(last()).toBe(0);
+  });
+
+  it("exposes the display string as aria-valuetext plus aria-orientation", async () => {
+    await mount(42, "vertical");
+    expect(slider().getAttribute("aria-valuetext")).toBe("42 u");
+    expect(slider().getAttribute("aria-valuenow")).toBe("42");
+    expect(slider().getAttribute("role")).toBe("slider");
+    expect(slider().getAttribute("aria-orientation")).toBe("vertical");
+  });
+
+  it("accepts type-in entry parsed through the descriptor", async () => {
+    await mount(50, "horizontal");
+    const valueButton = container?.querySelector(
+      '[data-slot="linear-slider-value"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      valueButton.click();
+    });
+    const input = container?.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      // Defeat React's controlled-input value tracker so onChange fires.
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setValue?.call(input, "75");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(last()).toBe(75);
+  });
+});

--- a/src/shared/param-control/__tests__/value-field.browser.test.ts
+++ b/src/shared/param-control/__tests__/value-field.browser.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Browser tests for the descriptor-driven ValueField (clickable value).
+ *
+ * Mounts the real component in Chromium and drives real pointer, keyboard, and
+ * input events. The public contract is canonical-only: every assertion is on
+ * the CANONICAL value emitted through onChange, never a normalized position.
+ * The field disambiguates a tap (type-in) from a drag on one element, so both
+ * paths are exercised.
+ */
+
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ValueField } from "../components/value-field";
+import type { ParamDescriptor } from "../types";
+
+declare global {
+  // Required by React so act() can flush effects in tests.
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Linear 0..100, display carries a unit so aria-valuetext != the raw number. */
+const testDescriptor: ParamDescriptor<number> = {
+  min: 0,
+  max: 100,
+  taper: { kind: "linear" },
+  default: 50,
+  format: (v) => `${v.toFixed(0)} u`,
+  parse: (t) => {
+    const n = Number.parseFloat(t);
+    return Number.isNaN(n) ? null : n;
+  },
+};
+
+type Recorded = {
+  changes: number[];
+  gestureStarts: number;
+  gestureEnds: number;
+};
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+let recorded: Recorded;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  recorded = { changes: [], gestureStarts: 0, gestureEnds: 0 };
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+async function mount(initial = 50) {
+  function Host() {
+    const [value, setValue] = useState(initial);
+    return createElement(ValueField<number>, {
+      descriptor: testDescriptor,
+      value,
+      label: "level",
+      onChange: (v: number) => {
+        recorded.changes.push(v);
+        setValue(v);
+      },
+      onGestureStart: () => {
+        recorded.gestureStarts += 1;
+      },
+      onGestureEnd: () => {
+        recorded.gestureEnds += 1;
+      },
+    });
+  }
+  await act(async () => {
+    root?.render(createElement(Host));
+  });
+}
+
+function field(): HTMLElement {
+  const el = container?.querySelector('[role="slider"]');
+  if (!(el instanceof HTMLElement)) throw new Error("value field not found");
+  return el;
+}
+
+function input(): HTMLInputElement | null {
+  return container?.querySelector("input") ?? null;
+}
+
+function last(): number {
+  return recorded.changes[recorded.changes.length - 1];
+}
+
+async function pointer(type: string, clientY: number, shiftKey = false) {
+  await act(async () => {
+    const target = type === "pointerdown" ? field() : window;
+    target.dispatchEvent(
+      new PointerEvent(type, {
+        clientY,
+        clientX: 0,
+        pointerId: 1,
+        bubbles: true,
+        cancelable: true,
+        shiftKey,
+      }),
+    );
+  });
+}
+
+async function keydown(key: string) {
+  await act(async () => {
+    field().dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }),
+    );
+  });
+}
+
+describe("ValueField interactions (canonical-only public API)", () => {
+  it("drags vertically to change value (up increases), past the threshold", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 95); // 5px > threshold: promotes, no change yet
+    await pointer("pointermove", 75); // +20px from 95 -> +0.1 pos -> 60
+    await pointer("pointerup", 75);
+    expect(last()).toBeCloseTo(60, 6);
+  });
+
+  it("a drag does not open the type-in editor", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 90);
+    await pointer("pointermove", 70);
+    await pointer("pointerup", 70);
+    expect(input()).toBeNull();
+  });
+
+  it("a tap (no movement) opens the type-in editor", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointerup", 100); // never crossed the threshold
+    expect(input()).not.toBeNull();
+    // No value change on a pure tap.
+    expect(recorded.changes).toHaveLength(0);
+  });
+
+  it("fires onGestureStart / onGestureEnd exactly once per drag", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 90);
+    await pointer("pointermove", 80);
+    await pointer("pointerup", 80);
+    expect(recorded.gestureStarts).toBe(1);
+    expect(recorded.gestureEnds).toBe(1);
+  });
+
+  it("halves the delta while Shift (fine) is held", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 95, true); // promote (no change)
+    await pointer("pointermove", 75, true); // +20px * 0.25 -> +0.025 -> 52.5
+    await pointer("pointerup", 75, true);
+    expect(last()).toBeCloseTo(52.5, 6);
+  });
+
+  it("steps by keyStep on arrows and keyStepLarge on Page", async () => {
+    await mount(50);
+    await keydown("ArrowUp"); // +0.01 pos -> 51
+    expect(last()).toBeCloseTo(51, 6);
+    await keydown("PageUp"); // +0.1 pos -> 61
+    expect(last()).toBeCloseTo(61, 6);
+  });
+
+  it("jumps to endpoints on Home / End", async () => {
+    await mount(50);
+    await keydown("End");
+    expect(last()).toBe(100);
+    await keydown("Home");
+    expect(last()).toBe(0);
+  });
+
+  it("resets to default on Delete (tap is reserved for type-in)", async () => {
+    await mount(20);
+    await keydown("Delete");
+    expect(last()).toBe(50);
+  });
+
+  it("exposes the display string as aria-valuetext, not the raw number", async () => {
+    await mount(42);
+    expect(field().getAttribute("aria-valuetext")).toBe("42 u");
+    expect(field().getAttribute("aria-valuenow")).toBe("42");
+    expect(field().getAttribute("role")).toBe("slider");
+  });
+
+  it("accepts type-in entry parsed through the descriptor", async () => {
+    await mount(50);
+    // Tap to open the editor.
+    await pointer("pointerdown", 100);
+    await pointer("pointerup", 100);
+    const el = input() as HTMLInputElement;
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setValue?.call(el, "75");
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      el.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Enter",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(last()).toBe(75);
+    // The tap opened one gesture; Enter committed and closed it.
+    expect(recorded.gestureStarts).toBe(1);
+    expect(recorded.gestureEnds).toBe(1);
+  });
+});

--- a/src/shared/param-control/components/linear-slider.tsx
+++ b/src/shared/param-control/components/linear-slider.tsx
@@ -1,0 +1,196 @@
+import type { CSSProperties } from "react";
+
+import { cn } from "@/shared/lib/utils";
+import { useParamControl } from "../hooks/use-param-control";
+import type { ParamDescriptor, RotaryKnobFutureSeams } from "../types";
+
+type SliderOrientation = "horizontal" | "vertical";
+
+type LinearSliderProps<T> = {
+  descriptor: ParamDescriptor<T>;
+  /** Value in CANONICAL units. */
+  value: T;
+  /** Emits the next value in CANONICAL units. */
+  onChange: (value: T) => void;
+  onGestureStart?: () => void;
+  onGestureEnd?: () => void;
+  disabled?: boolean;
+  label: string;
+  /** Opt-in tab order (default true). */
+  tabbable?: boolean;
+  id?: string;
+  /** "horizontal" (default) or "vertical" fader. */
+  orientation?: SliderOrientation;
+  /** Length of the track along its axis, in pixels. */
+  length?: number;
+  /** Thickness of the track across its axis, in pixels. */
+  thickness?: number;
+  /** Diameter of the thumb, in pixels. */
+  thumbSize?: number;
+  /** Hide the caption label. */
+  hideLabel?: boolean;
+  /** Hide the value readout. */
+  hideValue?: boolean;
+  className?: string;
+} & RotaryKnobFutureSeams;
+
+/**
+ * The linear (fader) presentation of the descriptor-driven control. A thin skin
+ * over `useParamControl`: it owns look only (track, fill, thumb, readout),
+ * while all behavior and the canonical-only contract live in the hook.
+ *
+ * The drag reads whichever axis the orientation names (up / right increases),
+ * always in normalized space, so `dragSensitivity`, fine drag, and detents work
+ * identically to the knob. FUTURE seams (modulation-range arc, drag mode,
+ * context menu) are declared on the props but intentionally not implemented.
+ */
+function LinearSlider<T>({
+  descriptor,
+  value,
+  onChange,
+  onGestureStart,
+  onGestureEnd,
+  disabled = false,
+  label,
+  tabbable = true,
+  id,
+  orientation = "horizontal",
+  length = 140,
+  thickness = 12,
+  thumbSize = 16,
+  hideLabel = false,
+  hideValue = false,
+  className,
+  // Declared future seams; not wired yet.
+  modulationRange: _modulationRange,
+  dragMode: _dragMode,
+  onContextMenuRequest: _onContextMenuRequest,
+}: LinearSliderProps<T>) {
+  const control = useParamControl({
+    descriptor,
+    value,
+    onChange,
+    onGestureStart,
+    onGestureEnd,
+    disabled,
+    label,
+    tabbable,
+    id,
+    dragAxis: orientation === "vertical" ? "vertical" : "horizontal",
+  });
+
+  const { position, bipolar } = control;
+  const isVertical = orientation === "vertical";
+
+  // Fill spans from the origin (bottom / left, or centre for bipolar) to the thumb.
+  const fillStart = bipolar ? 0.5 : 0;
+  const lo = Math.min(fillStart, position);
+  const hi = Math.max(fillStart, position);
+
+  const trackStyle: CSSProperties = isVertical
+    ? { width: thickness, height: length }
+    : { width: length, height: thickness };
+
+  const fillStyle: CSSProperties = isVertical
+    ? { bottom: `${lo * 100}%`, height: `${(hi - lo) * 100}%`, width: "100%" }
+    : { left: `${lo * 100}%`, width: `${(hi - lo) * 100}%`, height: "100%" };
+
+  const thumbStyle: CSSProperties = isVertical
+    ? {
+        width: thumbSize,
+        height: thumbSize,
+        bottom: `${position * 100}%`,
+        left: "50%",
+        transform: "translate(-50%, 50%)",
+      }
+    : {
+        width: thumbSize,
+        height: thumbSize,
+        left: `${position * 100}%`,
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+      };
+
+  return (
+    <div
+      data-slot="linear-slider"
+      data-orientation={orientation}
+      data-disabled={disabled || undefined}
+      data-dragging={control.isDragging || undefined}
+      className={cn(
+        "flex flex-col items-center gap-2 select-none",
+        disabled && "opacity-50",
+        className,
+      )}
+    >
+      <div
+        {...control.handlers}
+        {...control.ariaProps}
+        aria-orientation={orientation}
+        aria-labelledby={hideLabel ? undefined : `${control.id}-label`}
+        className={cn(
+          "relative touch-none rounded-full outline-none",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2",
+          isVertical ? "cursor-ns-resize" : "cursor-ew-resize",
+        )}
+        style={{ ...trackStyle, touchAction: "none" }}
+      >
+        {/* Track */}
+        <div
+          className="absolute inset-0 rounded-full bg-(--slider-track-bg) shadow-(--slider-track-shadow)"
+          aria-hidden="true"
+        />
+        {/* Fill */}
+        <div
+          className="bg-primary absolute rounded-full"
+          style={fillStyle}
+          aria-hidden="true"
+        />
+        {/* Thumb */}
+        <div
+          className="bg-surface absolute rounded-full border shadow-sm"
+          style={thumbStyle}
+          aria-hidden="true"
+        />
+      </div>
+
+      {!hideValue &&
+        (control.isEditing ? (
+          <input
+            {...control.editProps}
+            aria-label={`${label} value`}
+            className={cn(
+              "bg-surface text-foreground w-16 rounded-sm px-1 text-center text-xs",
+              "outline-none",
+            )}
+          />
+        ) : (
+          <button
+            type="button"
+            data-slot="linear-slider-value"
+            disabled={disabled || !descriptor.parse}
+            onClick={control.beginEdit}
+            className={cn(
+              "text-foreground-muted text-xs tabular-nums",
+              descriptor.parse && "hover:text-foreground cursor-text",
+            )}
+          >
+            {control.displayValue}
+          </button>
+        ))}
+
+      {!hideLabel && (
+        <span
+          id={`${control.id}-label`}
+          data-slot="linear-slider-label"
+          className="text-foreground-muted text-xs"
+        >
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export { LinearSlider };
+export type { LinearSliderProps, SliderOrientation };

--- a/src/shared/param-control/components/value-field.tsx
+++ b/src/shared/param-control/components/value-field.tsx
@@ -1,0 +1,122 @@
+import { cn } from "@/shared/lib/utils";
+import { useParamControl } from "../hooks/use-param-control";
+import type { ParamDescriptor } from "../types";
+
+/** Movement (px) before a press on the field counts as a drag rather than a tap. */
+const DRAG_THRESHOLD_PX = 3;
+
+type ValueFieldProps<T> = {
+  descriptor: ParamDescriptor<T>;
+  /** Value in CANONICAL units. */
+  value: T;
+  /** Emits the next value in CANONICAL units. */
+  onChange: (value: T) => void;
+  onGestureStart?: () => void;
+  onGestureEnd?: () => void;
+  disabled?: boolean;
+  label: string;
+  /** Opt-in tab order (default true). */
+  tabbable?: boolean;
+  id?: string;
+  /** Show the label inline before the value (default true). */
+  showLabel?: boolean;
+  className?: string;
+  labelClassName?: string;
+  valueClassName?: string;
+};
+
+/**
+ * The clickable value-field presentation of the descriptor-driven control: a
+ * number readout the user drags to change, taps to type, or steps with the
+ * keyboard. A thin skin over `useParamControl`; all behavior and the
+ * canonical-only contract live in the hook.
+ *
+ * One element does double duty, so it sets a small drag threshold: a press that
+ * moves is a vertical drag (up increases), a press that does not is a tap that
+ * opens the type-in editor. Because a tap is the type-in affordance, reset is
+ * Delete / Backspace (the hook) rather than double-click.
+ */
+function ValueField<T>({
+  descriptor,
+  value,
+  onChange,
+  onGestureStart,
+  onGestureEnd,
+  disabled = false,
+  label,
+  tabbable = true,
+  id,
+  showLabel = true,
+  className,
+  labelClassName,
+  valueClassName,
+}: ValueFieldProps<T>) {
+  const control = useParamControl({
+    descriptor,
+    value,
+    onChange,
+    onGestureStart,
+    onGestureEnd,
+    disabled,
+    label,
+    tabbable,
+    id,
+    dragThreshold: DRAG_THRESHOLD_PX,
+    tapOpensEdit: true,
+  });
+
+  const { handlers } = control;
+
+  return (
+    <div
+      data-slot="value-field"
+      data-disabled={disabled || undefined}
+      data-dragging={control.isDragging || undefined}
+      onPointerDown={handlers.onPointerDown}
+      onKeyDown={handlers.onKeyDown}
+      onWheel={handlers.onWheel}
+      {...control.ariaProps}
+      className={cn(
+        "focus-visible:ring-ring relative inline-block touch-none rounded-sm outline-none select-none focus-visible:ring-2",
+        control.isDragging ? "cursor-ns-resize" : "cursor-pointer",
+        disabled && "opacity-50",
+        className,
+      )}
+      style={{ touchAction: "none" }}
+    >
+      {/* The display stays in flow (invisible while editing) so the field keeps
+          its width when the input overlays it, even in content-sized layouts. */}
+      <span className={cn(control.isEditing && "invisible")}>
+        {showLabel && (
+          <span
+            id={`${control.id}-label`}
+            data-slot="value-field-label"
+            className={cn("text-foreground-muted", labelClassName)}
+          >
+            {label}{" "}
+          </span>
+        )}
+        <span
+          data-slot="value-field-value"
+          className={cn("tabular-nums", valueClassName)}
+        >
+          {control.displayValue}
+        </span>
+      </span>
+
+      {control.isEditing && (
+        <input
+          {...control.editProps}
+          aria-label={`${label} value`}
+          onFocus={(event) => event.target.select()}
+          className={cn(
+            "text-foreground absolute inset-0 m-0 w-full min-w-0 rounded-none border-none bg-transparent p-0 text-center leading-none outline-none",
+          )}
+        />
+      )}
+    </div>
+  );
+}
+
+export { ValueField };
+export type { ValueFieldProps };

--- a/src/shared/param-control/hooks/use-param-control.ts
+++ b/src/shared/param-control/hooks/use-param-control.ts
@@ -21,6 +21,9 @@ import {
 import { clamp01 } from "../lib/taper";
 import type { ParamDescriptor } from "../types";
 
+/** Which screen axis a drag reads: knobs and value fields use "vertical". */
+type DragAxis = "vertical" | "horizontal";
+
 interface UseParamControlProps<T> {
   descriptor: ParamDescriptor<T>;
   /** Current value, in CANONICAL units. */
@@ -36,6 +39,22 @@ interface UseParamControlProps<T> {
   /** Opt-in tab order: false removes the control from the tab sequence. */
   tabbable?: boolean;
   id?: string;
+  /**
+   * Which screen axis drives the drag. "vertical" (up increases) is the default
+   * for knobs and value fields; a horizontal fader passes "horizontal" (right
+   * increases). The delta is always computed in normalized space, so a single
+   * `dragSensitivity` is correct across every range and taper.
+   */
+  dragAxis?: DragAxis;
+  /**
+   * Pixels of movement before a press becomes a drag. 0 (the default) starts
+   * dragging immediately on pointer-down, as a knob or fader thumb does. A
+   * value field sets a small threshold so a click that never moves is treated
+   * as a tap (type-in) rather than a zero-delta drag.
+   */
+  dragThreshold?: number;
+  /** When true, a tap (a press released below `dragThreshold`) opens the type-in editor. */
+  tapOpensEdit?: boolean;
 }
 
 interface SliderAriaProps {
@@ -85,6 +104,9 @@ interface UseParamControlResult {
   bipolar: boolean;
 }
 
+/** Pointer-drag phase: idle, pressed-but-undecided, or actively dragging. */
+type DragPhase = "idle" | "pending" | "dragging";
+
 /**
  * Headless core for the descriptor-driven parameter control.
  *
@@ -92,6 +114,10 @@ interface UseParamControlResult {
  * strictly-internal transport. A gesture holds a raw, unrounded position and
  * rounds only at commit, so stepped params never accumulate drift and fine
  * drag can move sub-step amounts (docs/knob-primitive.md).
+ *
+ * The same core powers every presentation (knob, fader, value field). A drag
+ * reads whichever screen `dragAxis` names, and an optional `dragThreshold`
+ * lets a presentation distinguish a tap (type-in) from a drag on one element.
  */
 function useParamControl<T>({
   descriptor,
@@ -103,6 +129,9 @@ function useParamControl<T>({
   label,
   tabbable = true,
   id,
+  dragAxis = "vertical",
+  dragThreshold = 0,
+  tapOpensEdit = false,
 }: UseParamControlProps<T>): UseParamControlResult {
   const generatedId = useId();
   const controlId = id ?? generatedId;
@@ -111,13 +140,35 @@ function useParamControl<T>({
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState("");
 
+  // True while window pointer listeners are attached (pending OR dragging).
+  const [tracking, setTracking] = useState(false);
+
+  // Drag state held through a gesture, never re-rendering per move.
+  const phaseRef = useRef<DragPhase>("idle");
+  const startPointRef = useRef({ x: 0, y: 0 });
+  const lastPointRef = useRef({ x: 0, y: 0 });
   // Raw, unrounded position held through a drag gesture.
   const rawPositionRef = useRef(0);
-  const lastYRef = useRef(0);
 
   // Latest props referenced by window listeners without re-subscribing.
-  const latest = useRef({ descriptor, onChange });
-  latest.current = { descriptor, onChange };
+  const latest = useRef({
+    descriptor,
+    onChange,
+    onGestureStart,
+    onGestureEnd,
+    dragAxis,
+    dragThreshold,
+    tapOpensEdit,
+  });
+  latest.current = {
+    descriptor,
+    onChange,
+    onGestureStart,
+    onGestureEnd,
+    dragAxis,
+    dragThreshold,
+    tapOpensEdit,
+  };
 
   const position = canonicalToNormalized(descriptor, value);
   const displayValue = formatValue(descriptor, value);
@@ -151,6 +202,10 @@ function useParamControl<T>({
     setIsEditing(true);
     onGestureStart?.();
   }, [disabled, descriptor, displayValue, onGestureStart]);
+
+  // Referenced by the window pointer-up handler (a tap) without re-subscribing.
+  const beginEditRef = useRef(beginEdit);
+  beginEditRef.current = beginEdit;
 
   const commitEdit = useCallback(() => {
     const parsed = parseValue(descriptor, editText);
@@ -187,59 +242,108 @@ function useParamControl<T>({
 
   const handlePointerMove = useCallback((event: PointerEvent) => {
     event.preventDefault();
-    const { descriptor: d, onChange: emit } = latest.current;
+    const {
+      descriptor: d,
+      onChange: emit,
+      dragAxis: axis,
+      dragThreshold: threshold,
+    } = latest.current;
 
-    const dyIncrement = lastYRef.current - event.clientY; // up = positive
-    lastYRef.current = event.clientY;
+    const x = event.clientX;
+    const y = event.clientY;
+
+    // Pending press: promote to a drag only once movement clears the threshold.
+    if (phaseRef.current === "pending") {
+      const moved =
+        axis === "horizontal"
+          ? Math.abs(x - startPointRef.current.x)
+          : Math.abs(y - startPointRef.current.y);
+      if (moved < threshold) return;
+      phaseRef.current = "dragging";
+      lastPointRef.current = { x, y };
+      setIsDragging(true);
+      latest.current.onGestureStart?.();
+      return;
+    }
+
+    if (phaseRef.current !== "dragging") return;
+
+    // Up (vertical) or right (horizontal) increases the value.
+    const increment =
+      axis === "horizontal"
+        ? x - lastPointRef.current.x
+        : lastPointRef.current.y - y;
+    lastPointRef.current = { x, y };
 
     const sensitivity = d.dragSensitivity ?? DEFAULT_DRAG_SENSITIVITY;
     const fine = event.shiftKey;
     const factor = fine ? (d.fineDragFactor ?? DEFAULT_FINE_DRAG_FACTOR) : 1;
 
     rawPositionRef.current = clamp01(
-      rawPositionRef.current + dyIncrement * sensitivity * factor,
+      rawPositionRef.current + increment * sensitivity * factor,
     );
     emit(normalizedToCanonical(d, rawPositionRef.current, { fine }));
   }, []);
 
-  const endDrag = useCallback(() => {
-    setIsDragging(false);
-    onGestureEnd?.();
-  }, [onGestureEnd]);
+  const endGesture = useCallback((cancelled: boolean) => {
+    const phase = phaseRef.current;
+    phaseRef.current = "idle";
+    setTracking(false);
+    if (phase === "dragging") {
+      setIsDragging(false);
+      latest.current.onGestureEnd?.();
+    } else if (
+      phase === "pending" &&
+      !cancelled &&
+      latest.current.tapOpensEdit
+    ) {
+      // A press that never crossed the threshold is a tap: open the editor.
+      beginEditRef.current();
+    }
+  }, []);
 
   const handlePointerDown = useCallback(
     (event: React.PointerEvent) => {
       if (disabled) return;
       event.preventDefault();
       rawPositionRef.current = canonicalToNormalized(descriptor, value);
-      lastYRef.current = event.clientY;
-      setIsDragging(true);
-      onGestureStart?.();
+      startPointRef.current = { x: event.clientX, y: event.clientY };
+      lastPointRef.current = { x: event.clientX, y: event.clientY };
+
+      if (dragThreshold <= 0) {
+        phaseRef.current = "dragging";
+        setIsDragging(true);
+        onGestureStart?.();
+      } else {
+        phaseRef.current = "pending";
+      }
+      setTracking(true);
       try {
         event.currentTarget.setPointerCapture(event.pointerId);
       } catch {
         // best-effort capture
       }
     },
-    [disabled, descriptor, value, onGestureStart],
+    [disabled, descriptor, value, onGestureStart, dragThreshold],
   );
 
   useEffect(() => {
-    if (!isDragging) return;
+    if (!tracking) return;
 
     const onMove = (event: PointerEvent) => handlePointerMove(event);
-    const onUp = () => endDrag();
+    const onUp = () => endGesture(false);
+    const onCancel = () => endGesture(true);
     const options: AddEventListenerOptions = { passive: false };
 
     window.addEventListener("pointermove", onMove, options);
     window.addEventListener("pointerup", onUp);
-    window.addEventListener("pointercancel", onUp);
+    window.addEventListener("pointercancel", onCancel);
     return () => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
-      window.removeEventListener("pointercancel", onUp);
+      window.removeEventListener("pointercancel", onCancel);
     };
-  }, [isDragging, handlePointerMove, endDrag]);
+  }, [tracking, handlePointerMove, endGesture]);
 
   // --- Keyboard, wheel, double-click ---
 
@@ -341,4 +445,4 @@ function useParamControl<T>({
 }
 
 export { useParamControl };
-export type { UseParamControlProps, UseParamControlResult };
+export type { UseParamControlProps, UseParamControlResult, DragAxis };

--- a/src/shared/param-control/index.ts
+++ b/src/shared/param-control/index.ts
@@ -29,9 +29,17 @@ export { useParamControl } from "./hooks/use-param-control";
 export type {
   UseParamControlProps,
   UseParamControlResult,
+  DragAxis,
 } from "./hooks/use-param-control";
 export { RotaryKnob } from "./components/rotary-knob";
 export type { RotaryKnobProps } from "./components/rotary-knob";
+export { LinearSlider } from "./components/linear-slider";
+export type {
+  LinearSliderProps,
+  SliderOrientation,
+} from "./components/linear-slider";
+export { ValueField } from "./components/value-field";
+export type { ValueFieldProps } from "./components/value-field";
 export * from "./descriptors/canonical-scalars";
 export {
   FILTER_MIN_HZ,


### PR DESCRIPTION
Follow-on to the knob primitive (Epic 2), stage BC of the domain-representation refactor (epic #358).
Extends `src/shared/param-control` with two new presentations on the SAME shared descriptor core, additive and standalone exactly like `RotaryKnob`. Nothing is wired into any feature widget, store, bridge, or engine; that is stage C.

## What this builds

- **`LinearSlider`** - a horizontal or vertical fader (track, centre-origin fill for bipolar params, thumb, value readout). The drag reads the orientation's axis (up / right increases), always in normalized space, so `dragSensitivity`, fine drag, and detents behave identically to the knob.
- **`ValueField`** - a clickable number readout that drags to change, taps to type, and steps with the keyboard, mirroring the app's existing `ClickableValue`. One element does double duty, so a small drag threshold distinguishes a tap (type-in) from a drag.

Both are thin skins over `useParamControl` with a **canonical-only public API**: `value: T` in; `onChange` / `onGestureStart` / `onGestureEnd` out. Normalized [0, 1] never leaves the widget. No 0-100 anywhere. Both are exported with their prop types from the package `index.ts`.

## Shared-core changes (no duplication)

Rather than copy taper/format/parse/step logic, `useParamControl` gained three additive, default-inert options:

- `dragAxis: "vertical" | "horizontal"` - the slider passes the orientation's axis; delta stays in normalized space.
- `dragThreshold` + `tapOpensEdit` - the value field's tap-vs-drag disambiguation, implemented as a small idle/pending/dragging pointer state machine.

Defaults (vertical axis, zero threshold, no tap-edit) preserve `RotaryKnob`'s behavior exactly; its browser test is unchanged and green.

## Interaction set (per docs/knob-primitive.md)

Pointer drag, Shift fine-drag, keyboard (arrows = `keyStep`, Page = `keyStepLarge`, Home/End = endpoints), detents, wheel stepping, gesture bracketing, range clamping, `format`/`parse` type-in, and `role="slider"` with `aria-valuemin`/`max`/`now` and `aria-valuetext` as the display string (the slider also sets `aria-orientation`).

## Tests

New browser tests mirror `rotary-knob.browser.test.ts` (real pointer/keyboard/input events in Chromium, asserting only the canonical value): 10 for the slider, 10 for the value field. Coverage parity with `RotaryKnob`.

## Spec decisions (where knob-primitive.md is silent)

- **Value field = drag-to-change AND tap-to-type on one element.** A press that never crosses a 3px threshold is a tap that opens the editor; a press that moves is a vertical drag. This matches the app's `ClickableValue` and Ableton-style number boxes.
- **Reset on the value field is Delete / Backspace, not double-click.** Single-click / tap is the type-in affordance, so double-click-to-reset would conflict; the knob keeps double-click reset.
- **Slider drag is relative (thumb-style), not absolute track positioning.** Relative drag is what honors `dragSensitivity`, the fine-drag modifier, and taper-correct detents; absolute track-jump would bypass all three. Naming: `LinearSlider` (the `param-control` fader) avoids collision with the existing Radix `Slider` in `shared/ui`.

## Gate results

- `npx tsc --noEmit` - clean (`tsc OK`).
- `pnpm lint` (oxlint, `--max-warnings 0`) - clean, exit 0.
- `pnpm vitest run` (unit + browser) - `Test Files 53 passed | 1 skipped (54)`, `Tests 1471 passed | 4 skipped (1475)`. The new param-control browser tests: 28 passed (8 knob + 10 slider + 10 value field).
- `pnpm build` (`tsc && vite build`) - built in 2.07s (pre-existing chunk-size advisory only).
