### PR TITLE
feat(param-control): extract headless Knob primitive; recompose RotaryKnob + LinearSlider (#365)

### DIFF
--- a/src/shared/param-control/components/linear-slider.tsx
+++ b/src/shared/param-control/components/linear-slider.tsx
@@ -2,8 +2,8 @@ import type { CSSProperties } from "react";
 
 import { cn } from "@/shared/lib/utils";
 import { Label, Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui";
-import { useParamControl } from "../hooks/use-param-control";
 import { KNOB_DRAG_SENSITIVITY } from "../lib/descriptor";
+import { Knob, useKnob } from "../primitives/knob";
 import type { ParamDescriptor, RotaryKnobFutureSeams } from "../types";
 
 type SliderOrientation = "horizontal" | "vertical";
@@ -43,58 +43,35 @@ type LinearSliderProps<T> = {
   className?: string;
 } & RotaryKnobFutureSeams;
 
-/**
- * The linear (fader) presentation of the descriptor-driven control: the
- * hand-built hardware track and thumb driven by `useParamControl`. The body
- * owns look only (recessed track, raised thumb); all behaviour and the
- * canonical-only contract live in the hook.
- *
- * The resting fader shows no number - the value surfaces in a wrap-around
- * tooltip only while dragging, exactly as the original. The track is drag-only:
- * a press without drag changes nothing. Type-in is a deliberate double-click on
- * the caption label (swaps the word for an input; Enter/blur commits, Esc
- * cancels), and only when the descriptor can `parse`. The drag reads whichever
- * axis the orientation names (up / right increases), always in normalized space,
- * so `dragSensitivity`, fine drag, and detents work identically to the knob.
- * FUTURE seams are declared on the props but intentionally not implemented.
- */
-function LinearSlider<T>({
-  descriptor,
-  value,
-  onChange,
-  onGestureStart,
-  onGestureEnd,
-  disabled = false,
-  label,
-  tabbable = true,
-  id,
-  orientation = "horizontal",
-  length,
-  thickness = 12,
-  thumbSize = 16,
-  hideLabel = false,
-  dragSensitivity = KNOB_DRAG_SENSITIVITY,
-  className,
-  // Declared future seams; not wired yet.
-  modulationRange: _modulationRange,
-  dragMode: _dragMode,
-  onContextMenuRequest: _onContextMenuRequest,
-}: LinearSliderProps<T>) {
-  const control = useParamControl({
-    descriptor,
-    value,
-    onChange,
-    onGestureStart,
-    onGestureEnd,
-    disabled,
-    label,
-    tabbable,
-    id,
-    dragAxis: orientation === "vertical" ? "vertical" : "horizontal",
-    dragThreshold: DRAG_THRESHOLD_PX,
-    dragSensitivity,
-  });
+/** The styling-only props threaded from `LinearSlider` down to its body. */
+type LinearSliderBodyProps = {
+  disabled: boolean;
+  label: string;
+  orientation: SliderOrientation;
+  length?: number;
+  thickness: number;
+  thumbSize: number;
+  hideLabel: boolean;
+  className?: string;
+};
 
+/**
+ * The neumorphic fader skin, composed on the headless `Knob` primitive. Owns
+ * look only (recessed track, raised thumb, on-drag tooltip); all behaviour and
+ * the canonical-only contract live in the primitive, read here through
+ * `useKnob()`.
+ */
+function LinearSliderBody({
+  disabled,
+  label,
+  orientation,
+  length,
+  thickness,
+  thumbSize,
+  hideLabel,
+  className,
+}: LinearSliderBodyProps) {
+  const { control, descriptor } = useKnob();
   const { position } = control;
   const isVertical = orientation === "vertical";
 
@@ -143,9 +120,7 @@ function LinearSlider<T>({
     >
       <Tooltip open={control.isDragging}>
         <TooltipTrigger asChild>
-          <div
-            {...control.handlers}
-            {...control.ariaProps}
+          <Knob.Track
             aria-orientation={orientation}
             aria-labelledby={hideLabel ? undefined : `${control.id}-label`}
             className={cn(
@@ -157,15 +132,15 @@ function LinearSlider<T>({
             style={{ ...trackStyle, touchAction: "none" }}
           >
             {/* Thumb */}
-            <div
+            <Knob.Indicator
               className="bg-surface font-pixel absolute block rounded-full border"
               style={thumbStyle}
               aria-hidden="true"
             />
-          </div>
+          </Knob.Track>
         </TooltipTrigger>
         <TooltipContent side={isVertical ? "right" : "top"}>
-          {control.displayValue}
+          <Knob.Value />
         </TooltipContent>
       </Tooltip>
 
@@ -196,6 +171,72 @@ function LinearSlider<T>({
           </Label>
         ))}
     </div>
+  );
+}
+
+/**
+ * The linear (fader) presentation of the descriptor-driven control: the
+ * hand-built hardware track and thumb driven by the headless `Knob` primitive
+ * (whose engine is `useParamControl`). The body owns look only; all behaviour
+ * and the canonical-only contract live in the primitive.
+ *
+ * The resting fader shows no number - the value surfaces in a wrap-around
+ * tooltip only while dragging, exactly as the original. The track is drag-only:
+ * a press without drag changes nothing. Type-in is a deliberate double-click on
+ * the caption label (swaps the word for an input; Enter/blur commits, Esc
+ * cancels), and only when the descriptor can `parse`. The drag reads whichever
+ * axis the orientation names (up / right increases), always in normalized space,
+ * so `dragSensitivity`, fine drag, and detents work identically to the knob.
+ * FUTURE seams are declared on the props but intentionally not implemented.
+ */
+function LinearSlider<T>({
+  descriptor,
+  value,
+  onChange,
+  onGestureStart,
+  onGestureEnd,
+  disabled = false,
+  label,
+  tabbable = true,
+  id,
+  orientation = "horizontal",
+  length,
+  thickness = 12,
+  thumbSize = 16,
+  hideLabel = false,
+  dragSensitivity = KNOB_DRAG_SENSITIVITY,
+  className,
+  // Declared future seams; not wired yet.
+  modulationRange: _modulationRange,
+  dragMode: _dragMode,
+  onContextMenuRequest: _onContextMenuRequest,
+}: LinearSliderProps<T>) {
+  return (
+    <Knob.Root
+      descriptor={descriptor}
+      value={value}
+      onChange={onChange}
+      onGestureStart={onGestureStart}
+      onGestureEnd={onGestureEnd}
+      disabled={disabled}
+      label={label}
+      tabbable={tabbable}
+      id={id}
+      dragAxis={orientation === "vertical" ? "vertical" : "horizontal"}
+      dragThreshold={DRAG_THRESHOLD_PX}
+      dragSensitivity={dragSensitivity}
+    >
+      <LinearSliderBody
+        disabled={disabled}
+        label={label}
+        orientation={orientation}
+        length={length}
+        thickness={thickness}
+        thumbSize={thumbSize}
+        hideLabel={hideLabel}
+        className={className}
+      />
+    </Knob.Root>
   );
 }
 

--- a/src/shared/param-control/components/rotary-knob.tsx
+++ b/src/shared/param-control/components/rotary-knob.tsx
@@ -4,8 +4,8 @@ import { Coachmark } from "@/shared/components/coachmark";
 import { cn } from "@/shared/lib/utils";
 import { Label, Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui";
 import { useKnobGuidance } from "../hooks/use-knob-guidance";
-import { useParamControl } from "../hooks/use-param-control";
 import { KNOB_DRAG_SENSITIVITY } from "../lib/descriptor";
+import { Knob, useKnob } from "../primitives/knob";
 import type { ParamDescriptor, RotaryKnobFutureSeams } from "../types";
 import { KnobTicks } from "./knob-ticks";
 
@@ -49,11 +49,192 @@ type RotaryKnobProps<T> = {
   className?: string;
 } & RotaryKnobFutureSeams;
 
+/** The styling-only props threaded from `RotaryKnob` down to its body. */
+type RotaryKnobBodyProps = {
+  disabled: boolean;
+  label: string;
+  size: KnobSize;
+  outerTickCount: number;
+  showTickIndicator: boolean;
+  hideLabel: boolean;
+  className?: string;
+};
+
+/**
+ * The neumorphic skin, composed on the headless `Knob` primitive. Owns look
+ * only (sculpted base, rotating indicator, outer ticks, on-drag tooltip,
+ * first-use coachmark); all behaviour and the canonical-only contract live in
+ * the primitive, read here through `useKnob()`.
+ */
+function RotaryKnobBody({
+  disabled,
+  label,
+  size,
+  outerTickCount,
+  showTickIndicator,
+  hideLabel,
+  className,
+}: RotaryKnobBodyProps) {
+  const { control, descriptor } = useKnob();
+
+  const knobContainerRef = useRef<HTMLDivElement>(null);
+  const [tooltipSide, setTooltipSide] = useState<"left" | "right">("right");
+  const guidance = useKnobGuidance();
+
+  const rotation = START_ANGLE_DEG + control.position * ROTATION_RANGE_DEG;
+  const containerClass = size === "lg" ? "h-44" : "h-20";
+
+  // Wrap-around tooltip: flip to whichever side has more viewport room, mirroring
+  // the original hand-built knob so it never renders off-screen at the edges.
+  const updateTooltipSide = useCallback(() => {
+    const node = knobContainerRef.current;
+    if (!node) return;
+    const rect = node.getBoundingClientRect();
+    const spaceLeft = rect.left;
+    const spaceRight = window.innerWidth - rect.right;
+    setTooltipSide(spaceLeft > spaceRight ? "left" : "right");
+  }, []);
+
+  // Drive the first-use guidance heuristic and tooltip side alongside the
+  // primitive's own drag tracking; `Knob.Track` composes the engine's
+  // pointer-down after this, so the drag itself still starts. Window listeners
+  // self-tear-down on release.
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      if (disabled) return;
+      updateTooltipSide();
+
+      guidance.handleStart({ x: event.clientX, y: event.clientY });
+      const onMove = (ev: PointerEvent) =>
+        guidance.handleMove({ x: ev.clientX, y: ev.clientY });
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    },
+    [disabled, updateTooltipSide, guidance],
+  );
+
+  return (
+    <div
+      data-slot="rotary-knob"
+      data-disabled={disabled || undefined}
+      data-dragging={control.isDragging || undefined}
+      className={cn(
+        "flex aspect-square flex-col items-center justify-center",
+        containerClass,
+        disabled && "opacity-50",
+        className,
+      )}
+    >
+      <Tooltip open={control.isDragging}>
+        <TooltipTrigger asChild>
+          <div
+            ref={knobContainerRef}
+            className="relative flex aspect-square h-4/5 touch-none items-center justify-center rounded-full select-none"
+            style={{ touchAction: "none" }}
+          >
+            <Coachmark
+              visible={guidance.showCoachmark}
+              message="Drag up/down to adjust"
+              anchorRef={knobContainerRef}
+            />
+
+            {/* Hitbox - rotates with the value; carries the interaction. */}
+            <Knob.Track
+              onPointerDown={handlePointerDown}
+              aria-labelledby={hideLabel ? undefined : `${control.id}-label`}
+              className={cn(
+                "absolute z-1 aspect-square h-5/6 origin-center touch-none rounded-full outline-none select-none",
+                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2",
+              )}
+              style={{ transform: `rotate(${rotation}deg)` }}
+            >
+              {showTickIndicator && (
+                <Knob.Indicator asChild>
+                  <svg
+                    className="absolute top-[2%] left-1/2 w-[4.17%] -translate-x-1/2"
+                    height="19%"
+                    viewBox="0 0 2 20"
+                    preserveAspectRatio="none"
+                  >
+                    <line
+                      x1="1"
+                      y1="0"
+                      x2="1"
+                      y2="20"
+                      className="stroke-foreground-muted"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </Knob.Indicator>
+              )}
+            </Knob.Track>
+
+            {/* Knob base - fixed and motionless so the neumorphic shadow reads. */}
+            <div
+              className="border-shadow-30 flex aspect-square h-4/5 items-center justify-center rounded-full border shadow-(--shadow-neu-tall)"
+              style={{ background: "var(--knob-gradient)" }}
+            >
+              {/* Raised knob edge */}
+              <div
+                className="border-shadow-30 relative flex h-3/5 w-3/5 items-center justify-center rounded-full border shadow-(--shadow-neu-tall-raised)"
+                style={{ background: "var(--knob-gradient)" }}
+              >
+                {/* Raised knob inner circle */}
+                <div className="border-shadow-10 bg-knob raised absolute top-1/2 left-1/2 h-4/5 w-4/5 -translate-x-1/2 -translate-y-1/2 rounded-full border shadow-(--knob-shadow-center)" />
+              </div>
+            </div>
+
+            {/* Outer ticks */}
+            {outerTickCount > 0 && (
+              <KnobTicks outerTickCount={outerTickCount} />
+            )}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side={tooltipSide}>
+          <Knob.Value />
+        </TooltipContent>
+      </Tooltip>
+
+      {!hideLabel && (
+        <div className="flex items-center justify-center">
+          {control.isEditing ? (
+            // Type-in editor - the caption label becomes an input in place.
+            <input
+              {...control.editProps}
+              aria-label={`${label} value`}
+              onFocus={(event) => event.target.select()}
+              className={cn(
+                "bg-surface text-foreground w-16 rounded-sm px-1 text-center",
+                "text-xs leading-none outline-none",
+              )}
+            />
+          ) : (
+            <Label
+              id={`${control.id}-label`}
+              className={cn("text-xs", descriptor.parse && "cursor-text")}
+              onDoubleClick={descriptor.parse ? control.beginEdit : undefined}
+            >
+              {label}
+            </Label>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
  * The rotary presentation of the descriptor-driven control: the hand-built
- * neumorphic knob body driven entirely by `useParamControl`. The body owns look
- * only (sculpted base, rotating indicator, outer ticks); all behaviour and the
- * canonical-only contract live in the hook.
+ * neumorphic knob body driven entirely by the headless `Knob` primitive (whose
+ * engine is `useParamControl`). The body owns look only; all behaviour and the
+ * canonical-only contract live in the primitive.
  *
  * The resting knob shows no number - the value surfaces in a wrap-around
  * tooltip only while dragging (viewport-aware side), exactly as the original.
@@ -87,172 +268,30 @@ function RotaryKnob<T>({
   dragMode: _dragMode,
   onContextMenuRequest: _onContextMenuRequest,
 }: RotaryKnobProps<T>) {
-  const control = useParamControl({
-    descriptor,
-    value,
-    onChange,
-    onGestureStart,
-    onGestureEnd,
-    disabled,
-    label,
-    tabbable,
-    id,
-    dragThreshold: DRAG_THRESHOLD_PX,
-    dragSensitivity,
-  });
-
-  const knobContainerRef = useRef<HTMLDivElement>(null);
-  const [tooltipSide, setTooltipSide] = useState<"left" | "right">("right");
-  const guidance = useKnobGuidance();
-
-  const rotation = START_ANGLE_DEG + control.position * ROTATION_RANGE_DEG;
-  const containerClass = size === "lg" ? "h-44" : "h-20";
-
-  // Wrap-around tooltip: flip to whichever side has more viewport room, mirroring
-  // the original hand-built knob so it never renders off-screen at the edges.
-  const updateTooltipSide = useCallback(() => {
-    const node = knobContainerRef.current;
-    if (!node) return;
-    const rect = node.getBoundingClientRect();
-    const spaceLeft = rect.left;
-    const spaceRight = window.innerWidth - rect.right;
-    setTooltipSide(spaceLeft > spaceRight ? "left" : "right");
-  }, []);
-
-  const handlePointerDown = useCallback(
-    (event: React.PointerEvent) => {
-      if (disabled) return;
-      updateTooltipSide();
-
-      // Drive the first-use guidance heuristic alongside the hook's own drag
-      // tracking; window listeners self-tear-down on release.
-      guidance.handleStart({ x: event.clientX, y: event.clientY });
-      const onMove = (ev: PointerEvent) =>
-        guidance.handleMove({ x: ev.clientX, y: ev.clientY });
-      const onUp = () => {
-        window.removeEventListener("pointermove", onMove);
-        window.removeEventListener("pointerup", onUp);
-        window.removeEventListener("pointercancel", onUp);
-      };
-      window.addEventListener("pointermove", onMove);
-      window.addEventListener("pointerup", onUp);
-      window.addEventListener("pointercancel", onUp);
-
-      control.handlers.onPointerDown(event);
-    },
-    [disabled, updateTooltipSide, guidance, control.handlers],
-  );
-
   return (
-    <div
-      data-slot="rotary-knob"
-      data-disabled={disabled || undefined}
-      data-dragging={control.isDragging || undefined}
-      className={cn(
-        "flex aspect-square flex-col items-center justify-center",
-        containerClass,
-        disabled && "opacity-50",
-        className,
-      )}
+    <Knob.Root
+      descriptor={descriptor}
+      value={value}
+      onChange={onChange}
+      onGestureStart={onGestureStart}
+      onGestureEnd={onGestureEnd}
+      disabled={disabled}
+      label={label}
+      tabbable={tabbable}
+      id={id}
+      dragThreshold={DRAG_THRESHOLD_PX}
+      dragSensitivity={dragSensitivity}
     >
-      <Tooltip open={control.isDragging}>
-        <TooltipTrigger asChild>
-          <div
-            ref={knobContainerRef}
-            className="relative flex aspect-square h-4/5 touch-none items-center justify-center rounded-full select-none"
-            style={{ touchAction: "none" }}
-          >
-            <Coachmark
-              visible={guidance.showCoachmark}
-              message="Drag up/down to adjust"
-              anchorRef={knobContainerRef}
-            />
-
-            {/* Hitbox - rotates with the value; carries the interaction. */}
-            <div
-              {...control.ariaProps}
-              onKeyDown={control.handlers.onKeyDown}
-              onDoubleClick={control.handlers.onDoubleClick}
-              onWheel={control.handlers.onWheel}
-              onPointerDown={handlePointerDown}
-              aria-labelledby={hideLabel ? undefined : `${control.id}-label`}
-              className={cn(
-                "absolute z-1 aspect-square h-5/6 origin-center touch-none rounded-full outline-none select-none",
-                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2",
-              )}
-              style={{ transform: `rotate(${rotation}deg)` }}
-            >
-              {showTickIndicator && (
-                <svg
-                  className="absolute top-[2%] left-1/2 w-[4.17%] -translate-x-1/2"
-                  height="19%"
-                  viewBox="0 0 2 20"
-                  preserveAspectRatio="none"
-                >
-                  <line
-                    x1="1"
-                    y1="0"
-                    x2="1"
-                    y2="20"
-                    className="stroke-foreground-muted"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              )}
-            </div>
-
-            {/* Knob base - fixed and motionless so the neumorphic shadow reads. */}
-            <div
-              className="border-shadow-30 flex aspect-square h-4/5 items-center justify-center rounded-full border shadow-(--shadow-neu-tall)"
-              style={{ background: "var(--knob-gradient)" }}
-            >
-              {/* Raised knob edge */}
-              <div
-                className="border-shadow-30 relative flex h-3/5 w-3/5 items-center justify-center rounded-full border shadow-(--shadow-neu-tall-raised)"
-                style={{ background: "var(--knob-gradient)" }}
-              >
-                {/* Raised knob inner circle */}
-                <div className="border-shadow-10 bg-knob raised absolute top-1/2 left-1/2 h-4/5 w-4/5 -translate-x-1/2 -translate-y-1/2 rounded-full border shadow-(--knob-shadow-center)" />
-              </div>
-            </div>
-
-            {/* Outer ticks */}
-            {outerTickCount > 0 && (
-              <KnobTicks outerTickCount={outerTickCount} />
-            )}
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side={tooltipSide}>
-          {control.displayValue}
-        </TooltipContent>
-      </Tooltip>
-
-      {!hideLabel && (
-        <div className="flex items-center justify-center">
-          {control.isEditing ? (
-            // Type-in editor - the caption label becomes an input in place.
-            <input
-              {...control.editProps}
-              aria-label={`${label} value`}
-              onFocus={(event) => event.target.select()}
-              className={cn(
-                "bg-surface text-foreground w-16 rounded-sm px-1 text-center",
-                "text-xs leading-none outline-none",
-              )}
-            />
-          ) : (
-            <Label
-              id={`${control.id}-label`}
-              className={cn("text-xs", descriptor.parse && "cursor-text")}
-              onDoubleClick={descriptor.parse ? control.beginEdit : undefined}
-            >
-              {label}
-            </Label>
-          )}
-        </div>
-      )}
-    </div>
+      <RotaryKnobBody
+        disabled={disabled}
+        label={label}
+        size={size}
+        outerTickCount={outerTickCount}
+        showTickIndicator={showTickIndicator}
+        hideLabel={hideLabel}
+        className={className}
+      />
+    </Knob.Root>
   );
 }
 

--- a/src/shared/param-control/components/value-field.tsx
+++ b/src/shared/param-control/components/value-field.tsx
@@ -37,6 +37,14 @@ type ValueFieldProps<T> = {
  * moves is a vertical drag (up increases), a press that does not is a tap that
  * opens the type-in editor. Because a tap is the type-in affordance, reset is
  * Delete / Backspace (the hook) rather than double-click.
+ *
+ * Unlike `RotaryKnob` / `LinearSlider`, this presentation is NOT composed on the
+ * `Knob` primitive: its interactive surface is fused with the value readout (one
+ * element is both the `role="slider"` and the display), and it deliberately
+ * omits the double-click-to-reset that `Knob.Track` wires by default (a
+ * double-click here is two taps on a tap-to-edit field). Routing it through
+ * `Knob.Track` would either change that behaviour or need a special-case opt-out,
+ * so it stays a direct, thin skin over `useParamControl` - the shared engine.
  */
 function ValueField<T>({
   descriptor,

--- a/src/shared/param-control/index.ts
+++ b/src/shared/param-control/index.ts
@@ -32,6 +32,14 @@ export type {
   UseParamControlResult,
   DragAxis,
 } from "./hooks/use-param-control";
+export { Knob, useKnob } from "./primitives/knob";
+export type {
+  KnobRootProps,
+  KnobTrackProps,
+  KnobIndicatorProps,
+  KnobValueProps,
+  KnobContextValue,
+} from "./primitives/knob";
 export { RotaryKnob } from "./components/rotary-knob";
 export type { RotaryKnobProps } from "./components/rotary-knob";
 export { LinearSlider } from "./components/linear-slider";

--- a/src/shared/param-control/primitives/knob.tsx
+++ b/src/shared/param-control/primitives/knob.tsx
@@ -1,0 +1,214 @@
+/**
+ * The headless `Knob` compound primitive.
+ *
+ * A Radix-style, unstyled composition around the descriptor-driven interaction
+ * engine (`useParamControl`). `Knob.Root` runs the engine and shares its state
+ * through context; the part slots (`Knob.Track`, `Knob.Indicator`, `Knob.Value`)
+ * are unstyled and carry no look of their own. Drumhaus's neumorphic controls
+ * (`RotaryKnob`, `LinearSlider`) compose their styling on top; a future
+ * standalone instrument can reuse the same primitive with its own skin, or reuse
+ * the whole styled control.
+ *
+ *   <Knob.Root descriptor value onChange>
+ *     <Knob.Track>          // interactive surface: role/aria + all handlers
+ *       <Knob.Indicator />  // position-driven visual (tick, thumb)
+ *     </Knob.Track>
+ *     <Knob.Value />         // the display string projected from canonical
+ *   </Knob.Root>
+ *
+ * The public contract is canonical-only, exactly as the engine: `value` and
+ * `onChange` speak canonical units; the normalized position stays internal and
+ * is read (for styling transforms) through `useKnob()`.
+ *
+ * Every part supports Radix's `asChild` so styling can merge onto an existing
+ * element (an `<svg>` tick, a shaped thumb) without adding a wrapper node.
+ */
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useMemo,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { Slot } from "@radix-ui/react-slot";
+
+import {
+  useParamControl,
+  type UseParamControlProps,
+  type UseParamControlResult,
+} from "../hooks/use-param-control";
+import type { ParamDescriptor } from "../types";
+
+/**
+ * Their handler runs first, then ours - unless they called `preventDefault`.
+ * Mirrors Radix's own event composition so an `asChild` consumer's handler and
+ * the engine's handler both fire in a predictable order.
+ */
+function composeEventHandlers<E extends { defaultPrevented: boolean }>(
+  theirHandler: ((event: E) => void) | undefined,
+  ourHandler: (event: E) => void,
+) {
+  return (event: E) => {
+    theirHandler?.(event);
+    if (!event.defaultPrevented) ourHandler(event);
+  };
+}
+
+interface KnobContextValue {
+  /** The full engine result: position, displayValue, aria, handlers, edit, … */
+  control: UseParamControlResult;
+  /** The descriptor driving this control (e.g. for `parse` affordances). */
+  descriptor: ParamDescriptor<unknown>;
+  disabled: boolean;
+  label: string;
+}
+
+const KnobContext = createContext<KnobContextValue | null>(null);
+
+/**
+ * Read the `Knob.Root` engine state from a styling layer. This is the escape
+ * hatch a skin uses for values the part slots do not carry (the normalized
+ * `position` for a rotation / fill transform, `isEditing`, `editProps`, …).
+ */
+function useKnob(): KnobContextValue {
+  const ctx = useContext(KnobContext);
+  if (!ctx) {
+    throw new Error(
+      "`Knob` compound parts must be rendered within `<Knob.Root>`.",
+    );
+  }
+  return ctx;
+}
+
+type KnobRootProps<T> = UseParamControlProps<T> & {
+  children?: ReactNode;
+};
+
+/**
+ * Owns behaviour, a11y, and interaction: runs `useParamControl` and provides its
+ * state to the part slots through context. Renders no DOM of its own - the skin
+ * supplies the container - so it composes into any layout without disturbing it.
+ */
+function KnobRoot<T>({ children, ...controlProps }: KnobRootProps<T>) {
+  const control = useParamControl<T>(controlProps);
+  const value = useMemo<KnobContextValue>(
+    () => ({
+      control,
+      descriptor: controlProps.descriptor as ParamDescriptor<unknown>,
+      disabled: controlProps.disabled ?? false,
+      label: controlProps.label,
+    }),
+    [
+      control,
+      controlProps.descriptor,
+      controlProps.disabled,
+      controlProps.label,
+    ],
+  );
+  return <KnobContext.Provider value={value}>{children}</KnobContext.Provider>;
+}
+
+type KnobTrackProps = ComponentPropsWithoutRef<"div"> & {
+  asChild?: boolean;
+};
+
+/**
+ * The interactive surface: the `role="slider"` element that carries the aria
+ * contract and every pointer/keyboard/wheel handler. Its own event props are
+ * composed *before* the engine's, so a skin can layer extra behaviour (the
+ * knob's first-use guidance) without losing the drag. Unstyled by default.
+ */
+const KnobTrack = forwardRef<HTMLDivElement, KnobTrackProps>(function KnobTrack(
+  {
+    asChild = false,
+    onPointerDown,
+    onKeyDown,
+    onWheel,
+    onDoubleClick,
+    ...rest
+  },
+  ref,
+) {
+  const { control } = useKnob();
+  const Comp = asChild ? Slot : "div";
+  return (
+    <Comp
+      ref={ref}
+      {...control.ariaProps}
+      data-dragging={control.isDragging || undefined}
+      onPointerDown={composeEventHandlers(
+        onPointerDown,
+        control.handlers.onPointerDown,
+      )}
+      onKeyDown={composeEventHandlers(onKeyDown, control.handlers.onKeyDown)}
+      onWheel={composeEventHandlers(onWheel, control.handlers.onWheel)}
+      onDoubleClick={composeEventHandlers(
+        onDoubleClick,
+        control.handlers.onDoubleClick,
+      )}
+      {...rest}
+    />
+  );
+});
+
+type KnobIndicatorProps = ComponentPropsWithoutRef<"div"> & {
+  asChild?: boolean;
+};
+
+/**
+ * The position-driven visual: a knob's rotating tick, a fader's thumb. Unstyled
+ * and unpositioned - the skin drives the transform from `useKnob().control
+ * .position`, since the mapping (rotate vs. translate) is presentation-specific.
+ * Carries only `data-dragging` for state-based styling.
+ */
+const KnobIndicator = forwardRef<HTMLDivElement, KnobIndicatorProps>(
+  function KnobIndicator({ asChild = false, ...rest }, ref) {
+    const { control } = useKnob();
+    const Comp = asChild ? Slot : "div";
+    return (
+      <Comp
+        ref={ref}
+        data-dragging={control.isDragging || undefined}
+        {...rest}
+      />
+    );
+  },
+);
+
+type KnobValueProps = ComponentPropsWithoutRef<"span"> & {
+  asChild?: boolean;
+};
+
+/**
+ * The value readout: renders the display string projected from the canonical
+ * value (an on-drag tooltip in the knob/fader, an always-on readout elsewhere).
+ * Defaults to the engine's `displayValue`; pass children to override.
+ */
+const KnobValue = forwardRef<HTMLSpanElement, KnobValueProps>(
+  function KnobValue({ asChild = false, children, ...rest }, ref) {
+    const { control } = useKnob();
+    const Comp = asChild ? Slot : "span";
+    return (
+      <Comp ref={ref} {...rest}>
+        {children ?? control.displayValue}
+      </Comp>
+    );
+  },
+);
+
+const Knob = {
+  Root: KnobRoot,
+  Track: KnobTrack,
+  Indicator: KnobIndicator,
+  Value: KnobValue,
+};
+
+export { Knob, useKnob, composeEventHandlers };
+export type {
+  KnobRootProps,
+  KnobTrackProps,
+  KnobIndicatorProps,
+  KnobValueProps,
+  KnobContextValue,
+};


### PR DESCRIPTION
Closes #365.

## What

Extracts a Radix-style headless **`Knob` compound primitive** around the existing `useParamControl` engine, and recomposes the styled controls as `primitive + styling`. Behavior-preserving and **pixel-identical** (verified). Public API is unchanged: `RotaryKnob`, `LinearSlider`, `ValueField`, `useParamControl` and their prop types keep working, so the 6 consumers need no edits.

## Primitive API (additive, exported from `@/shared/param-control`)

```jsx
<Knob.Root descriptor value onChange>   // runs useParamControl, provides state via context; renders no DOM
  <Knob.Track>                          // role="slider" surface: aria + all handlers; composes consumer handlers before the engine's
    <Knob.Indicator />                  // position-driven visual (tick / thumb), unstyled
  </Knob.Track>
  <Knob.Value />                        // display string projected from canonical (defaults to displayValue)
</Knob.Root>
```

- `useKnob()` - escape hatch for styling that needs raw engine state (normalized `position` for rotation/fill, `isEditing`, `editProps`).
- Every part supports `asChild` (via `@radix-ui/react-slot`) so styling merges onto an existing element (the `<svg>` tick, the shaped thumb) with no wrapper node.
- `useParamControl` is untouched - it remains the single internal engine.

## Recomposed

- **`RotaryKnob`** -> `Knob.Root` + neumorphic body (Track = rotating hitbox, Indicator = 12 o'clock tick, Value = on-drag tooltip). Guidance coachmark + viewport-aware tooltip side layer on via a composed `onPointerDown`.
- **`LinearSlider`** -> `Knob.Root` + fader body (Track = track, Indicator = thumb, Value = tooltip).
- **`ValueField`** - intentionally left on `useParamControl` directly (documented in-file). Its interactive surface is fused with the readout and it deliberately omits double-click-to-reset (a double-click there is two taps on a tap-to-edit field), so `Knob.Track` would not fit without changing behavior or adding a special-case opt-out.

## Parity evidence (zero visual regression)

Captured tightly-cropped PNGs of every styled control across representative states from **pristine main** (baseline) and from this branch (after), at a fixed 2x viewport with animations disabled, then diffed with ImageMagick `compare -metric AE`. **All 21 shots: 0 differing pixels.**

| shot | AE | shot | AE |
| --- | --- | --- | --- |
| knob-linear-min/mid/max | 0 | slider-h-min/mid/max | 0 |
| knob-decay-real | 0 | slider-v-mid | 0 |
| knob-pan-bipolar | 0 | slider-drag (tooltip) | 0 |
| knob-comp-thresh | 0 | value-field-bpm | 0 |
| knob-lg | 0 | value-field-no-label | 0 |
| knob-no-indicator | 0 | value-field-disabled | 0 |
| knob-no-label | 0 | value-field-edit (input) | 0 |
| knob-disabled | 0 | knob-edit (input) | 0 |
| knob-drag (tooltip) | 0 | | |

The throwaway parity harness (Vite build of the public components + Playwright capture + `compare`) was deleted before commit; only the pixel-delta evidence is kept here.

## Gates

- `pnpm tsc --noEmit` - 0 errors
- `pnpm lint` - 0 warnings
- `pnpm test` - 796 passed / 4 skipped / 0 failed (722 unit + 74 browser; the existing rotary-knob/linear-slider/value-field browser suites pass unchanged, proving behavior preservation)
- `pnpm build` - succeeds