### PR TITLE
fix(param-control): align reset targets and pin bpm to canonical defaults

### DIFF
--- a/src/core/audio/engine/constants.ts
+++ b/src/core/audio/engine/constants.ts
@@ -102,7 +102,11 @@ const MASTER_COMP_RATIO_RANGE: Range = [1, 8];
 const MASTER_COMP_MIX_RANGE: Range = [0, 1]; // Parallel wet/dry
 
 const MASTER_COMP_ATTACK_RANGE: Range = [0.001, 0.1]; // 1ms - 100ms
-const MASTER_COMP_ATTACK = 0.01; // 10 ms - catches transients (legacy constant)
+// The shipped default compressor attack: the migrated legacy knob-50 value that
+// the init preset (init.dh) and the master-chain store hold, expressed as the
+// exact stored float64 so descriptor reset lands on it byte-for-byte (no dirty
+// flag on a factory-fresh preset). Single source of truth for that default.
+const MASTER_COMP_ATTACK_DEFAULT = 0.025750000000000002; // 25.75 ms
 const MASTER_COMP_RELEASE = 0.05; // 50 ms - fast recovery, punchy drums
 const MASTER_COMP_KNEE = 0; // dB - hard knee
 const MASTER_COMP_MAKEUP_GAIN = 1.5; // dB - compensates gain reduction
