### PR TITLE
fix(param-control): clamp volume type-in to the schema floor

### DIFF
--- a/src/shared/param-control/__tests__/descriptors.test.ts
+++ b/src/shared/param-control/__tests__/descriptors.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { CanonicalFilter } from "@/core/audio/canonical/filter";
 import {
+  INSTRUMENT_VOLUME_RANGE,
+  MASTER_VOLUME_RANGE,
+} from "@/core/audio/engine/constants";
+import {
   instrumentDecayDescriptor,
   instrumentPanDescriptor,
   instrumentTuneDescriptor,
@@ -17,7 +21,9 @@ import {
 } from "../descriptors/filter";
 import {
   canonicalToNormalized,
+  endpointValue,
   normalizedToCanonical,
+  parseValue,
 } from "../lib/descriptor";
 
 describe("volume descriptor", () => {
@@ -62,6 +68,77 @@ describe("volume descriptor", () => {
       expect(instrumentVolumeDescriptor.parse?.(text)).toBeCloseTo(v, 1);
     }
   });
+});
+
+// The document schema pins volumeDb to [floor, ceil] (nullable, where null is
+// the JSON-safe spelling of -Infinity silence). The type-in commit path is
+// `parseValue`; every value it yields must satisfy those bounds so no egress
+// (export, share, autosave, dirty-hash) throws a ZodError. See issue #383.
+describe("volume type-in stays within the document schema bounds (#383)", () => {
+  const cases = [
+    {
+      name: "instrument",
+      descriptor: instrumentVolumeDescriptor,
+      range: INSTRUMENT_VOLUME_RANGE,
+    },
+    {
+      name: "master",
+      descriptor: masterVolumeDescriptor,
+      range: MASTER_VOLUME_RANGE,
+    },
+  ] as const;
+
+  /** A committed volume is schema-acceptable: -Infinity silence, or in range. */
+  function isSchemaAcceptable(value: number, range: readonly [number, number]) {
+    return value === -Infinity || (value >= range[0] && value <= range[1]);
+  }
+
+  for (const { name, descriptor, range } of cases) {
+    it(`${name}: type-in below the floor clamps up to the floor, not below`, () => {
+      const parsed = parseValue(descriptor, "-50");
+      expect(parsed).toBe(range[0]);
+      expect(isSchemaAcceptable(parsed as number, range)).toBe(true);
+    });
+
+    it(`${name}: type-in above the ceiling clamps down to the ceiling`, () => {
+      expect(parseValue(descriptor, "20")).toBe(range[1]);
+    });
+
+    it(`${name}: "-inf" still reaches true silence (-Infinity) via type-in`, () => {
+      expect(parseValue(descriptor, "-inf")).toBe(-Infinity);
+      expect(parseValue(descriptor, "-∞ dB")).toBe(-Infinity);
+    });
+
+    it(`${name}: every commit path (type-in, drag ends, Home) is schema-acceptable`, () => {
+      // Type-in across and beyond the range.
+      for (const text of [
+        "-999",
+        "-46",
+        "-46.5",
+        "-12",
+        "0",
+        "4",
+        "4.1",
+        "50",
+      ]) {
+        const parsed = parseValue(descriptor, text);
+        expect(parsed).not.toBeNull();
+        expect(isSchemaAcceptable(parsed as number, range)).toBe(true);
+      }
+      // Drag/keyboard endpoints resolve through normalizedToCanonical.
+      for (const position of [0, 0.001, 0.25, 0.5, 0.75, 1]) {
+        expect(
+          isSchemaAcceptable(
+            normalizedToCanonical(descriptor, position),
+            range,
+          ),
+        ).toBe(true);
+      }
+      // Home is true silence; End is the ceiling.
+      expect(endpointValue(descriptor, "min")).toBe(-Infinity);
+      expect(endpointValue(descriptor, "max")).toBe(range[1]);
+    });
+  }
 });
 
 describe("pan descriptor", () => {

--- a/src/shared/param-control/__tests__/rotary-knob.browser.test.ts
+++ b/src/shared/param-control/__tests__/rotary-knob.browser.test.ts
@@ -10,7 +10,9 @@ import { act, createElement, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { INSTRUMENT_VOLUME_RANGE } from "@/core/audio/engine/constants";
 import { RotaryKnob } from "../components/rotary-knob";
+import { instrumentVolumeDescriptor } from "../descriptors/canonical-scalars";
 import type { ParamDescriptor } from "../types";
 
 declare global {
@@ -204,6 +206,39 @@ describe("RotaryKnob interactions (canonical-only public API)", () => {
     expect(slider().getAttribute("aria-valuetext")).toBe("42 u");
     expect(slider().getAttribute("aria-valuenow")).toBe("42");
     expect(slider().getAttribute("role")).toBe("slider");
+  });
+
+  it("renders finite ARIA numbers for a silenced volume control (#383)", async () => {
+    // A volume control at true silence holds -Infinity, which is not a valid
+    // ARIA number: aria-valuemin/now must fall back to the finite floor, while
+    // aria-valuetext still reads "-∞ dB".
+    await act(async () => {
+      root?.render(
+        createElement(RotaryKnob<number>, {
+          descriptor: instrumentVolumeDescriptor,
+          value: -Infinity,
+          label: "Volume",
+          onChange: () => {},
+        }),
+      );
+    });
+    const el = slider();
+    expect(Number.isFinite(Number(el.getAttribute("aria-valuemin")))).toBe(
+      true,
+    );
+    expect(Number.isFinite(Number(el.getAttribute("aria-valuemax")))).toBe(
+      true,
+    );
+    expect(Number.isFinite(Number(el.getAttribute("aria-valuenow")))).toBe(
+      true,
+    );
+    expect(Number(el.getAttribute("aria-valuemin"))).toBe(
+      INSTRUMENT_VOLUME_RANGE[0],
+    );
+    expect(Number(el.getAttribute("aria-valuenow"))).toBe(
+      INSTRUMENT_VOLUME_RANGE[0],
+    );
+    expect(el.getAttribute("aria-valuetext")).toBe("-∞ dB");
   });
 
   it("accepts type-in entry opened by a double-click on the label", async () => {

--- a/src/shared/param-control/descriptors/canonical-scalars.ts
+++ b/src/shared/param-control/descriptors/canonical-scalars.ts
@@ -58,8 +58,10 @@ function parseDb(text: string): number | null {
  * Volume taper: position 0 is true silence (-Infinity dB); positions above 0
  * map linearly across the finite [floorDb, ceilDb] display range. This restores
  * the legacy `withInfinityAtZero` behavior so a fader dragged fully down is real
- * silence rather than the -46 dB floor. The descriptor pairs it with a min of
- * -Infinity so the emitted silence survives range clamping.
+ * silence rather than the -46 dB floor. The descriptor's `min` is the finite
+ * floor (`floorDb`), so type-in of a sub-floor value clamps up to it rather than
+ * committing a value the document schema rejects; the -Infinity silence sentinel
+ * rides below that floor and is preserved by `clampValue`.
  */
 function volumeTaper(range: readonly [number, number]): Taper<number> {
   const [floorDb, ceilDb] = range;
@@ -107,7 +109,7 @@ const instrumentDecayDescriptor: ParamDescriptor<number> = {
 };
 
 const instrumentVolumeDescriptor: ParamDescriptor<number> = {
-  min: -Infinity,
+  min: INSTRUMENT_VOLUME_RANGE[0],
   max: INSTRUMENT_VOLUME_RANGE[1],
   taper: volumeTaper(INSTRUMENT_VOLUME_RANGE),
   default: 0,
@@ -158,7 +160,7 @@ function parsePan(text: string): number | null {
 // --- Master descriptors (nine params; `filter` is the generic-T descriptor) ---
 
 const masterVolumeDescriptor: ParamDescriptor<number> = {
-  min: -Infinity,
+  min: MASTER_VOLUME_RANGE[0],
   max: MASTER_VOLUME_RANGE[1],
   taper: volumeTaper(MASTER_VOLUME_RANGE),
   default: 0,

--- a/src/shared/param-control/hooks/use-param-control.ts
+++ b/src/shared/param-control/hooks/use-param-control.ts
@@ -185,9 +185,16 @@ function useParamControl<T>({
   const bipolar = descriptor.polarity === "bipolar";
 
   const numeric = typeof descriptor.min === "number";
-  const descriptorMin = numeric ? (descriptor.min as unknown as number) : 0;
-  const descriptorMax = numeric ? (descriptor.max as unknown as number) : 1;
-  const descriptorNow = numeric ? (value as unknown as number) : position;
+  const rawMin = numeric ? (descriptor.min as unknown as number) : 0;
+  const rawMax = numeric ? (descriptor.max as unknown as number) : 1;
+  const rawNow = numeric ? (value as unknown as number) : position;
+  // ARIA numbers must be finite. A volume control's silence sentinel
+  // (-Infinity) - and defensively any non-finite bound - is not a valid ARIA
+  // number, so substitute the finite floor; `aria-valuetext` still carries the
+  // human label ("-∞ dB").
+  const ariaMin = Number.isFinite(rawMin) ? rawMin : rawMax;
+  const ariaMax = Number.isFinite(rawMax) ? rawMax : rawMin;
+  const ariaNow = Number.isFinite(rawNow) ? rawNow : ariaMin;
 
   /** Commit a discrete change as its own bracketed gesture (own undo unit). */
   const commitDiscrete = useCallback(
@@ -453,9 +460,9 @@ function useParamControl<T>({
     role: "slider",
     tabIndex: disabled || !tabbable ? -1 : 0,
     "aria-label": label,
-    "aria-valuemin": descriptorMin,
-    "aria-valuemax": descriptorMax,
-    "aria-valuenow": descriptorNow,
+    "aria-valuemin": ariaMin,
+    "aria-valuemax": ariaMax,
+    "aria-valuenow": ariaNow,
     "aria-valuetext": displayValue,
     "aria-disabled": disabled || undefined,
   };

--- a/src/shared/param-control/lib/descriptor.ts
+++ b/src/shared/param-control/lib/descriptor.ts
@@ -29,6 +29,10 @@ function isNumericDescriptor<T>(
 /** Clamp a canonical value to [min, max] (numeric params only; no-op otherwise). */
 function clampValue<T>(descriptor: ParamDescriptor<T>, value: T): T {
   if (typeof value === "number" && isNumericDescriptor(descriptor)) {
+    // -Infinity is the silence sentinel (a volume fader fully down): it rides
+    // below the finite floor and must survive clamping so true silence stays
+    // reachable and round-trips (canonical-scalars.ts `volumeTaper`).
+    if (value === -Infinity) return value as unknown as T;
     return clamp(value, descriptor.min, descriptor.max) as unknown as T;
   }
   return value;


### PR DESCRIPTION
## Summary

The volume descriptors (`instrumentVolumeDescriptor`, `masterVolumeDescriptor`) declared `min: -Infinity` so position 0 maps to true silence, but that left the **type-in path unbounded below**: `parseDb` returns any finite number and `clampValue` had no lower bound. Typing `-50` committed `-50` dB to the store, and the document schema pins `volumeDb >= -46`, so every egress (export, share, session autosave, dirty-hash) then threw a `ZodError` until the value was nudged back. Drag could not produce this; type-in was the only gap.

## Fix

- **Finite floor at the descriptor edge.** The volume descriptors now use a finite `min` (the range floor, the same `INSTRUMENT_VOLUME_RANGE[0]` / `MASTER_VOLUME_RANGE[0]` constant the taper's `floorDb` uses, so the floor has one source of truth). Type-in of a sub-floor value clamps up to the floor via the standard `parse -> clampValue` path (`-50` becomes `-46`).
- **Silence still reachable.** `clampValue` treats `-Infinity` as a pass-through silence sentinel that rides below the finite floor, so `-inf`/`∞` type-in, Home, and drag-to-zero all still reach true silence and round-trip.
- **ARIA gap.** `aria-valuemin`/`aria-valuenow` rendered as `-Infinity` on a silenced volume control, which is not a valid ARIA number. The hook now substitutes the finite floor for the aria numbers when a bound (or the current value) is non-finite; `aria-valuetext` still reads `-∞ dB`.

Invariants held: no input path (type-in, drag, keyboard, reset) can commit a value the document schema rejects; `-Infinity` silence remains reachable and round-trips.

## Not changed

- The taper is untouched, so **drag and keyboard feel are identical**.
- No rendering, styling, or layout change (value/parse/aria logic only) - **zero visual change**.

## Tests

- `descriptors.test.ts`: for both volume descriptors, `parseValue("-50")` clamps to the floor and satisfies the schema bounds; `"20"` clamps to the ceiling; `"-inf"`/`"-∞ dB"` yield `-Infinity`; a sweep of type-in strings and drag/keyboard endpoints are all schema-acceptable (asserted against `INSTRUMENT_VOLUME_RANGE` / `MASTER_VOLUME_RANGE`, which are the `volumeDb` schema bounds).
- `rotary-knob.browser.test.ts`: a silenced volume control (`value: -Infinity`) renders finite `aria-valuemin`/`max`/`now` while `aria-valuetext` stays `-∞ dB`.

## Gates

- `pnpm test`: 797 passed | 4 skipped
- `pnpm build`: built successfully
- `pnpm lint`: exit 0
- `pnpm prettier . --check`: exit 0

Closes #383