### PR TITLE
refactor(test): canonicalize the golden/stem render harness inputs (#372)

### DIFF
--- a/src/core/audio/engine/__tests__/golden-render.browser.test.ts
+++ b/src/core/audio/engine/__tests__/golden-render.browser.test.ts
@@ -33,16 +33,20 @@ const STEP = 60 / BPM / 4; // 0.125s
 const TOL = 0.005;
 
 /**
- * Swing offset applied to odd 16th steps at swing knob 50.
- * Engine (#269 retune): transport.swing = (50 / 100) *
- * TRANSPORT_SWING_MAX(0.375) = 0.1875 (MPC 56.25%).
+ * Canonical Tone.Transport swing fraction used by the swing spec: 0.1875, which
+ * is MPC 56.25% and the midpoint of the range (TRANSPORT_SWING_MAX = 0.375).
+ */
+const SWING = 0.1875;
+
+/**
+ * Swing offset applied to odd 16th steps at swing 0.1875.
  * Tone Transport._processTick (tone@15.5.25): for ticks halfway between
  * swing subdivision pairs, offset = sin(pi * 0.5) * swing * Ticks((swingTicks * 2) / 3).
  * With 16n subdivision (48 ticks at PPQ 192): (48 * 2) / 3 = 32 ticks
  * = (32 / 192) beats = (1 / 6) * (60 / BPM) seconds.
  * At 120 BPM: 0.1875 * (1 / 6) * 0.5 = 0.0156250s.
  */
-const SWING_50_OFFSET = 0.1875 * (1 / 6) * (60 / BPM);
+const SWING_OFFSET = SWING * (1 / 6) * (60 / BPM);
 
 /** FLAM_OFFSET_SECONDS in engine/sequencer/sequencer.ts. */
 const FLAM_OFFSET = 0.015;
@@ -57,10 +61,10 @@ const RATCHET_OFFSET = 0.125 * (60 / BPM); // 0.0625s
 const NUDGE_PLUS_2_OFFSET = (2 / 96) * (60 / BPM); // 0.0104167s
 
 /**
- * Master params that disable parallel compression for stable peak
- * comparisons (compMix 0 = fully dry, compThreshold 100 = knob fully open).
+ * Canonical master params that disable parallel compression for stable peak
+ * comparisons (compMix 0 = fully dry, compThreshold 0 dB = fully open).
  */
-const NO_COMP = { compMix: 0, compThreshold: 100 };
+const NO_COMP = { compMix: 0, compThreshold: 0 };
 
 let clickUrl: string;
 let toneUrl: string;
@@ -118,13 +122,13 @@ describe("golden render: swing", () => {
       steps: Array.from({ length: 16 }, (_, step) => ({ voice: 0, step })),
     });
 
-  it("alternates long/short 16ths at swing 50 and stays uniform at swing 0", async () => {
+  it("alternates long/short 16ths at swing 0.1875 and stays uniform at swing 0", async () => {
     const swungBuffer = await renderFixture({
       pattern: pattern(),
       instruments: [makeInstrument(0, "hat")],
       sampleUrls: [clickUrl],
       bpm: BPM,
-      swing: 50,
+      swing: SWING,
     });
 
     const onsets = findOnsets(swungBuffer);
@@ -134,8 +138,7 @@ describe("golden render: swing", () => {
     // Odd steps are pushed late: even->odd gaps are long, odd->even short.
     expect(swungDeltas[0]).toBeGreaterThan(0.13);
     for (let i = 0; i < swungDeltas.length; i++) {
-      const expected =
-        i % 2 === 0 ? STEP + SWING_50_OFFSET : STEP - SWING_50_OFFSET;
+      const expected = i % 2 === 0 ? STEP + SWING_OFFSET : STEP - SWING_OFFSET;
       expect(swungDeltas[i]).toBeGreaterThan(expected - TOL);
       expect(swungDeltas[i]).toBeLessThan(expected + TOL);
     }

--- a/src/core/audio/engine/__tests__/stem-render.browser.test.ts
+++ b/src/core/audio/engine/__tests__/stem-render.browser.test.ts
@@ -214,7 +214,7 @@ describe("stem render: masterTap", () => {
       instruments: [makeInstrument(0, "snare")],
       sampleUrls: [clickUrl],
       bpm: BPM,
-      masterParams: { reverb: 100 },
+      masterParams: { reverb: 1 },
     });
 
     const masterBuffer = await renderWithOptions(fixture(), {

--- a/src/test/audition/swing-audition.browser.test.ts
+++ b/src/test/audition/swing-audition.browser.test.ts
@@ -40,8 +40,13 @@ const OUT_DIR = "audition-out";
 /** Per-render timeout headroom: offline render of ~10s of audio + sampler loads. */
 const RENDER_TIMEOUT = 300_000;
 
-/** Knob positions to audition on the shipped curve. */
-const KNOBS = [0, 25, 50, 67, 85, 100];
+/**
+ * Shipped-curve swing values to audition (canonical Tone fractions), spanning
+ * the production range evenly. These are the exact canonical equivalents of the
+ * old 0-100 audition ladder [0, 25, 50, 67, 85, 100] on the shipped linear
+ * curve (s = knob/100 * TRANSPORT_SWING_MAX, TRANSPORT_SWING_MAX = 0.375).
+ */
+const SHIPPED_SWINGS = [0, 0.09375, 0.1875, 0.25125, 0.31875, 0.375];
 
 /**
  * MPC reference ladder: fixed domain swing values. Values above the
@@ -176,15 +181,12 @@ describe.runIf(!!import.meta.env.VITE_AUDITION)(
     }
 
     it(
-      `renders the shipped curve at knob ${KNOBS.join("/")}`,
+      `renders the shipped curve at swing ${SHIPPED_SWINGS.join("/")}`,
       async () => {
-        for (const k of KNOBS) {
-          // Knob (0-100) to the canonical Tone swing fraction, matching the
-          // retired transportSwingKnobToDomain exactly.
-          const s = (k / 100) * TRANSPORT_SWING_MAX;
+        for (const s of SHIPPED_SWINGS) {
           await renderToFile(
             s,
-            `swing-shipped-knob${k}-mpc${mpcLabel(s)}-${BPM}bpm.wav`,
+            `swing-shipped-s${s}-mpc${mpcLabel(s)}-${BPM}bpm.wav`,
           );
         }
       },

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -14,70 +14,35 @@ import type {
   InstrumentData,
   InstrumentParams,
 } from "@/features/instrument/types/instrument";
-import { frozenSplitFilterPositionToCanonical } from "@/features/preset/document/frozen-split-filter";
 import { createEmptyPattern } from "@/features/sequencer/lib/helpers";
-import {
-  instrumentDecayDescriptor,
-  instrumentPanDescriptor,
-  instrumentTuneDescriptor,
-  instrumentVolumeDescriptor,
-  normalizedToCanonical,
-} from "@/shared/param-control";
 
 const FIXTURE_SAMPLE_RATE = 44100;
 
-/** Instrument params as the 0-100 knob positions the golden/stem specs pin. */
-interface KnobInstrumentParams {
-  tune: number;
-  decay: number;
-  filter: number;
-  volume: number;
-  pan: number;
-  solo: boolean;
-  mute: boolean;
-}
-
 /**
- * Neutral instrument knob values: tune centered, full decay, filter centered,
- * unity volume, centered pan.
+ * Neutral canonical instrument params: full decay (5 s), filter fully open
+ * (high-pass at 0 Hz), unity volume (0 dB), centered pan, no tune.
+ *
+ * These are CANONICAL units - the same shape the instrument store holds - fed
+ * straight to the engine bridge. The values are the exact canonical equivalents
+ * of the pre-flip golden knob snapshot (tune 50, decay 100, filter 50, volume
+ * 92, pan 50), computed once through the production conversions and inlined so
+ * golden/stem renders stay byte-identical (a JS number literal round-trips its
+ * double losslessly).
  *
  * Deliberately hand-pinned rather than derived from init(): these are
  * golden-stability snapshots, so golden renders cannot silently shift when
  * the app's default preset changes. Any edit here invalidates the golden
  * baselines - change these values only on purpose.
  */
-const DEFAULT_INSTRUMENT_PARAMS: KnobInstrumentParams = {
-  tune: 50,
-  decay: 100,
-  filter: 50,
-  volume: 92,
-  pan: 50,
+const DEFAULT_INSTRUMENT_PARAMS: InstrumentParams = {
+  decay: 5,
+  filter: { side: "highpass", cutoffHz: 0 },
+  volume: 0,
+  pan: 0,
+  tune: 0,
   solo: false,
   mute: false,
 };
-
-/**
- * Convert the harness knob params to canonical units through the PRODUCTION
- * conversions: the scalar descriptors (src/shared/param-control) for
- * decay/volume/pan/tune and the frozen split-filter curve for the filter. The
- * harness API stays knob-valued so the golden/stem specs pass the same values;
- * routing through production means any drift between production canonical
- * conversion and the old engine mapping surfaces as a golden/stem failure.
- */
-function knobParamsToCanonical(knob: KnobInstrumentParams): InstrumentParams {
-  return {
-    decay: normalizedToCanonical(instrumentDecayDescriptor, knob.decay / 100),
-    filter: frozenSplitFilterPositionToCanonical(knob.filter),
-    volume: normalizedToCanonical(
-      instrumentVolumeDescriptor,
-      knob.volume / 100,
-    ),
-    pan: normalizedToCanonical(instrumentPanDescriptor, knob.pan / 100),
-    tune: normalizedToCanonical(instrumentTuneDescriptor, knob.tune / 100),
-    solo: knob.solo,
-    mute: knob.mute,
-  };
-}
 
 function samplesToBlobUrl(samples: Float32Array<ArrayBuffer>): string {
   const buffer = new AudioBuffer({
@@ -125,7 +90,7 @@ function makeToneSampleUrl(durationSeconds = 1.5): string {
 function makeInstrument(
   index: number,
   role: InstrumentRole,
-  overrides?: Partial<KnobInstrumentParams>,
+  overrides?: Partial<InstrumentParams>,
 ): InstrumentData {
   return {
     meta: { id: `test-inst-${index}`, name: `Test ${role} ${index}` },
@@ -134,10 +99,7 @@ function makeInstrument(
       meta: { id: `test-sample-${index}`, name: `Test sample ${index}` },
       path: `test-sample-${index}.wav`,
     },
-    params: knobParamsToCanonical({
-      ...DEFAULT_INSTRUMENT_PARAMS,
-      ...overrides,
-    }),
+    params: { ...DEFAULT_INSTRUMENT_PARAMS, ...overrides },
   };
 }
 

--- a/src/test/render.ts
+++ b/src/test/render.ts
@@ -8,14 +8,12 @@
  *
  * Rendering goes through the REAL production path: fixture state is pushed
  * into a throwaway AudioEngine via the engine's command API and rendered with
- * engine.renderWav. Instruments are CANONICAL (the store-facing units), so
- * they cross the boundary through the canonical-to-engine bridge
- * (engine-params.ts) exactly like production. The master chain and swing are
- * still supplied to this harness as 0-100 knob positions - the golden and stem
- * specs pin knob values that must not change - and this file converts them to
- * canonical through PRODUCTION code (the scalar descriptors and the frozen
- * split-filter curve), so any drift between production conversion and the old
- * engine mapping surfaces as a golden/stem failure.
+ * engine.renderWav. Every input is CANONICAL - the same store-facing units
+ * production holds (instrument params, the master chain, and swing as the Tone
+ * fraction) - and crosses the boundary through the canonical-to-engine bridge
+ * (engine-params.ts) exactly like production. No 0-100 knob position lives
+ * anywhere in this harness; knob space belongs to the param-control descriptors
+ * and the legacy-read frozen island only.
  */
 
 import { getContext } from "tone/build/esm/index";
@@ -34,19 +32,6 @@ import type {
   VariationId,
 } from "@/core/audio/engine/pattern-types";
 import type { InstrumentData } from "@/features/instrument/types/instrument";
-import { frozenSplitFilterPositionToCanonical } from "@/features/preset/document/frozen-split-filter";
-import {
-  masterCompAttackDescriptor,
-  masterCompMixDescriptor,
-  masterCompRatioDescriptor,
-  masterCompThresholdDescriptor,
-  masterPhaserDescriptor,
-  masterReverbDescriptor,
-  masterSaturationDescriptor,
-  masterVolumeDescriptor,
-  normalizedToCanonical,
-  transportSwingDescriptor,
-} from "@/shared/param-control";
 
 /**
  * Historical extra render time after the last bar. Kept exported for
@@ -56,100 +41,35 @@ import {
 const RENDER_TAIL_SECONDS = 0.3;
 
 /**
- * Master chain as the 0-100 knob positions the golden and stem specs pin.
+ * Neutral canonical master chain: filter fully open (high-pass at 0 Hz), all
+ * sends off, compressor threshold fully open (0 dB), unity volume (0 dB).
  *
- * The stores hold canonical master units now; this knob shape is a FROZEN
- * test-harness boundary that keeps the pinned golden values (NO_COMP,
- * { reverb: 100 }, ...) meaning what they meant pre-flip. masterKnobsToCanonical
- * converts it back to canonical before the engine sees it.
- */
-interface MasterChainParams {
-  /** Split-filter position (0-100). */
-  filter: number;
-  saturation: number;
-  phaser: number;
-  reverb: number;
-  compThreshold: number;
-  compRatio: number;
-  compAttack: number;
-  compMix: number;
-  masterVolume: number;
-}
-
-/**
- * Neutral master chain knob values: filter centered, all sends off,
- * compressor threshold fully open (minimal compression), unity volume.
+ * These are CANONICAL units - the same shape the master-chain store holds - fed
+ * straight to the engine bridge via mapMasterToSettings. The values are the
+ * exact canonical equivalents of the pre-flip golden knob snapshot (filter 50,
+ * sends 0, compThreshold 100, compRatio 50, compAttack 50, compMix 70,
+ * masterVolume 92), computed once through the production conversions and inlined
+ * so golden/stem renders stay byte-identical (a JS number literal round-trips
+ * its double losslessly).
  *
  * Deliberately hand-pinned rather than derived from init(): these are
  * golden-stability snapshots, so golden renders cannot silently shift when
  * the app's default preset changes. compRatio deliberately differs from the
- * app default (50 here vs init()'s ~57.14) - the golden baselines were
+ * app default (5:1 here vs init()'s ~4.29) - the golden baselines were
  * captured against this value. Any edit here invalidates them, so change
  * these values only on purpose.
  */
-const DEFAULT_MASTER_PARAMS: MasterChainParams = {
-  filter: 50,
+const DEFAULT_MASTER_PARAMS: MasterChainCanonical = {
+  filter: { side: "highpass", cutoffHz: 0 },
   saturation: 0,
   phaser: 0,
   reverb: 0,
-  compThreshold: 100,
-  compRatio: 50,
-  compAttack: 50,
-  compMix: 70,
-  masterVolume: 92,
+  compThreshold: 0,
+  compRatio: 5,
+  compAttack: 0.025750000000000002,
+  compMix: 0.7,
+  masterVolume: 0,
 };
-
-// --- Knob-to-canonical master conversion ------------------------------------
-//
-// The harness API stays knob-valued so the golden and stem specs pass the same
-// values, but the conversion runs through PRODUCTION code: the scalar
-// descriptors (src/shared/param-control) and the frozen split-filter curve for
-// the filter (Max's two-curve decision - the live descriptor curve is
-// exponential, the frozen curve preserves old/factory cutoffs). Routing
-// through production means any drift between production canonical conversion
-// and the old engine mapping surfaces as a golden/stem failure. No live store,
-// bridge, or engine holds a 0-100 knob value.
-
-/**
- * Maps the harness knob master params to the canonical master chain the engine
- * bridge consumes. The filter uses the frozen curve (position 50 = highpass at
- * 0 Hz, the old open extreme); every scalar uses its production descriptor; the
- * two macros stay 0-1 wet fractions that engine-params expands to their engine
- * companions.
- */
-function masterKnobsToCanonical(
-  params: MasterChainParams,
-): MasterChainCanonical {
-  return {
-    filter: frozenSplitFilterPositionToCanonical(params.filter),
-    saturation: normalizedToCanonical(
-      masterSaturationDescriptor,
-      params.saturation / 100,
-    ),
-    phaser: normalizedToCanonical(masterPhaserDescriptor, params.phaser / 100),
-    reverb: normalizedToCanonical(masterReverbDescriptor, params.reverb / 100),
-    compThreshold: normalizedToCanonical(
-      masterCompThresholdDescriptor,
-      params.compThreshold / 100,
-    ),
-    compRatio: normalizedToCanonical(
-      masterCompRatioDescriptor,
-      params.compRatio / 100,
-    ),
-    compAttack: normalizedToCanonical(
-      masterCompAttackDescriptor,
-      params.compAttack / 100,
-    ),
-    compMix: normalizedToCanonical(
-      masterCompMixDescriptor,
-      params.compMix / 100,
-    ),
-    masterVolume: normalizedToCanonical(
-      masterVolumeDescriptor,
-      params.masterVolume / 100,
-    ),
-  };
-}
 
 interface RenderFixtureOptions {
   pattern: Pattern;
@@ -157,13 +77,13 @@ interface RenderFixtureOptions {
   /** Blob URLs, one per instrument (parallel array). */
   sampleUrls: string[];
   bpm: number;
-  /** 0-100 knob value. */
+  /** Canonical Tone.Transport swing fraction (0..TRANSPORT_SWING_MAX). */
   swing?: number;
   bars?: number;
   chain?: PatternChain;
   chainEnabled?: boolean;
   variation?: VariationId;
-  masterParams?: Partial<MasterChainParams>;
+  masterParams?: Partial<MasterChainCanonical>;
 }
 
 /**
@@ -197,7 +117,7 @@ async function createFixtureEngine(
     );
   }
 
-  const mergedMasterParams: MasterChainParams = {
+  const mergedMasterParams: MasterChainCanonical = {
     ...DEFAULT_MASTER_PARAMS,
     ...masterParams,
   };
@@ -229,15 +149,10 @@ async function createFixtureEngine(
       );
     });
 
-    engine.setMasterSettings(
-      mapMasterToSettings(masterKnobsToCanonical(mergedMasterParams)),
-    );
+    engine.setMasterSettings(mapMasterToSettings(mergedMasterParams));
     engine.setTempo(bpm);
-    // Knob (0-100) to the canonical Tone swing fraction via the production
-    // swing descriptor.
-    engine.setSwing(
-      normalizedToCanonical(transportSwingDescriptor, swing / 100),
-    );
+    // swing is already the canonical Tone.Transport fraction the engine holds.
+    engine.setSwing(swing);
 
     await engine.loadKit(
       toKitSampleDescriptors(instruments),
@@ -275,4 +190,4 @@ export {
   DEFAULT_MASTER_PARAMS,
   RENDER_TAIL_SECONDS,
 };
-export type { RenderFixtureOptions, MasterChainParams };
+export type { RenderFixtureOptions };


### PR DESCRIPTION
## What

Removes the 0-100 knob-space input convention from the golden/stem render test harness. After the #357 flip, production is canonical end to end; the harness was the last place still speaking knob space. It now accepts CANONICAL units directly and feeds them straight through the engine bridge, exactly like production.

### Harness API change

`src/test/render.ts`
- Deleted `MasterChainParams` (0-100 knob interface), `masterKnobsToCanonical`, and the swing knob->canonical conversion.
- `RenderFixtureOptions.masterParams` is now `Partial<MasterChainCanonical>`; `swing` is now the canonical Tone.Transport fraction directly.
- `DEFAULT_MASTER_PARAMS` is now a `MasterChainCanonical`.

`src/test/fixtures.ts`
- Deleted `KnobInstrumentParams` and `knobParamsToCanonical`.
- `makeInstrument` overrides are now `Partial<InstrumentParams>` (canonical, filter as `{ side, cutoffHz }`).
- `DEFAULT_INSTRUMENT_PARAMS` is now canonical `InstrumentParams`.

The `/ 100` + param-control-descriptor + frozen-split-filter conversion plumbing is gone from the harness. Knob space now lives only where #357 says it should: the param-control descriptors and the legacy-read frozen island.

## Byte-identity

The harness already converted knob->canonical BEFORE the engine, so feeding the EXACT canonical equivalent of each prior knob value reaches the engine identically -> identical bytes. Every pinned spec input was re-expressed as its exact canonical equivalent, computed once by CALLING the production conversion helpers (`normalizedToCanonical` with the production descriptors, `frozenSplitFilterPositionToCanonical`) in a throwaway script and inlined at full float precision (a JS number literal round-trips its double losslessly). Nothing was hand-rounded.

Equivalents used:
- Instrument default (knob tune 50 / decay 100 / filter 50 / volume 92 / pan 50) -> `{ decay: 5, filter: { side: "highpass", cutoffHz: 0 }, volume: 0, pan: 0, tune: 0 }`
- Master default (filter 50 / sends 0 / compThreshold 100 / compRatio 50 / compAttack 50 / compMix 70 / masterVolume 92) -> `{ filter: { side: "highpass", cutoffHz: 0 }, saturation: 0, phaser: 0, reverb: 0, compThreshold: 0, compRatio: 5, compAttack: 0.025750000000000002, compMix: 0.7, masterVolume: 0 }`
- `NO_COMP` (compMix 0, compThreshold 100) -> `{ compMix: 0, compThreshold: 0 }`
- stem reverb send (knob 100) -> `{ reverb: 1 }`
- swing knob 50 -> `0.1875`; swing 0 -> `0`
- swing-audition shipped-curve ladder `[0,25,50,67,85,100]` -> `[0, 0.09375, 0.1875, 0.25125, 0.31875, 0.375]`

**The golden and stem baselines/assertions were NOT touched** - only the input expression changed. `golden-render.browser.test.ts` (all swing/flam/ratchet/nudge/accent/choke/mute/solo cases) and `stem-render.browser.test.ts` pass unchanged, which is the byte-identity proof.

## Gates
- `pnpm tsc --noEmit`: 0 errors
- `pnpm lint`: 0 warnings
- `pnpm test`: 792 passed / 4 skipped / 0 failed (matches main)
- `pnpm build`: succeeds

Closes #372