@@ -236,7 +240,7 @@ export {
   MASTER_COMP_RATIO_RANGE,
   MASTER_COMP_MIX_RANGE,
   MASTER_COMP_ATTACK_RANGE,
-  MASTER_COMP_ATTACK,
+  MASTER_COMP_ATTACK_DEFAULT,
   MASTER_COMP_RELEASE,
   MASTER_COMP_KNEE,
   MASTER_COMP_MAKEUP_GAIN,

--- a/src/features/master-bus/store/use-master-chain-store.ts
+++ b/src/features/master-bus/store/use-master-chain-store.ts
@@ -7,6 +7,7 @@ import { immer } from "zustand/middleware/immer";
 // React mounts.
 
 import type { MasterChainCanonical } from "@/core/audio/bridge/engine-params";
+import { MASTER_COMP_ATTACK_DEFAULT } from "@/core/audio/engine/constants";
 
 /**
  * Canonical master-chain defaults (docs/data-representation.md): the units the
@@ -21,7 +22,7 @@ const DEFAULT_MASTER_CHAIN: MasterChainCanonical = {
   reverb: 0,
   compThreshold: 0, // dB
   compRatio: 5,
-  compAttack: 0.02575, // seconds
+  compAttack: MASTER_COMP_ATTACK_DEFAULT, // seconds
   compMix: 0.7,
   masterVolume: 0, // dB
 };

--- a/src/features/preset/document/document.test.ts
+++ b/src/features/preset/document/document.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { TRANSPORT_BPM_RANGE } from "@/core/audio/engine/constants";
 import type {
   StepSequence,
   TimingNudge,
@@ -168,10 +169,52 @@ describe("presetDocumentSchema", () => {
     );
   });
 
-  it("rejects a non-positive bpm", () => {
+  // bpm is pinned to the engine's TRANSPORT_BPM_RANGE ([40, 300]) like every
+  // other param field, closing the one unbounded schema hole (issue #385).
+  it("accepts bpm at both ends of the engine range", () => {
+    expect(
+      presetDocumentSchema.safeParse(
+        mutated((d) => {
+          d.transport.bpm = TRANSPORT_BPM_RANGE[0];
+        }),
+      ).success,
+    ).toBe(true);
+    expect(
+      presetDocumentSchema.safeParse(
+        mutated((d) => {
+          d.transport.bpm = TRANSPORT_BPM_RANGE[1];
+        }),
+      ).success,
+    ).toBe(true);
+  });
+
+  it("rejects a bpm below the engine range", () => {
+    expectFailureAt(
+      mutated((d) => {
+        d.transport.bpm = TRANSPORT_BPM_RANGE[0] - 1;
+      }),
+      ["transport", "bpm"],
+    );
+    // 0 (non-positive) is below the floor too and still fails.
     expectFailureAt(
       mutated((d) => {
         d.transport.bpm = 0;
+      }),
+      ["transport", "bpm"],
+    );
+  });
+
+  it("rejects a bpm above the engine range", () => {
+    expectFailureAt(
+      mutated((d) => {
+        d.transport.bpm = TRANSPORT_BPM_RANGE[1] + 1;
+      }),
+      ["transport", "bpm"],
+    );
+    // The previously-accepted hand-crafted out-of-range value now fails.
+    expectFailureAt(
+      mutated((d) => {
+        d.transport.bpm = 10000;
       }),
       ["transport", "bpm"],
     );

--- a/src/features/preset/document/document.ts
+++ b/src/features/preset/document/document.ts
@@ -33,6 +33,7 @@ import {
   MASTER_COMP_THRESHOLD_RANGE,
   MASTER_VOLUME_RANGE,
   STEP_COUNT,
+  TRANSPORT_BPM_RANGE,
   TRANSPORT_SWING_MAX,
 } from "@/core/audio/engine/constants";
 import {
@@ -174,7 +175,7 @@ const playbackSchema = z.object({
 });
 
 const transportSchema = z.object({
-  bpm: z.number().positive(),
+  bpm: z.number().min(TRANSPORT_BPM_RANGE[0]).max(TRANSPORT_BPM_RANGE[1]),
   swing: z.number().min(0).max(TRANSPORT_SWING_MAX),
 });
 

--- a/src/shared/param-control/__tests__/descriptors.test.ts
+++ b/src/shared/param-control/__tests__/descriptors.test.ts
@@ -5,13 +5,16 @@ import {
   INSTRUMENT_VOLUME_RANGE,
   MASTER_VOLUME_RANGE,
 } from "@/core/audio/engine/constants";
+import { init } from "@/core/dh";
 import {
   instrumentDecayDescriptor,
   instrumentPanDescriptor,
   instrumentTuneDescriptor,
   instrumentVolumeDescriptor,
+  masterCompAttackDescriptor,
   masterCompRatioDescriptor,
   masterVolumeDescriptor,
+  transportBpmDescriptor,
   transportSwingDescriptor,
 } from "../descriptors/canonical-scalars";
 import {
@@ -207,6 +210,42 @@ describe("swing descriptor", () => {
   it("round-trips MPC display back to the swing fraction", () => {
     expect(transportSwingDescriptor.parse?.("62.5%")).toBeCloseTo(0.375, 9);
     expect(transportSwingDescriptor.parse?.("50%")).toBeCloseTo(0, 9);
+  });
+});
+
+// A double-click/Enter reset commits the descriptor's `default`. If that value
+// diverges from what a factory-fresh session actually holds (the init preset,
+// which is the shipped truth applied by bootstrapSession), the reset instantly
+// dirty-flags an untouched preset. This guards every reset target that has bitten
+// us against the init document so the two can never drift again (issue #385).
+describe("descriptor reset targets match the shipped init defaults (#385)", () => {
+  const initDoc = init();
+
+  it("compressor ratio default equals the init ratio", () => {
+    expect(masterCompRatioDescriptor.default).toBe(initDoc.master.compRatio);
+  });
+
+  it("compressor attack default equals the init attack byte-for-byte", () => {
+    // The init value is a specific float64 (the migrated legacy knob-50 value);
+    // toBe pins it exactly, not merely close, so a reset produces no dirty flag.
+    expect(masterCompAttackDescriptor.default).toBe(
+      initDoc.master.compAttackSeconds,
+    );
+  });
+
+  it("bpm default equals the init bpm", () => {
+    expect(transportBpmDescriptor.default).toBe(initDoc.transport.bpm);
+  });
+
+  it("split-filter default matches the init filter spelling and renders centred", () => {
+    expect(splitFilterDescriptor.default).toEqual(initDoc.master.filter);
+    // Same open extreme as the mapping's knob-centre, so reset lands at 0.5.
+    expect(
+      canonicalToNormalized(
+        splitFilterDescriptor,
+        splitFilterDescriptor.default,
+      ),
+    ).toBeCloseTo(0.5, 9);
   });
 });
 

--- a/src/shared/param-control/descriptors/canonical-scalars.ts
+++ b/src/shared/param-control/descriptors/canonical-scalars.ts
@@ -13,6 +13,7 @@ import {
   INSTRUMENT_PAN_RANGE,
   INSTRUMENT_TUNE_SEMITONE_RANGE,
   INSTRUMENT_VOLUME_RANGE,
+  MASTER_COMP_ATTACK_DEFAULT,
   MASTER_COMP_ATTACK_RANGE,
   MASTER_COMP_MIX_RANGE,
   MASTER_COMP_RATIO_RANGE,
@@ -210,7 +211,9 @@ const masterCompRatioDescriptor: ParamDescriptor<number> = {
   min: MASTER_COMP_RATIO_RANGE[0],
   max: MASTER_COMP_RATIO_RANGE[1],
   taper: { kind: "linear" },
-  default: 4,
+  // Matches the shipped init/store default so double-click reset never dirties
+  // a factory-fresh preset (see the descriptor drift-guard test).
+  default: 5,
   interval: 1,
   format: (v) => `${Math.round(v)}:1`,
   parse: parseNumber,
@@ -220,7 +223,9 @@ const masterCompAttackDescriptor: ParamDescriptor<number> = {
   min: MASTER_COMP_ATTACK_RANGE[0],
   max: MASTER_COMP_ATTACK_RANGE[1],
   taper: { kind: "exponential", skew: LEGACY_EXP_SKEW },
-  default: 0.01,
+  // Shared with the init/store default (the migrated legacy knob-50 value) so
+  // reset lands on the factory value byte-for-byte and never dirties it.
+  default: MASTER_COMP_ATTACK_DEFAULT,
   unit: "ms",
   format: (v) => `${(v * 1000).toFixed(v < 0.01 ? 1 : 0)} ms`,
   parse: (t) => {
@@ -274,7 +279,9 @@ const transportBpmDescriptor: ParamDescriptor<number> = {
   min: TRANSPORT_BPM_RANGE[0],
   max: TRANSPORT_BPM_RANGE[1],
   taper: { kind: "linear" },
-  default: 120,
+  // Matches the shipped init/store default (100 bpm) so reset never dirties a
+  // factory-fresh preset.
+  default: 100,
   interval: 1,
   // Finer than the general knob feel: bpm is a precision screen-bar control.
   // The old ClickableValue moved ~0.3 bpm/px; over the ~260 bpm span that is

--- a/src/shared/param-control/descriptors/filter.ts
+++ b/src/shared/param-control/descriptors/filter.ts
@@ -61,7 +61,11 @@ const splitFilterDescriptor: ParamDescriptor<CanonicalFilter> = {
     to01: filterToPosition,
     from01: positionToFilter,
   },
-  default: { side: "lowpass", cutoffHz: FILTER_MAX_HZ },
+  // Factory/init/store spelling of "fully open" (renders at knob-centre 0.5, the
+  // same open extreme as { lowpass, FILTER_MAX_HZ }). Matching the factory
+  // spelling exactly means resetting a factory-fresh filter knob does not
+  // rewrite the stored value and never dirties the preset.
+  default: { side: "highpass", cutoffHz: 0 },
   polarity: "bipolar",
   detents: [
     { value: { side: "lowpass", cutoffHz: FILTER_MAX_HZ }, radiusPct: 0.04 },


### PR DESCRIPTION
Closes #385

## Problem

The 2026-07-16 post-epic crack audit found canonical constants with a second notion of "default": three descriptor reset targets diverged from the shipped init/store defaults, the split-filter reset spelling differed from factory data, and bpm was the one unbounded document-schema field. Double-click/Enter reset therefore landed on values that differ from what a factory-fresh session actually holds, instantly dirty-flagging an untouched preset.

## Changes

Reset targets aligned to the shipped init/store defaults (init.dh is the shipped truth; factory data untouched):

- `masterCompRatioDescriptor.default` `4` -> `5`
- `masterCompAttackDescriptor.default` `0.01` -> the shipped `0.025750000000000002` (the migrated legacy knob-50 value). This is now a single source of truth, `MASTER_COMP_ATTACK_DEFAULT`, shared by the descriptor and the master-chain store. It replaces the dead, wrongly-valued `MASTER_COMP_ATTACK = 0.01` engine constant (which was exported but consumed nowhere; the compressor reads `settings.compAttack`). Note the store literal was `0.02575`, a *different* float64 from init.dh's `0.025750000000000002`; the shared constant uses the exact init value so reset lands byte-for-byte on what a fresh session loads.
- `transportBpmDescriptor.default` `120` -> `100`
- `splitFilterDescriptor.default` `{ side: "lowpass", cutoffHz: 15000 }` -> the factory spelling `{ side: "highpass", cutoffHz: 0 }`. Both render at knob-centre 0.5 (verified in the new test), but matching the factory spelling means resetting a factory-fresh filter knob no longer rewrites the stored value. The center detent keeps its `{ lowpass, FILTER_MAX_HZ }` value, which is what `positionToFilter(0.5)` produces, so drag-snap behaviour is unchanged.

Schema hole closed:

- `document.ts` transport `bpm: z.number().positive()` -> `.min(TRANSPORT_BPM_RANGE[0]).max(TRANSPORT_BPM_RANGE[1])`, pinning it to the engine range `[40, 300]` like every other param field.

Fixture corpus check: every historical fixture and factory `.dh` carries `bpm: 100`, well inside `[40, 300]`, so no legacy file fails under the tightened schema and no v1-migration clamp was needed.

Tests:

- Descriptor drift guard (descriptors.test.ts): asserts each reset target equals the corresponding field of the parsed init document (`init()`), including a byte-exact `toBe` on the attack float and a check that the filter default renders at position 0.5.
- Document schema bpm bounds (document.test.ts): both range ends pass; below-floor and above-ceiling (including the old `bpm: 10000` that previously validated) fail typed at `["transport", "bpm"]`.

Zero visual change: on load, every control renders from the unchanged store/document values. Only reset targets change.

## Notes

The frozen legacy island (`migrate-v1.ts`, `frozen-split-filter.ts`) was not touched.

## Gates

- `pnpm test`: 806 passed | 4 skipped
- `pnpm build`: built in 2.14s
- `pnpm lint`: clean
- `pnpm prettier . --check`: all files formatted