### PR TITLE
docs: mark shipped design docs shipped, banner stale spec blocks

### DIFF
--- a/docs/audio-engine-refactor.md
+++ b/docs/audio-engine-refactor.md
@@ -79,6 +79,10 @@ src/core/audio/
     knob-to-domain.ts      # knob mapping applied here, at the boundary
 ```
 
+Update (2026-07-16, epic #357): this is the phase-3/4 target sketch, not the shipped layout.
+`scheduler.ts` shipped as `engine/sequencer/sequencer.ts`.
+`bridge/knob-to-domain.ts` was deleted by the later domain-representation flip (docs/data-representation.md): the stores became canonical, so the bridge (`bridge/engine-params.ts`) is a thin canonical-to-engine crossing with no knob mapping left at the boundary.
+
 ### The engine facade
 
 A single class owning channels, master bus, transport, and scheduler, with a narrow command API in domain units:
@@ -97,6 +101,10 @@ engine.onStep(cb)                    // events out, for playhead / step ticker
 engine.getAnalyser(i)                // taps for meters and analyzers
 engine.rebuild()                     // teardown + reconstruct graph from last-pushed state
 ```
+
+Update (2026-07-16): this is the phase-3 target sketch, not the shipped command surface.
+On the shipped facade (`src/core/audio/engine/audio-engine.ts`), `setChannelParams` shipped as `setChannelContinuousParams`, and `setMasterParams` shipped as `setMasterSettings`.
+`onStep` and `getAnalyser` never shipped; the events out are `onPlaybackVariationChange`, `onKitLoaded`, and `onPlaybackStateChange`, and the read-only taps are `getChannelMeter`, `getMasterLevelDb` (issue #268), and `getCurrentStep`.
 
 Key properties:
 
@@ -196,6 +204,7 @@ Notable findings and deviations recorded for posterity:
   `loadKit` retains kit descriptors and the resolved sample resolver, so `renderWav` needs no store access and no `init()`.
   The golden test helper drives the production render path end to end via a throwaway `AudioEngine`.
 - **The playback data model moved engine-side** (`engine/pattern-types.ts`), with the old `features/sequencer` locations kept as re-export shims; `InstrumentData` moved to `features/instrument/types` since it references preset metadata.
+  Update (2026-07-16, epic #357): the `features/sequencer` re-export shims are gone; `features/sequencer` now imports `Pattern`, `PatternChain`, and related types straight from `engine/pattern-types.ts`.
 - **The transport store issues engine commands directly** (features -> core is the allowed direction); full store purity was deliberately not pursued because the gesture-gated context unlock must run inside the click task.
 - **Context recovery** now tries `engine.rebuild()` on the second stalled check and only falls back to the page reload if the clock is still stalled afterwards.
 

--- a/docs/audio-engine-refactor.md
+++ b/docs/audio-engine-refactor.md
@@ -104,7 +104,7 @@ engine.rebuild()                     // teardown + reconstruct graph from last-p
 
 Update (2026-07-16): this is the phase-3 target sketch, not the shipped command surface.
 On the shipped facade (`src/core/audio/engine/audio-engine.ts`), `setChannelParams` shipped as `setChannelContinuousParams`, and `setMasterParams` shipped as `setMasterSettings`.
-`onStep` and `getAnalyser` never shipped; the events out are `onPlaybackVariationChange`, `onKitLoaded`, and `onPlaybackStateChange`, and the read-only taps are `getChannelMeter`, `getMasterLevelDb` (issue #268), and `getCurrentStep`.
+`onStep` and the per-channel `getAnalyser(i)` never shipped; the events out are `onPlaybackVariationChange`, `onKitLoaded`, and `onPlaybackStateChange`, and the read-only taps are `getChannelMeter`, `getMasterLevelDb` (issue #268), `getMasterAnalyser` (issue #384), and `getCurrentStep`.
 
 Key properties:
 

--- a/docs/data-representation.md
+++ b/docs/data-representation.md
@@ -1,6 +1,6 @@
 # Musical data representation
 
-Status: proposed (principles rubric; audit and fixes to follow).
+Status: shipped and complete (epic #357, squash PR #366).
 Author: Max, July 2026.
 
 ## Why this exists
@@ -226,5 +226,6 @@ The main coordinator checks each PR against the row below independently, not on 
 | Knob primitive (knob-primitive.md)           | Epic 2                | descriptor model, interaction set, canonical-only API, tests                       |
 | Approved decisions 1-7, principles P1-P7     | across B-F and Epic 2 | each closed finding restores its principle                                         |
 
-Verification status: Epic 2 (PR #359) is verified and closes the knob-primitive row and V8's new-code half.
-The remaining rows are open until their PR lands and is checked against this table.
+Verification status: closed.
+Epic 2 (PR #359, recomposed onto the headless primitive in PR #365) closes the knob-primitive row and V8's new-code half.
+PRs B through F landed as a single squash merge (PR #366), closing epic #357; every remaining row above is closed and was checked against that diff.

--- a/docs/knob-primitive.md
+++ b/docs/knob-primitive.md
@@ -1,6 +1,6 @@
 # The knob primitive
 
-Status: proposed (design; implementation as its own epic).
+Status: shipped and complete (epic #359; recomposed onto the headless primitive in PR #365).
 Author: Max, July 2026.
 Related: [data-representation.md](./data-representation.md) defines the canonical-units rule this control binds to (its P4 confines control position to this widget).
 

--- a/docs/preset-persistence.md
+++ b/docs/preset-persistence.md
@@ -1,6 +1,6 @@
 # Preset persistence: maturing .dh save/load
 
-Status: accepted (audit complete, greenfield redesign adopted in review, implementation pending).
+Status: shipped and complete (#329, across PRs #339-#355).
 Author: Max, July 2026.
 Tracking issue: #329.
 
@@ -8,6 +8,11 @@ Update (2026-07-14, #269): the swing retune landed before this design's document
 Version 1.5 is a knob-space revision of the v1 shape (identical fields; `transport.swing` knob values written under the old curve are rescaled by 4/3 on load, see `src/features/preset/document/migrate.ts`), the share codec gained a `v` field mirroring the file version (absent = legacy URL, swing migrated on decode), and the transport persist is now versioned (v1, with a swing migrate).
 Version 2 remains the domain-unit document described below, unchanged; its 1-to-2 migration must now also accept 1.5 as input (the swing rescale is already applied there).
 The audit sections still describe the pre-#269 state where they mention an unversioned codec and transport persist.
+
+Update (2026-07-16, #389): the greenfield design below shipped as document version 2.1, not the version 2 this doc specifies.
+The domain-representation flip (epic #357, squash PR #366) went one step further than decision 11: the split filter is canonical `{ side, cutoffHz }`, not a 0-100 position, and the stores and bridge are canonical end to end, not knob-space.
+The Inventory and Schema assessment sections below (the pre-refactor audit, including `getCurrentPreset`, `loadPreset`, and `use-preset-loading.ts` as then written) describe code that the pipeline in this design's own Greenfield section replaced; `getCurrentPreset`/`loadPreset` are gone, replaced by `snapshot()`/`apply()` under `src/features/preset/document/` and `src/features/preset/session/`.
+This doc remains as design history; for the shape and rules that actually shipped, see docs/data-representation.md (canonical units) and docs/preset-versioning.md (the living version policy; it already supersedes this doc's own Versioning section, tracked separately as #381).
 
 ## Summary
 
@@ -198,6 +203,8 @@ The initial draft's one genuinely debatable call was keeping UI knob positions (
 Review overruled it: the file format should be UI-agnostic and coupled to the engine, which is the stable semantic core after the engine refactor, while knob curves are a UI concern that should be free to change.
 The v2 schema therefore stores the engine's domain vocabulary (Hz, dB, seconds, playback rate, normalized mix fractions), exactly as `setChannelParams` and `setMasterParams` consume it.
 Pattern data (triggers, normalized velocities, nudge) and bpm already speak musical units; this change brings the instrument and master parameters in line, and any remaining knob-space stragglers (swing, if it proves to be one) get audited in PR 2.
+Update (2026-07-16, #389): `setChannelParams` and `setMasterParams` are this design's names for the facade methods, not what shipped.
+The shipped facade (`src/core/audio/engine/audio-engine.ts`) names them `setChannelContinuousParams` and `setMasterSettings`; see docs/audio-engine-refactor.md for the full shipped command surface.
 The costs the draft weighed are real but contained: each mapping needs an inverse (the curves are monotonic, so invertible), save and load each gain one mapping crossing at the serialization boundary, and the stores and bridge stay knob-space so nothing else moves.
 The payoff is structural: the 1-to-2 migration freezes the current curves as the permanent interpretation of v1 files, and from v2 on, retuning a knob curve changes where a knob sits, never how a saved preset sounds.
 
@@ -224,6 +231,10 @@ Every ingress runs the same pipeline, `decode -> migrate -> validate -> document
 Every egress is `snapshot() -> encode`.
 
 ### The document model (v2)
+
+Update (2026-07-16, #389): the block below is this design's original v2 target, and it shipped, but a later epic moved the ground again.
+Version 2.1 (epic #357, squash PR #366) replaced the `filter` field's `0..100 split position` shown below with the canonical `{ side, cutoffHz }` shape, and made the split filter the only case where domain units per decision 15 were not the final word.
+See docs/data-representation.md for the shipped canonical-units model and docs/preset-versioning.md for the version-2-to-2.1 migration and the current document shape.
 
 The document, with units chosen from the mapping audit:
 
@@ -268,6 +279,9 @@ Each unit choice is forced by something the mapping audit surfaced (decision 15)
 - Velocities, accents, ratchets, flams, and nudge are already musical values and carry over unchanged; the accent boost factor, flam offset, and ratchet spacing are engine constants, not preset fields, and stay that way.
 
 ### The pipeline and its two halves
+
+Update (2026-07-16, #389): "crosses knob-to-domain" and "crosses domain-to-knob" below describe this design's target, written before the domain-representation flip.
+Now that the stores are canonical (epic #357), `snapshot()` and `apply()` read and write canonical units directly; there is no knob-to-domain crossing left at this boundary, only at the thin canonical-to-engine bridge (`src/core/audio/bridge/engine-params.ts`).
 
 `snapshot()` reads the stores and crosses knob-to-domain once, using the same mapping module the bridge uses, so the document a save produces is by construction the state the engine is hearing; a dev-mode assertion can compare `snapshot()` against the bridge's last pushes.
 `apply(document)` is all-or-nothing: decode, migration, and validation have already happened in the codec, so apply only stops playback, crosses domain-to-knob, and commits all stores in one pass; the bridge then propagates to the engine exactly as it does for any store change.
@@ -399,6 +413,9 @@ They are recorded here with rationale so implementation PRs can cite them by num
     The stores and bridge stay knob-space; only the serialization boundary changes.
     The 1-to-2 migration bakes the current knob curves in as the permanent interpretation of v1 files, and from v2 on a curve retune is a pure UI concern that can never change how a saved preset sounds, which retires the retune-means-version-bump policy the draft had proposed instead.
     Alternatives rejected: keeping knob space with that policy (leaves the format UI-coupled), and making the stores themselves domain-native (relocates mapping into every knob component, against the engine refactor's bridge-boundary rule).
+    Update (2026-07-16, #389): "the stores and bridge stay knob-space" is false as of the domain-representation flip (epic #357, squash PR #366).
+    The alternative rejected here, making the stores themselves domain-native, is what shipped: every store holds canonical units, and the bridge (`src/core/audio/bridge/engine-params.ts`) is a thin canonical-to-engine crossing with no knob mapping left at that boundary.
+    See docs/data-representation.md for the shipped model and its rationale.
 12. **Kit storage: reference by stable id, not embedded.**
     Review asked whether the embed survives first-principles scrutiny without the legacy code, and it does not.
     The file is not self-contained regardless (samples live in the app bundle and are referenced by path), stable ids already solve reordering, and the embed denormalizes registry data into every preset so upstream fixes never propagate.
@@ -415,3 +432,6 @@ They are recorded here with rationale so implementation PRs can cite them by num
 15. **Document units where mappings are not clean functions.**
     Split filters store the engine's own 0-100 position (the Hz value is non-bijective across the LP/HP split); saturation and reverb store one normalized macro amount each (one control fans out to two engine fields by a fixed engine-side recipe); volume fields are nullable dB (JSON has no `-Infinity`, so `null` means silence); tune stores a semitone offset rather than Hz (Hz bakes in the sample's base pitch); comp ratio stores the quantized integer; swing stores the 0..0.5 engine fraction.
     These refine decision 11: "domain units" means the engine's semantic surface, which for macro controls is one normalized amount, not a raw pair of internal fields.
+    Update (2026-07-16, #389): the split-filter call was reversed by the domain-representation flip.
+    Canonical is `{ side, cutoffHz }`, not the engine's 0-100 position; P2 in docs/data-representation.md accepts a musical exception to acoustic-unit canonical precisely when it is strictly more stable than the engine's own vocabulary, and the split filter turned out to qualify.
+    The other unit choices in this decision (macro amounts, nullable dB, semitone tune, quantized comp ratio, fractional swing) shipped as described.

--- a/src/features/preset/document/__fixtures__/README.md
+++ b/src/features/preset/document/__fixtures__/README.md
@@ -6,7 +6,7 @@ The `.dh` JSON format was born at commit `78fe632b` (2025-11-18); before that, p
 Truncated or otherwise invalid JSON should be tested inline as a string literal in the test, not as a fixture file, because editors and formatters will not preserve broken JSON on disk.
 
 Migrators referenced below live in `src/features/sequencer/lib/migrations.ts` unless noted otherwise.
-`legacyCycleToChain` lives in `src/features/sequencer/lib/chain.ts` and is applied by `src/features/preset/hooks/use-preset-loading.ts`.
+`legacyCycleToChain` lives in `src/features/sequencer/lib/chain.ts` and is applied by `src/features/preset/document/migrate-v1.ts` (the 1-to-2 document migration) and `src/features/preset/session/legacy-adopter.ts` (one-time adoption of pre-document session state).
 
 ## v1-current.json
 
@@ -36,7 +36,7 @@ Notably its instrument params are already modern (`decay`/`tune`), making this a
 
 Source: synthetic (modern `v1-current.json` with `sequencer.chain`/`chainEnabled` replaced by `variationCycle: "AB"`).
 Era for the primary trait: 2025-11-18 to 2025-12-11 in committed files, but this exact combination (modern pattern plus `variationCycle`) never existed as a factory `.dh` file and could only arise from mid-migration user state.
-Primary trait: `sequencer.variationCycle` instead of `chain`/`chainEnabled`, handled by `legacyCycleToChain` in `src/features/sequencer/lib/chain.ts` via `use-preset-loading.ts`.
+Primary trait: `sequencer.variationCycle` instead of `chain`/`chainEnabled`, handled by `legacyCycleToChain` in `src/features/sequencer/lib/chain.ts`.
 The `"AB"` value is chosen deliberately because it maps to a non-trivial two-step chain with `chainEnabled: true`, unlike `"A"` which degenerates to the default chain.
 All other sections are fully modern so this fixture isolates the cycle-to-chain migration.
 


### PR DESCRIPTION
## Summary

- `docs/data-representation.md`, `docs/knob-primitive.md`, `docs/preset-persistence.md`: status lines updated from proposed/accepted-pending to shipped, with the closing epic/PR numbers (#357/#366, #359/#365, #329 across #339-#355).
- `docs/data-representation.md`: verification table's closing paragraph now says every row is closed instead of "open until their PR lands".
- `docs/preset-persistence.md`: added dated "Update (2026-07-16, #389)" notes (matching the doc's existing `#269` convention) at the top of the doc, at "The document model (v2)", at "The pipeline and its two halves", and at decisions 11 and 15, pointing to what actually shipped (2.1 canonical `{ side, cutoffHz }`, canonical stores/bridge after the #357 flip, the real facade method names) and to `docs/data-representation.md` / `docs/preset-versioning.md`. Original design text is untouched, only annotated.
- `docs/audio-engine-refactor.md`: added update notes after the target-layout and facade-sketch code blocks with the real shipped file/method/event/tap names (`engine/sequencer/sequencer.ts`, `setChannelContinuousParams`, `setMasterSettings`, `onPlaybackVariationChange`/`onKitLoaded`/`onPlaybackStateChange`, `getChannelMeter`/`getMasterLevelDb`/`getCurrentStep`), and noted the `features/sequencer` re-export shims are gone.
- `src/features/preset/document/__fixtures__/README.md`: fixed the stale claim that `legacyCycleToChain` runs through the deleted `use-preset-loading.ts`; it actually runs through `document/migrate-v1.ts` and `session/legacy-adopter.ts`, verified against the current call sites.

Docs-only change, no source edits. Verified every renamed method/event/tap and file path against the current code before writing each banner.

Did not touch `preset-persistence.md`'s "Versioning" section or decisions 9/10's substance, since `docs/preset-versioning.md` already supersedes that content and it's tracked separately by #381.

Closes #389

## Test plan

- [x] `pnpm prettier . --check` passes
- [x] Verified facade method/event/tap names against `src/core/audio/engine/audio-engine.ts`
- [x] Verified document version (2.1) and canonical filter shape against `src/features/preset/document/document.ts`
- [x] Verified bridge/store canonicalization against `src/core/audio/bridge/engine-params.ts` header
- [x] Verified `legacyCycleToChain` call sites (`migrate-v1.ts`, `legacy-adopter.ts`) and confirmed `use-preset-loading.ts` no longer contains that path
- [x] Verified `scheduler.ts` -> `engine/sequencer/sequencer.ts`, `bridge/knob-to-domain.ts` deletion, and `features/sequencer` re-export shim removal