### PR TITLE
test(split-filter): stable non-default render guard (#363)

### DIFF
--- a/src/core/audio/engine/fx/split-filter.browser.test.ts
+++ b/src/core/audio/engine/fx/split-filter.browser.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Render-path smoke for a NON-default split-filter position (issue #363).
+ *
+ * The deterministic unit test (split-filter.test.ts) already pins the exact
+ * `deriveSplitFilterFrequencies` node targets. This is the complementary
+ * broadband guard: it renders REAL audio through the production offline path
+ * with the MASTER split filter pushed to an engaged high-pass (knob 70) and
+ * asserts the beat still comes out as a stable, audible four-on-the-floor.
+ * knob 70 -> frozenSplitFilterPositionToCanonical -> { side: "highpass",
+ * cutoffHz ~= 2499 } (position > 49 selects the high-pass side), so the
+ * low-pass opens to the range max and the high-pass tracks ~2.5 kHz.
+ *
+ * ISOLATION / STABILITY NOTE (why this file is structured like golden-render):
+ * PR B first added this file with the same assertions; it flaked ONCE on CI
+ * headless chromium with a standardized-audio-context error -
+ * "A value with the given key could not be found" - thrown from
+ * getNativeAudioNode -> GainNode.connect inside connectMasterBusNodes
+ * (master-bus.ts), i.e. during GENERIC master-bus Gain wiring, BEFORE any
+ * filter value is applied. That location proves it is not a filter or engine
+ * defect: it is standardized-audio-context's per-context node registry failing
+ * to resolve a node's native counterpart. The trigger is browser-test
+ * concurrency: vitest browser mode runs every *.browser.test.ts in the shared
+ * chromium browser, and with file parallelism each offline-render suite spins
+ * up real-time + OfflineAudioContexts that contend for the browser process's
+ * audio subsystem. Adding a THIRD offline-render file raised that contention
+ * and reshuffled scheduling; the new file lost the s-a-c registration race
+ * once on a slower CI runner. golden-render / stem-render never regressed
+ * because the flake is load/ordering dependent, not specific to their code.
+ * The fix is two-part: (1) this file uses the IDENTICAL proven harness path
+ * (renderFixture + the same beforeAll/const lifecycle as golden-render), with
+ * no bespoke context handling; (2) the browser project runs test files
+ * serially (test.fileParallelism: false in vitest.config.ts) so no two
+ * offline-render files ever contend for AudioContext registration. That change
+ * is scheduling-only - it cannot change a single rendered byte, so golden and
+ * stem output stay byte-identical.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { findOnsets, rmsInWindow } from "@/test/analysis";
+import {
+  makeClickSampleUrl,
+  makeInstrument,
+  makePattern,
+} from "@/test/fixtures";
+import { renderFixture } from "@/test/render";
+
+const BPM = 120;
+/** Duration of one 16th note at 120 BPM. */
+const STEP = 60 / BPM / 4; // 0.125s
+/** Tolerance for onset-delta assertions. */
+const TOL = 0.005;
+
+/**
+ * Master split-filter knob 70: an engaged high-pass. Positions 50-100 select
+ * the high-pass side of the frozen curve; 70 lands at ~2.5 kHz cutoff, so the
+ * sub/low-mids are attenuated while the click's bright transient survives.
+ */
+const HIGH_PASS_70 = { filter: 70 };
+
+let clickUrl: string;
+
+beforeAll(() => {
+  clickUrl = makeClickSampleUrl();
+});
+
+function deltas(onsets: number[]): number[] {
+  return onsets.slice(1).map((t, i) => t - onsets[i]);
+}
+
+describe("split filter: non-default position render", () => {
+  it("renders a stable four-on-the-floor through an engaged high-pass", async () => {
+    const buffer = await renderFixture({
+      pattern: makePattern({
+        steps: [0, 4, 8, 12].map((step) => ({ voice: 0, step })),
+      }),
+      instruments: [makeInstrument(0, "kick")],
+      sampleUrls: [clickUrl],
+      bpm: BPM,
+      masterParams: HIGH_PASS_70,
+    });
+
+    const onsets = findOnsets(buffer);
+    expect(onsets).toHaveLength(4);
+    for (const delta of deltas(onsets)) {
+      expect(delta).toBeGreaterThan(4 * STEP - TOL);
+      expect(delta).toBeLessThan(4 * STEP + TOL);
+    }
+    // The engaged high-pass keeps the bright transient audible.
+    expect(rmsInWindow(buffer, onsets[0], onsets[0] + 0.02)).toBeGreaterThan(
+      0.02,
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,20 @@ export default defineConfig({
         test: {
           name: "browser",
           include: ["src/**/*.browser.test.ts"],
+          // Run browser test FILES serially (issue #363). Every
+          // *.browser.test.ts runs in the one shared chromium browser, and the
+          // offline-render suites (golden, stem, master-level, rebuild,
+          // kit-swap, split-filter) each spin up real-time + OfflineAudioContexts.
+          // Under file parallelism those contexts contend for the browser
+          // process's audio subsystem, and standardized-audio-context can
+          // intermittently fail to resolve a freshly-created node's native
+          // counterpart during generic node wiring (a
+          // "value with the given key could not be found" crash in
+          // connectMasterBusNodes, before any effect value is applied).
+          // Serializing removes that cross-file contention. It is scheduling
+          // only - each file still renders identically, so golden/stem output
+          // stays byte-identical.
+          fileParallelism: false,
           browser: {
             enabled: true,
             headless: true,


### PR DESCRIPTION
Follow-up from PR B (#361), part of #357. Re-adds `src/core/audio/engine/fx/split-filter.browser.test.ts` as a broadband offline-render smoke for an engaged master high-pass (knob 70), complementing the deterministic `split-filter.test.ts` derivation guard.

## Root cause of the PR B flake

Not a filter or engine defect. The one-off CI crash was:

```
Error: A value with the given key could not be found.
  at getValueForKey (tone / standardized-audio-context)
  at getNativeAudioNode
  at GainNode.connect
  at connectMasterBusNodes (master-bus.ts)
  at MasterBus.create
```

That stack lands in GENERIC master-bus `Gain` wiring, BEFORE any filter value is applied - it is standardized-audio-context's per-context node registry failing to resolve a freshly-created node's native counterpart, not anything the high-pass position does.

The trigger is browser-test concurrency. Vitest browser mode runs every `*.browser.test.ts` in the one shared chromium browser with `isolate: true` (each file its own iframe/Tone context) but `fileParallelism: true` (files run concurrently). The offline-render suites (golden, stem, master-level, rebuild, kit-swap) each spin up real-time + `OfflineAudioContext`s that contend for the browser process's audio subsystem. Adding a THIRD offline-render file raised that contention and reshuffled scheduling; the new file lost the standardized-audio-context registration race once on a slower CI runner. golden-render / stem-render never regressed because the flake is load/ordering dependent, not specific to their code.

## Fix

1. The new test uses the IDENTICAL proven harness path as golden/stem: `renderFixture` + the same `beforeAll`/const lifecycle, no bespoke context handling.
2. The browser project now runs test files serially (`test.fileParallelism: false` in `vitest.config.ts`) so no two offline-render files ever contend for AudioContext registration concurrently.

The config change is scheduling-only: it cannot change a single rendered byte, so golden/stem output stays byte-identical (SOUND IDENTITY invariant preserved - no golden/stem assertion touched).

knob 70 -> `frozenSplitFilterPositionToCanonical` -> `{ side: "highpass", cutoffHz ~= 2499 }` (position > 49 selects the high-pass side), confirmed an engaged high-pass under the current canonical `deriveSplitFilterFrequencies`.

## Stability tally (local, back-to-back, zero failures)

- `split-filter.browser.test.ts` alone: 10/10 passed
- full engine render suite (`src/core/audio/engine`, 10 files / 62 tests): 12/12 passed

## Gates

- `pnpm tsc --noEmit`: 0
- `pnpm lint`: 0 warnings
- `pnpm test` (full, both projects): 793 passed / 4 skipped / 0 failed (+1 from this test)
- `pnpm build`: success

Closes #363