### PR TITLE
test(filter): re-add stable engaged high-pass render guard (#363)

### DIFF
--- a/src/core/audio/engine/fx/split-filter.browser.test.ts
+++ b/src/core/audio/engine/fx/split-filter.browser.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Render-path smoke for a NON-default split-filter position.
+ *
+ * The golden renders (../__tests__/golden-render.browser.test.ts) only exercise
+ * the neutral, fully-open filter (high-pass at 0 Hz), so the derived LP/HP node
+ * targets for an ENGAGED filter never go through an offline render there. This
+ * drives an engaged high-pass through the real render path (the same
+ * renderFixture + masterParams contract golden/stem use) and confirms it still
+ * renders a stable, audible four-on-the-floor - a broadband regression guard
+ * complementing the exact-value unit test in split-filter.test.ts.
+ *
+ * ISOLATION NOTE: vitest browser mode runs every *.browser.test.ts in ONE
+ * shared chromium instance, and each offline-render suite spins up real-time +
+ * OfflineAudioContexts that contend for the browser's audio subsystem. With
+ * file parallelism, adding this third offline-render file once lost a
+ * standardized-audio-context node-registration race during GENERIC master-bus
+ * Gain wiring (connectMasterBusNodes), before any filter value applies - a
+ * test-isolation flake, not a filter/engine defect. vitest.config.ts pins the
+ * browser project to fileParallelism: false so the render suites run serially;
+ * that change is scheduling-only and cannot alter a rendered byte.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { findOnsets, rmsInWindow } from "@/test/analysis";
+import {
+  makeClickSampleUrl,
+  makeInstrument,
+  makePattern,
+} from "@/test/fixtures";
+import { renderFixture } from "@/test/render";
+
+const BPM = 120;
+/** One 16th note at 120 BPM. */
+const STEP = 60 / BPM / 4;
+const TOL = 0.005;
+
+/**
+ * Engaged high-pass cutoff (canonical Hz), well inside the master filter range
+ * ([0, 15000] Hz). This is the historical knob-70 position expressed in
+ * canonical units: (((70 - 50) / 49) * 100 / 100)^2 * 15000 = ~2499 Hz. Being
+ * on the high-pass side, the derivation opens the low-pass node to the range
+ * max and tracks this cutoff on the high-pass node - a clearly-engaged, non-
+ * default position that still lets the click's bright transient through.
+ */
+const HIGH_PASS_CUTOFF_HZ = 2499;
+
+let clickUrl: string;
+
+beforeAll(() => {
+  clickUrl = makeClickSampleUrl();
+});
+
+describe("split filter: non-default position render", () => {
+  it("renders a stable four-on-the-floor through an engaged high-pass", async () => {
+    const buffer = await renderFixture({
+      pattern: makePattern({
+        steps: [0, 4, 8, 12].map((step) => ({ voice: 0, step })),
+      }),
+      instruments: [makeInstrument(0, "kick")],
+      sampleUrls: [clickUrl],
+      bpm: BPM,
+      masterParams: {
+        filter: { side: "highpass", cutoffHz: HIGH_PASS_CUTOFF_HZ },
+      },
+    });
+
+    const onsets = findOnsets(buffer);
+    expect(onsets).toHaveLength(4);
+    for (let i = 1; i < onsets.length; i++) {
+      const delta = onsets[i] - onsets[i - 1];
+      expect(delta).toBeGreaterThan(4 * STEP - TOL);
+      expect(delta).toBeLessThan(4 * STEP + TOL);
+    }
+    // High-pass keeps the click transients audible rather than silencing them.
+    expect(rmsInWindow(buffer, onsets[0], onsets[0] + 0.02)).toBeGreaterThan(
+      0.02,
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
         test: {
           name: "browser",
           include: ["src/**/*.browser.test.ts"],
+          // vitest browser mode runs every *.browser.test.ts in ONE shared
+          // chromium instance. The offline-render suites each spin up
+          // real-time + OfflineAudioContexts that contend for the browser's
+          // audio subsystem; with file parallelism that contention once lost a
+          // standardized-audio-context node-registration race during generic
+          // master-bus Gain wiring (a test-isolation flake, not an engine
+          // defect - see split-filter.browser.test.ts). Running the browser
+          // files serially removes the contention. This is scheduling-only and
+          // cannot change a rendered byte, so golden/stem output is unchanged.
+          fileParallelism: false,
           browser: {
             enabled: true,
             headless: true,


### PR DESCRIPTION
## Summary

Re-adds a stable, non-default split-filter offline-render guard on the canonical render harness (post-#372), plus the test-isolation fix that makes it stable. This is a re-do of the render smoke dropped from PR B (#361), now expressed in canonical units.

## Canonical filter value

`masterParams: { filter: { side: "highpass", cutoffHz: 2499 } }` - a clearly-engaged high-pass, well inside the master filter range `[0, 15000]` Hz. This is the historical knob-70 position expressed in canonical units: `(((70 - 50) / 49) * 100 / 100)^2 * 15000 ≈ 2498.96 Hz`. On the high-pass side the derivation opens the low-pass node to the range max and tracks this cutoff on the high-pass node, while still letting the click's bright transient through (so the RMS assertion holds). No 0-100 knob position or knob->canonical conversion is reintroduced; the harness is canonical-only.

The test asserts an engaged high-pass still renders a stable, audible four-on-the-floor: exactly 4 onsets, consecutive onset deltas within tolerance of `4 * one-16th-at-120bpm`, and `rmsInWindow` over the first onset > 0.02.

## Root cause + fix

PR B's `split-filter.browser.test.ts` flaked once on CI headless chromium with a standardized-audio-context error ("A value with the given key could not be found") thrown from `getNativeAudioNode -> GainNode.connect` inside `connectMasterBusNodes` (master-bus.ts) - i.e. during GENERIC master-bus Gain wiring, before any filter value applies. golden-render and stem-render exercise the same `renderFixture` + master path and pass stably.

Root cause is browser-test file concurrency: vitest browser mode runs every `*.browser.test.ts` in the ONE shared chromium instance, and each offline-render suite spins up real-time + OfflineAudioContexts that contend for the browser's audio subsystem. Adding a third offline-render file with file parallelism raised the contention and lost the standardized-audio-context registration race once. It is a test-isolation flake, not a filter/engine defect.

Fix: `vitest.config.ts` pins the browser project to `fileParallelism: false` so the render suites run serially. This is scheduling-only and cannot change a rendered byte.

## Sound identity

golden-render and stem-render test files and assertions are untouched. The `fileParallelism` change is scheduling-only; golden/stem output stays byte-identical.

## Stability

- New file back-to-back 10x: **10 passed / 0 failed**
- Full engine render suite (`pnpm test src/core/audio/engine`) 2x: both **62 passed** (10 files)

## Gates

- `pnpm tsc --noEmit`: 0
- `pnpm lint`: 0 warnings
- `pnpm test` (both projects): **793 passed / 4 skipped / 0 failed** (baseline 792 + this one new test)
- `pnpm build`: succeeds

Closes #363