### PR TITLE
Comment and naming drift sweep (post-flip cleanup)

### DIFF
--- a/docs/preset-persistence.md
+++ b/docs/preset-persistence.md
@@ -5,7 +5,7 @@ Author: Max, July 2026.
 Tracking issue: #329.
 
 Update (2026-07-14, #269): the swing retune landed before this design's document model shipped, as `.dh` version 1.5.
-Version 1.5 is a knob-space revision of the v1 shape (identical fields; `transport.swing` knob values written under the old curve are rescaled by 4/3 on load, see `src/features/preset/document/migrate.ts`), the share codec gained a `v` field mirroring the file version (absent = legacy URL, swing migrated on decode), and the transport persist is now versioned (v1, with a swing migrate).
+Version 1.5 is a knob-space revision of the v1 shape (identical fields; `transport.swing` knob values written under the old curve are rescaled by 4/3 on load, see `src/features/preset/document/legacy-file-version.ts`), the share codec gained a `v` field mirroring the file version (absent = legacy URL, swing migrated on decode), and the transport persist is now versioned (v1, with a swing migrate).
 Version 2 remains the domain-unit document described below, unchanged; its 1-to-2 migration must now also accept 1.5 as input (the swing rescale is already applied there).
 The audit sections still describe the pre-#269 state where they mention an unversioned codec and transport persist.
 

--- a/docs/preset-versioning.md
+++ b/docs/preset-versioning.md
@@ -24,13 +24,13 @@ The rest of this doc is about namespaces 1 and 2.
 
 Document versions (the `version` field of a `.dh` file / `PresetDocument`):
 
-| version       | shape                             | readable | writable | notes                                                                                             |
-| ------------- | --------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
-| 1             | knob-space file (0-100 positions) | yes      | no       | legacy `.dh`; migrates 1 -> 1.5 swing on read (`migrate.ts`), then 1.x -> 2.1 (`migrate-v1.ts`)   |
-| 1.5           | knob-space file                   | yes      | no       | #269 swing retune; identical shape to v1                                                          |
-| 2             | first domain document             | yes      | no       | domain-space except the split filter, still a 0-100 position; migrates 2 -> 2.1 (`migrate-v2.ts`) |
-| 2.1           | canonical domain document         | yes      | yes      | current; split filter is canonical `{ side, cutoffHz }`; the only writable version                |
-| anything else | -                                 | no       | no       | hard-refused with `UnsupportedVersionError` (decision 2)                                          |
+| version       | shape                             | readable | writable | notes                                                                                                       |
+| ------------- | --------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| 1             | knob-space file (0-100 positions) | yes      | no       | legacy `.dh`; migrates 1 -> 1.5 swing on read (`legacy-file-version.ts`), then 1.x -> 2.1 (`migrate-v1.ts`) |
+| 1.5           | knob-space file                   | yes      | no       | #269 swing retune; identical shape to v1                                                                    |
+| 2             | first domain document             | yes      | no       | domain-space except the split filter, still a 0-100 position; migrates 2 -> 2.1 (`migrate-v2.ts`)           |
+| 2.1           | canonical domain document         | yes      | yes      | current; split filter is canonical `{ side, cutoffHz }`; the only writable version                          |
+| anything else | -                                 | no       | no       | hard-refused with `UnsupportedVersionError` (decision 2)                                                    |
 
 Compact share-codec versions (the `v` field of a `?p=` payload; a separate namespace).
 Unlike documents, share links are latest-only: exactly one codec version is readable, and it is the same version that is written.
@@ -51,7 +51,7 @@ Where each is read or written:
 - Read dispatch (documents): `decode.ts` `decodePresetObject` routes `1`/`1.5` -> `migrateV1ToDocument(validatePresetFileV1(...))`, `2` -> `migrateV2ToDocument`, `2.1` -> strict `presetDocumentSchema` parse, else `UnsupportedVersionError`.
   The version is dispatched BEFORE the strict parse so a v2 position-filter can never be mis-read as a v2.1 canonical filter.
 - Read dispatch (shares): `serialization/index.ts` `urlToDocument` routes `v === COMPACT_CODEC_VERSION` -> `decodeCompactDocument` and refuses every other `v` with `UnsupportedVersionError` (latest-only, #373); there is no legacy share branch.
-- v1-family reader: `parse.ts` + `file-v1.ts` (tolerant schema) + `migrate.ts` (`isReadablePresetFileVersion`, `migratePresetFileVersion`).
+- v1-family reader: `parse.ts` + `file-v1.ts` (tolerant schema) + `legacy-file-version.ts` (`isReadablePresetFileVersion`, `migratePresetFileVersion`).
 - Write (egress), always v2.1: `snapshot.ts` and `encode.ts` both stamp `PRESET_DOCUMENT_VERSION`, and `presetDocumentSchema` pins `version` to `z.literal(2.1)`; the compact encoder stamps `COMPACT_CODEC_VERSION`.
 - There is no production downgrade path: `toV1` exists only in `migrate-v1.test.ts` as a round-trip helper.
 
@@ -96,7 +96,7 @@ The boundary is physical, not a comment: every member lives under `src/features/
 Its members:
 
 - `document/migrate-v1.ts` (`frozenV1Curves`: v1 knob -> canonical) and `document/frozen-split-filter.ts` (position -> canonical), the frozen curves.
-- `document/file-v1.ts`, `document/parse.ts`, `document/migrate.ts`, the tolerant v1-family read and normalization.
+- `document/file-v1.ts`, `document/parse.ts`, `document/legacy-file-version.ts`, the tolerant v1-family read and normalization.
 - `document/legacy-knob-migrators.ts`, the runtime knob-space v1 migrators (pattern / instrument / master-chain), relocated from `features/sequencer/lib/migrations.ts` so its innocuous name can no longer be mistaken for the sequencer's own migrations (#387).
 - `document/legacy-swing.ts`, the pre-#269 swing knob migrator, relocated from `features/transport/lib/legacy-swing.ts` (#387).
 - `document/legacy-cycle-to-chain.ts`, the v1 `variationCycle` -> canonical chain conversion, extracted from `features/sequencer/lib/chain.ts` so it no longer shares a module with the live `appendChainDraftStep` (#387).
@@ -118,7 +118,7 @@ Stores, the engine, egress, and every newly written file or link are canonical o
 The frozen curves never read a live UI curve; the parity tests assert frozen equals live today, and on a deliberate retune the TEST is updated to pin the frozen values, never the frozen module.
 
 The sunset seam: the island is deletable as one unit at the moment the product accepts breaking a legacy generation.
-The v1.x sub-island (`migrate-v1.ts`, `file-v1.ts`, `parse.ts`, `migrate.ts`, `legacy-knob-migrators.ts`, `legacy-swing.ts`, `legacy-cycle-to-chain.ts`, `frozenV1Curves`, `types/legacy-v1.ts`, and the v1 fixtures) can be deleted together once no v1 / v1.5 `.dh` files need to load AND the one-time localStorage adopters have run everywhere and their legacy keys are gone.
+The v1.x sub-island (`migrate-v1.ts`, `file-v1.ts`, `parse.ts`, `legacy-file-version.ts`, `legacy-knob-migrators.ts`, `legacy-swing.ts`, `legacy-cycle-to-chain.ts`, `frozenV1Curves`, `types/legacy-v1.ts`, and the v1 fixtures) can be deleted together once no v1 / v1.5 `.dh` files need to load AND the one-time localStorage adopters have run everywhere and their legacy keys are gone.
 The share side of that seam is already cut: #373 removed the `v: 1.5` share decoder ahead of the rest, since share links are ephemeral and safe to break early.
 Deleting the remaining sub-island means removing the `1` / `1.5` rungs from `document/decode.ts`, dropping `READABLE_V1_FILE_VERSIONS` and `PRESET_FILE_VERSION` from `document/versions.ts`, deleting those modules and fixtures, and letting `decode` reject those versions with `UnsupportedVersionError`.
 `frozen-split-filter.ts` OUTLIVES the v1 sub-island because `migrate-v2.ts` also depends on it; it retires only when both v1 AND v2 documents are no longer read.
@@ -137,7 +137,7 @@ No live correctness bug was found that warranted halting the audit.
   Severity was low: the change happened inside the unreleased #357 epic across a ~1-day window, share links are ephemeral, and the failure was fail-safe.
   #373 resolved it by collapsing to a single share codec and giving its sole canonical shape a fresh, honest version (`3`): version now maps 1:1 to shape, and any `v: 2` payload (scalar or canonical) is refused uniformly with `UnsupportedVersionError` rather than decoded, so the shape collision can never resurface.
 - Readable-version literals were decentralized: issue [#380](https://github.com/mxfng/drumhaus/issues/380) - RESOLVED (folded into #387).
-  The readable-but-not-writable versions (`1`, `1.5`, `2`) once appeared as bare literals across `decode.ts` (`PRESET_DOCUMENT_VERSION_V2 = 2`), `migrate.ts`, and `file-v1.ts` rather than a single shared registry.
+  The readable-but-not-writable versions (`1`, `1.5`, `2`) once appeared as bare literals across `decode.ts` (`PRESET_DOCUMENT_VERSION_V2 = 2`), `legacy-file-version.ts`, and `file-v1.ts` rather than a single shared registry.
   This was not a correctness gap; the shared `document/versions.ts` registry now backs the decode ladder and the v1 read helpers, so the readable set lives in one self-documenting place.
 - The Versioning and Migration-path sections of docs/preset-persistence.md are a past-tense design narrative that predates the shipped outcome (no issue filed).
   They describe an integer `CURRENT_VERSION = 2` and a `MIGRATIONS[]` ladder, whereas the code shipped a fractional `2.1` and an explicit if-ladder in `decode.ts`.

--- a/e2e/session-adoption.spec.ts
+++ b/e2e/session-adoption.spec.ts
@@ -158,8 +158,8 @@ test.describe("legacy session adoption", () => {
     // and pin the user-visible MPC swing display.
     const swingControl = page.getByRole("slider", { name: "swing" });
     await expect(swingControl).toHaveText(/swing\s+60/);
-    const swingKnobValue = await swingControl.getAttribute("aria-valuenow");
-    expect(Number(swingKnobValue)).toBeCloseTo(0.3, 9);
+    const swingValue = await swingControl.getAttribute("aria-valuenow");
+    expect(Number(swingValue)).toBeCloseTo(0.3, 9);
 
     // Storage after adoption: one session document, the four retired keys
     // deleted (only after the write landed). The legacy preset-meta key is

--- a/src/core/audio/bridge/kit-descriptors.test.ts
+++ b/src/core/audio/bridge/kit-descriptors.test.ts
@@ -54,10 +54,10 @@ describe("kitDescriptorsChanged", () => {
     expect(kitDescriptorsChanged(kit, instruments)).toBe(false);
   });
 
-  it("ignores params-only changes (knob drags)", () => {
+  it("ignores params-only changes (a volume edit)", () => {
     const tweaked = instruments.map((instrument) => ({
       ...instrument,
-      params: { ...instrument.params, volume: 30 },
+      params: { ...instrument.params, volume: -12 },
     }));
     expect(kitDescriptorsChanged(kit, tweaked)).toBe(false);
   });

--- a/src/core/audio/bridge/use-engine-bridge.ts
+++ b/src/core/audio/bridge/use-engine-bridge.ts
@@ -69,7 +69,7 @@ function useEngineBridge(): void {
       }),
     );
 
-    // --- Instrument params (continuous + play params, knob -> domain) ---
+    // --- Instrument params (continuous + play params, canonical pass-through) ---
     unsubscribers.push(subscribeInstrumentParamsToEngine(engine));
 
     // --- Kit (descriptor-keyed loads + failure rollback, decision 5) ---

--- a/src/core/audio/canonical/filter.ts
+++ b/src/core/audio/canonical/filter.ts
@@ -6,11 +6,11 @@
  * two raw node frequencies. This is one of the two principled musical
  * exceptions to "canonical equals engine-native".
  *
- * This type is the SHARED seam between two epics:
- *   - the knob primitive (Epic 2) maps a normalized position to and from this
- *     value inside the filter descriptor's custom taper, and
- *   - the engine refactor (Epic 1 PR B) will consume this same type when the
- *     split filter becomes Tone-native (the engine takes derived frequencies).
+ * This type is the SHARED seam between two consumers:
+ *   - the knob primitive maps a normalized position to and from this value
+ *     inside the filter descriptor's custom taper, and
+ *   - the engine (fx/split-filter.ts, master-bus.ts) consumes this same type
+ *     directly, deriving Tone-native node frequencies from side + cutoffHz.
  *
  * Keep both consumers pointed at THIS definition so the widget and the engine
  * cannot drift.

--- a/src/core/audio/engine/audio-engine.ts
+++ b/src/core/audio/engine/audio-engine.ts
@@ -112,14 +112,15 @@ interface PlaybackConfig {
 
 /**
  * Read-only transport/context diagnostics for debug displays and the
- * context guards: transport state, the context clock, and the resume
- * guard's context health, in one snapshot.
+ * context guards: transport state, the context clock, the resume guard's
+ * context health, and the context's sample rate, in one snapshot.
  */
 interface EngineDiagnostics {
   transportState: string;
   transportPosition: string;
   contextTime: number;
   contextHealth: AudioContextHealth;
+  sampleRate: number;
 }
 
 /**
@@ -223,7 +224,7 @@ class AudioEngine {
   private anySolos = false;
   private masterSettings: MasterChainSettings | null = null;
   private bpm = 120;
-  /** Transport swing in Tone units (0-TRANSPORT_SWING_MAX); the bridge converts from knobs. */
+  /** Transport swing in Tone units (0-TRANSPORT_SWING_MAX); canonical end to end, the store calls setSwing directly. */
   private swing = 0;
 
   // --- Lifecycle & playback state ---
@@ -748,8 +749,8 @@ class AudioEngine {
 
   /**
    * Sets the transport swing in DOMAIN units, clamped to the valid Tone
-   * swing range [0, TRANSPORT_SWING_MAX]; the bridge converts from the
-   * 0-100 knob value.
+   * swing range [0, TRANSPORT_SWING_MAX]. Swing is canonical end to end;
+   * the store calls setSwing directly with no knob conversion.
    */
   setSwing(swing: number): void {
     const clamped = Math.max(0, Math.min(TRANSPORT_SWING_MAX, swing));
@@ -935,6 +936,9 @@ class AudioEngine {
       transportPosition: transport.position.toString(),
       contextTime: getContext().currentTime,
       contextHealth: getAudioContextHealth(),
+      // Sourced from the transport's own context reference (stable for the
+      // context's lifetime), not a fresh ambient getContext() call.
+      sampleRate: transport.context.sampleRate,
     };
   }
 

--- a/src/core/audio/engine/fx/split-filter.test.ts
+++ b/src/core/audio/engine/fx/split-filter.test.ts
@@ -11,7 +11,6 @@
 
 import { describe, expect, it } from "vitest";
 
-import { SPLIT_FILTER_MAX_CUTOFF_HZ } from "@/features/preset/document/frozen-split-filter";
 import {
   INSTRUMENT_FILTER_RANGE,
   MASTER_FILTER_RANGE,
@@ -21,6 +20,14 @@ import {
   deriveSplitFilterFrequencies,
   type SplitFilterConfig,
 } from "./split-filter";
+
+// The frozen curve's HP-side overshoot of the 15 kHz range (15000 *
+// (50/49)^2), an out-of-range Hz value above the live [0, 15000] range this
+// module derives from. Inlined rather than imported from the legacy-read
+// island (frozen-split-filter.ts): this engine module must never depend on
+// that island, and the curve's own literal is pinned there
+// (frozen-split-filter.test.ts).
+const OUT_OF_RANGE_CUTOFF_HZ = 15618.4922949;
 
 // Configs built exactly as the two call sites build them (instrument-channel.ts
 // and master-bus.ts): the range endpoints, no explicit bypass floor.
@@ -90,22 +97,17 @@ describe.each([
     });
   });
 
-  it("deep high-pass: LP opens to the range max, HP tracks the frozen curve maximum", () => {
+  it("deep high-pass: LP opens to the range max, HP tracks an out-of-range cutoff unclamped", () => {
     expect(
       deriveSplitFilterFrequencies(
-        { side: "highpass", cutoffHz: SPLIT_FILTER_MAX_CUTOFF_HZ },
+        { side: "highpass", cutoffHz: OUT_OF_RANGE_CUTOFF_HZ },
         config,
       ),
     ).toEqual({
       lowPassTarget: rangeMax,
-      highPassTarget: SPLIT_FILTER_MAX_CUTOFF_HZ,
+      highPassTarget: OUT_OF_RANGE_CUTOFF_HZ,
     });
   });
-});
-
-it("the frozen curve maximum is the HP-side overshoot of the 15 kHz range", () => {
-  // 15000 * (50/49)^2, the closed-high-pass extreme at position 100.
-  expect(SPLIT_FILTER_MAX_CUTOFF_HZ).toBeCloseTo(15618.49, 2);
 });
 
 it("the bypass floor stays at 10 Hz so the HP node never clamps to 0 Hz", () => {

--- a/src/core/audio/engine/instrument-channel.ts
+++ b/src/core/audio/engine/instrument-channel.ts
@@ -219,8 +219,9 @@ class InstrumentChannel {
    * This ensures consistent behavior across manual playback, sequencer
    * playback, and any other trigger sources.
    *
-   * Note that the inputs are domain values, not knob values. Be sure to
-   * convert knob values from state with mapping functions before calling.
+   * Note that the inputs are domain values (seconds, gain, semitones), not
+   * knob values - state is canonical end to end, so no conversion is needed
+   * before calling.
    */
   trigger(time: number, hit: InstrumentHit): void {
     // Enforce monophonic behavior - stop any previous notes for all pitches

--- a/src/core/audio/export/midi-exporter.test.ts
+++ b/src/core/audio/export/midi-exporter.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptyPattern } from "@/features/sequencer/lib/helpers";
 import {
   ACCENT_BOOST,
   ACCENT_DAMPEN,
@@ -10,6 +9,7 @@ import {
   TRANSPORT_SWING_MAX,
 } from "../engine/constants";
 import type { InstrumentRole } from "../engine/instrument/types";
+import { createEmptyPattern } from "../engine/pattern-types";
 import {
   assignDrumNotes,
   BAKE_SWING_INTO_EXPORT,
@@ -83,7 +83,7 @@ describe("tick math", () => {
   it.runIf(BAKE_SWING_INTO_EXPORT)(
     "delays offbeat 16ths by swing * 2/3 of an 8th, like Tone.js",
     () => {
-      // Max app swing (knob 100) is Tone swing 0.375 -> 30 ticks (#269).
+      // Max canonical swing (0.375, TRANSPORT_SWING_MAX) is 30 ticks (#269).
       expect(swingDelayTicks(1, TRANSPORT_SWING_MAX)).toBe(30);
       expect(swingDelayTicks(3, 0.25)).toBe(20);
       // Even steps sit on 8th boundaries and never swing.

--- a/src/core/audio/export/stem-exporter.test.ts
+++ b/src/core/audio/export/stem-exporter.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { createEmptyPattern } from "@/features/sequencer/lib/helpers";
-import type {
-  Pattern,
-  PatternChain,
-  VariationId,
+import {
+  createEmptyPattern,
+  type Pattern,
+  type PatternChain,
+  type VariationId,
 } from "../engine/pattern-types";
 import {
   buildStemReadme,

--- a/src/features/groove/components/groove-controls.tsx
+++ b/src/features/groove/components/groove-controls.tsx
@@ -24,9 +24,6 @@ const TOOLTIPS = {
   FLAM_MODE: "Toggle flam mode (a quick pre-hit)",
 } as const;
 /**
- * Work in progress
- * TODO: Add the remaining features
- *
  * Flam — “Human grace-note before the main hit.”
  * A flam adds a quiet pre-hit just before the step, giving snares, claps, and percussion a natural, human feel. It mimics the way a drummer strikes slightly early with one stick, creating expressive accents and groove variation.
  *

--- a/src/features/preset/components/preset-select.tsx
+++ b/src/features/preset/components/preset-select.tsx
@@ -18,8 +18,8 @@ import {
 interface PresetSelectProps {
   selectedPresetId: string;
   // Both lists are read for identity only (meta.id/meta.name), so they take
-  // the minimal PresetListItem shape: factory presets (PresetFileV1) and
-  // library entries (PresetDocument) both satisfy it.
+  // the minimal PresetListItem shape: factory presets and library entries
+  // are both PresetDocument (2.1) values.
   defaultPresets: PresetListItem[];
   customPresets: PresetListItem[];
   onSelect: (value: string) => void;

--- a/src/features/preset/document/__fixtures__/README.md
+++ b/src/features/preset/document/__fixtures__/README.md
@@ -5,8 +5,8 @@ The v1-era real fixtures are the `init` preset extracted from git history, so di
 The `.dh` JSON format was born at commit `78fe632b` (2025-11-18); before that, presets were TypeScript modules under `src/lib/presets/*.ts` and there is no earlier file era to capture.
 Truncated or otherwise invalid JSON should be tested inline as a string literal in the test, not as a fixture file, because editors and formatters will not preserve broken JSON on disk.
 
-Migrators referenced below live in `src/features/sequencer/lib/migrations.ts` unless noted otherwise.
-`legacyCycleToChain` lives in `src/features/sequencer/lib/chain.ts` and is applied by `src/features/preset/document/migrate-v1.ts` (the 1-to-2 document migration) and `src/features/preset/session/legacy-adopter.ts` (one-time adoption of pre-document session state).
+Migrators referenced below live in `src/features/preset/document/legacy-knob-migrators.ts` unless noted otherwise.
+`legacyCycleToChain` lives in `src/features/preset/document/legacy-cycle-to-chain.ts` and is applied by `src/features/preset/document/migrate-v1.ts` (the 1-to-2 document migration) and `src/features/preset/session/legacy-adopter.ts` (one-time adoption of pre-document session state).
 
 ## v1-current.json
 

--- a/src/features/preset/document/apply.ts
+++ b/src/features/preset/document/apply.ts
@@ -97,8 +97,8 @@ function applyPresetDocument(document: PresetDocument): void {
     (preset) => preset.meta.id === document.meta.id,
   );
 
-  // Commit phase: the same setters in the same order as the legacy
-  // loadPreset; the bridge's push order to the engine depends on it.
+  // Commit phase: this order is load-bearing - the bridge's push order to
+  // the engine depends on it.
 
   // Stop playback first: committing instruments below kicks off the async
   // engine kit reload (samples will reload).
@@ -115,7 +115,7 @@ function applyPresetDocument(document: PresetDocument): void {
   }
 
   // Update metadata (the clean dirty baseline is set post-commit below)
-  presetMeta.loadPreset(document.meta, kit.meta);
+  presetMeta.setLoadedPresetMeta(document.meta, kit.meta);
 
   // Update sequencer
   const pattern = usePatternStore.getState();

--- a/src/features/preset/document/decode.ts
+++ b/src/features/preset/document/decode.ts
@@ -11,7 +11,7 @@ import {
   PresetDocumentError,
   UnsupportedVersionError,
 } from "./errors";
-import { isReadablePresetFileVersion } from "./migrate";
+import { isReadablePresetFileVersion } from "./legacy-file-version";
 import { migrateV1ToDocument } from "./migrate-v1";
 import { migrateV2ToDocument } from "./migrate-v2";
 import { validatePresetFileV1 } from "./parse";

--- a/src/features/preset/document/document.ts
+++ b/src/features/preset/document/document.ts
@@ -7,8 +7,8 @@
  * inferred from it.
  *
  * Version history:
- * - 1 / 1.5: the knob-space `.dh` file shape (migrate.ts); 1.5 marks the
- *   #269 swing retune.
+ * - 1 / 1.5: the knob-space `.dh` file shape (legacy-file-version.ts); 1.5
+ *   marks the #269 swing retune.
  * - 2: the first domain document; every field domain-space EXCEPT the split
  *   filter, which was still persisted as its 0-100 position.
  * - 2.1 (this version): a refinement of the v2 domain document - the split
@@ -49,9 +49,9 @@ const PRESET_DOCUMENT_KIND = "drumhaus.preset";
 /**
  * Current preset document version. Fractional minor (2.1) marks a refinement
  * of the v2 domain document - the canonical split filter - not a new
- * generation, mirroring the `.dh` file's v1.5 (migrate.ts). Everything that
- * dispatches on this value must treat versions as fractional, never
- * integer-only.
+ * generation, mirroring the `.dh` file's v1.5 (legacy-file-version.ts).
+ * Everything that dispatches on this value must treat versions as
+ * fractional, never integer-only.
  */
 const PRESET_DOCUMENT_VERSION = 2.1;
 
@@ -135,7 +135,7 @@ const channelSchema = z.object({
     .max(INSTRUMENT_DECAY_RANGE[1]),
   // Canonical split filter `{ side, cutoffHz }`.
   filter: canonicalFilterSchema,
-  // null is the JSON-safe spelling of -Infinity (knob 0 = silence).
+  // null is the JSON-safe spelling of -Infinity (silence).
   volumeDb: z
     .number()
     .min(INSTRUMENT_VOLUME_RANGE[0])
@@ -200,7 +200,7 @@ const masterSchema = z.object({
     .min(MASTER_COMP_ATTACK_RANGE[0])
     .max(MASTER_COMP_ATTACK_RANGE[1]),
   compMix: z.number().min(0).max(1),
-  // null is the JSON-safe spelling of -Infinity (knob 0 = silence).
+  // null is the JSON-safe spelling of -Infinity (silence).
   masterVolumeDb: z
     .number()
     .min(MASTER_VOLUME_RANGE[0])

--- a/src/features/preset/document/file-v1.ts
+++ b/src/features/preset/document/file-v1.ts
@@ -11,9 +11,9 @@ import { READABLE_V1_FILE_VERSIONS } from "./versions";
  * Deliberately tolerant: these schemas must accept every legacy shape the
  * runtime migrators (src/features/preset/document/legacy-knob-migrators.ts)
  * accept, so value-level coercion stays in the migrators and the schema only
- * rejects inputs that would crash loadPreset today. Tightening a field here is
- * a behavior change and needs a fixture proving no in-the-wild file relied
- * on the old leniency.
+ * rejects inputs that would crash migrateV1ToDocument today. Tightening a
+ * field here is a behavior change and needs a fixture proving no in-the-wild
+ * file relied on the old leniency.
  */
 
 // migrateInstrumentParams and migrateMasterChainParams only gate on
@@ -55,7 +55,7 @@ const kitSchema = z.object({
   instruments: z.array(instrumentSchema),
 });
 
-// loadPreset passes bpm/swing straight to setBpm/setSwing.
+// applyPresetDocument passes bpm/swing straight to setBpm/setSwing.
 const transportSchema = z.object({
   bpm: z.number(),
   swing: z.number(),
@@ -80,8 +80,8 @@ const patternSchema = z.unknown().superRefine((value, ctx) => {
   });
 });
 
-// chain/chainEnabled/variationCycle are all defaulted by loadPreset and
-// sanitized downstream (sanitizeChain, legacyCycleToChain), so they stay
+// chain/chainEnabled/variationCycle are all defaulted by migrateV1ToDocument
+// and sanitized downstream (sanitizeChain, legacyCycleToChain), so they stay
 // loose here.
 const sequencerSchema = z.object({
   pattern: patternSchema,

--- a/src/features/preset/document/frozen-split-filter.test.ts
+++ b/src/features/preset/document/frozen-split-filter.test.ts
@@ -17,6 +17,7 @@ import type { CanonicalFilter } from "@/core/audio/canonical/filter";
 import {
   FROZEN_SPLIT_FILTER_RANGE,
   frozenSplitFilterPositionToCanonical,
+  SPLIT_FILTER_MAX_CUTOFF_HZ,
 } from "./frozen-split-filter";
 
 // Local inverse of the frozen curve (the retired transform.ts
@@ -96,4 +97,10 @@ describe("frozen split-filter curve inverts through the frozen inverse", () => {
       frozenSplitFilterPositionToCanonical(100),
     );
   });
+});
+
+it("the frozen curve maximum is the HP-side overshoot of the 15 kHz range", () => {
+  // 15000 * (50/49)^2, the closed-high-pass extreme at position 100 - the
+  // same value pinned above at position 100.
+  expect(SPLIT_FILTER_MAX_CUTOFF_HZ).toBeCloseTo(15618.49, 2);
 });

--- a/src/features/preset/document/legacy-file-version.ts
+++ b/src/features/preset/document/legacy-file-version.ts
@@ -14,9 +14,11 @@ function isReadablePresetFileVersion(version: unknown): boolean {
  * (the shape is identical across the two versions). Idempotent: current
  * version presets pass through by reference.
  *
- * Every ingress must run this: file import and share URLs get it via
- * validatePresetFileV1, while presets stored verbatim in localStorage
- * (customPresets) get it in usePresetLoading.loadPreset.
+ * Every v1-family ingress must run this via validatePresetFileV1: file import
+ * (decode.ts), legacy-library adoption (library/adoption.ts), and session
+ * adoption (session/bootstrap.ts) all reach it through validatePresetFileV1.
+ * Share URLs are unrelated - they use the separate compact codec (`v: 3`)
+ * and never carry a v1-family payload.
  */
 function migratePresetFileVersion(preset: PresetFileV1): PresetFileV1 {
   if (preset.version >= PRESET_FILE_VERSION) return preset;

--- a/src/features/preset/document/migrate-v1.ts
+++ b/src/features/preset/document/migrate-v1.ts
@@ -183,8 +183,8 @@ function channelFromKnobParams(params: LegacyKnobInstrumentParams) {
 }
 
 function masterFromV1(masterChain: PresetFileV1["masterChain"]) {
-  // The declared type is knob-space MasterChainParams, but the tolerant v1
-  // schema lets legacy key sets through; inspect the raw keys.
+  // The declared type is knob-space LegacyKnobMasterChainParams, but the
+  // tolerant v1 schema lets legacy key sets through; inspect the raw keys.
   const raw = masterChain as unknown as Record<string, unknown>;
   // The earliest era (2025-11-18 to 2025-11-20) spelled the high-pass knob
   // "hiPass"; migrateMasterChainParams only ever learned "highPass", so

--- a/src/features/preset/document/parse.ts
+++ b/src/features/preset/document/parse.ts
@@ -8,7 +8,7 @@ import { collectStrippedKeyPaths, presetFileV1Schema } from "./file-v1";
 import {
   isReadablePresetFileVersion,
   migratePresetFileVersion,
-} from "./migrate";
+} from "./legacy-file-version";
 import { warnStrippedKeyPaths } from "./stripped-keys";
 
 /**
@@ -63,7 +63,8 @@ function validatePresetFileV1(data: unknown): PresetFileV1 {
   warnStrippedKeyPaths("Preset file", collectStrippedKeyPaths(raw));
 
   // The schema is intentionally looser than the compile-time type; the
-  // migrators invoked by loadPreset normalize the remaining legacy variance.
+  // migrators invoked by migrateV1ToDocument normalize the remaining legacy
+  // variance.
   return migratePresetFileVersion(result.data as unknown as PresetFileV1);
 }
 

--- a/src/features/preset/document/versions.ts
+++ b/src/features/preset/document/versions.ts
@@ -1,10 +1,11 @@
 /**
  * Registry of the readable document version literals.
  *
- * The decode ladder (decode.ts) and the v1-family read helpers (migrate.ts,
- * file-v1.ts) reference this one list instead of scattering bare literals, so
- * the ladder is self-documenting and adding a readable version is a single
- * registry edit (#380, docs/preset-versioning.md section 1). Every version
+ * The decode ladder (decode.ts) and the v1-family read helpers
+ * (legacy-file-version.ts, file-v1.ts) reference this one list instead of
+ * scattering bare literals, so the ladder is self-documenting and adding a
+ * readable version is a single registry edit (#380,
+ * docs/preset-versioning.md section 1). Every version
  * here is read-only ingress; the sole WRITABLE version is
  * PRESET_DOCUMENT_VERSION (document.ts), which stays the single source of
  * truth for "current".

--- a/src/features/preset/lib/operations.ts
+++ b/src/features/preset/lib/operations.ts
@@ -5,8 +5,8 @@ import { MAX_PRESET_NAME_LENGTH } from "./constants";
 
 /**
  * Generate a shareable URL for a preset: the standard egress,
- * snapshot() -> encode. The payload is the v2 compact document encoding
- * (share links write version 2, decision 1).
+ * snapshot() -> encode. The payload is the compact share codec; share
+ * links write codec `v: 3` (see compact.ts, decision 1).
  */
 async function generateShareUrl(
   presetMeta: Meta,
@@ -72,8 +72,8 @@ function normalizePresetName(name: string): string {
 
 /**
  * Create a Blob for downloading the current store state as a .dh file:
- * the standard egress, snapshot() -> encode. The payload is the v2 document
- * encoding: exports write version 2 (decision 1).
+ * the standard egress, snapshot() -> encode. The payload is the preset
+ * document encoding; exports write document version 2.1 (decision 1).
  */
 function createPresetExportBlob(presetMeta: Meta, kitMeta: Meta): Blob {
   const json = encodePresetDocument(

--- a/src/features/preset/lib/serialization/compact.ts
+++ b/src/features/preset/lib/serialization/compact.ts
@@ -72,52 +72,44 @@ const CHANNEL_COUNT = 8;
  * Per-field quantization (decimal places written to the payload).
  *
  * Requirement: decode(encode(doc)) must yield a document whose canonical
- * knob values differ from the original's by less than 0.05 knob units (half
- * the 0.1 knob display step).
+ * fields differ from the original's by no more than one quantization grid
+ * step, each measured in that field's OWN canonical unit - there is no
+ * further conversion downstream of this table.
  *
- * Derivation: quantizing to `p` decimals perturbs the domain value by at
- * most one grid step q = 10^-p (q/2 from rounding; up to q when a
- * near-default value is omitted as sparse and decodes to the default). The
- * knob error is that domain perturbation times the slope of the INVERSE
- * (domain -> knob) mapping, so each field's precision is set by the inverse
- * mapping's steepest region:
+ * Derivation: quantizing a value to `p` decimals (see `quantize` below) rounds
+ * it to the nearest multiple of q = 10^-p, so it can move the value by at
+ * most q. `sparse`/`sparseFilter` compare the quantized value against the
+ * quantized default and omit the field when they're equal, so a near-default
+ * original can also decode to the raw (unquantized) default - which, by the
+ * same equality, lands within that same q of the original. Either path is
+ * bounded by q, so p alone sets each field's worst-case round-trip error:
+ * err <= 10^-p in the field's own unit. This is exactly what
+ * `expectCanonicalRoundTrip` in url-codec.test.ts asserts.
  *
- * - Linear fields have a constant inverse slope of 100/span knob units per
- *   domain unit, so the bound is uniform: err <= q * 100 / span.
- * - Exponential fields (decay, compAttack; forward domain =
- *   min + (knob/100)^2 * span) have inverse knob = 100 * sqrt((d - min) /
- *   span). The FORWARD curve is steepest at knob 100, which means the
- *   inverse is steepest at the opposite end: d(knob)/d(domain) =
- *   50 / sqrt((d - min) * span) diverges as d -> min (knob 0), so the
- *   binding region is the domain floor, not knob 100. Worst case over a
- *   grid step at the floor: err <= 100 * sqrt(q / span).
+ * The split filter's cutoffHz is carried directly in Hz (no widget position
+ * involved in this codec - that curve lives in the param-control filter
+ * descriptor, src/shared/param-control/descriptors/filter.ts, which shapes
+ * position exponentially over [20, 15000] Hz and is irrelevant to this
+ * table). p = 3 leaves sub-Hz precision, far finer than the ear resolves.
  *
- * The split filter is carried as a `[sideCode, cutoffHz]` pair (sideCode
- * 0 = lowpass, 1 = highpass); its widget position is recovered downstream by
- * the filter descriptor's filterToPosition (position = 49 * sqrt(cutoffHz /
- * 15000) per side). That inverse is steepest at the cutoff floor, so like the
- * exponential
- * fields the bound is worst at cutoffHz -> 0: err <= 49 * sqrt(q / 15000);
- * p = 3 keeps it at ~0.013 knob units, well under 0.05.
- *
- * | field             | key | mapping (inverse slope, worst)       | p | worst knob err |
- * |-------------------|-----|--------------------------------------|---|----------------|
- * | decaySeconds      | d   | exp, span 4.995 s; 100*sqrt(q/span)  | 7 | 0.015          |
- * | filter (cutoffHz) | f   | 49*sqrt(q/15000) at the floor        | 3 | 0.013          |
- * | volumeDb          | v   | linear, span 50 dB; 2 knob/dB        | 2 | 0.02           |
- * | pan               | p   | linear, span 2; 50 knob/unit         | 4 | 0.005          |
- * | tuneSemitones     | t   | linear, span 14 st; 50/7 knob/st     | 3 | 0.008          |
- * | saturation        | s   | linear, span 1; 100 knob/unit        | 4 | 0.01           |
- * | phaser            | ph  | linear, span 1; 100 knob/unit        | 4 | 0.01           |
- * | reverb            | rv  | linear, span 1; 100 knob/unit        | 4 | 0.01           |
- * | compThresholdDb   | ct  | linear, span 40 dB; 2.5 knob/dB      | 2 | 0.025          |
- * | compRatio         | cr  | integer 1..8, carried exactly        | - | 0              |
- * | compAttackSeconds | ca  | exp, span 0.099 s; 100*sqrt(q/span)  | 8 | 0.032          |
- * | compMix           | cm  | linear, span 1; 100 knob/unit        | 4 | 0.01           |
- * | masterVolumeDb    | mv  | linear, span 50 dB; 2 knob/dB        | 2 | 0.02           |
- * | swing (fraction)  | sw  | linear, span 0.375; 266.7 knob/unit  | 4 | 0.027          |
- * | bpm               | bpm | raw domain value in both spaces      | - | 0              |
- * | velocities        |     | sparse ints 0-100 (not a knob)       | - | 0.005 velocity |
+ * | field             | key | canonical unit                | p | tolerance |
+ * |-------------------|-----|--------------------------------|---|-----------|
+ * | decaySeconds      | d   | seconds                        | 7 | 1e-7 s    |
+ * | filter (cutoffHz) | f   | Hz                             | 3 | 1e-3 Hz   |
+ * | volumeDb          | v   | dB                             | 2 | 1e-2 dB   |
+ * | pan               | p   | fraction, -1..1                | 4 | 1e-4      |
+ * | tuneSemitones     | t   | semitones                      | 3 | 1e-3 st   |
+ * | saturation        | s   | fraction, 0..1                 | 4 | 1e-4      |
+ * | phaser            | ph  | fraction, 0..1                 | 4 | 1e-4      |
+ * | reverb            | rv  | fraction, 0..1                 | 4 | 1e-4      |
+ * | compThresholdDb   | ct  | dB                             | 2 | 1e-2 dB   |
+ * | compRatio         | cr  | integer 1..8, carried exactly  | - | 0         |
+ * | compAttackSeconds | ca  | seconds                        | 8 | 1e-8 s    |
+ * | compMix           | cm  | fraction, 0..1                 | 4 | 1e-4      |
+ * | masterVolumeDb    | mv  | dB                             | 2 | 1e-2 dB   |
+ * | swing (fraction)  | sw  | fraction, 0..0.375             | 4 | 1e-4      |
+ * | bpm               | bpm | raw domain value, carried exactly | - | 0      |
+ * | velocities        |     | sparse ints 0-100 (pattern-codec, not this table) | - | 0.005 fraction |
  */
 const PRECISION = {
   decaySeconds: 7,
@@ -316,7 +308,7 @@ function encodeMaster(
 const DEFAULT_CHAIN_STRING = stringifyChain(INIT_DOCUMENT.playback.chain);
 
 /**
- * Encode a preset document as the v2 compact share payload.
+ * Encode a preset document as the compact share payload (`v: 3`).
  *
  * @throws {UnknownKitError} If the document's kit id does not resolve in the
  * registry (nothing in the app can currently produce one)
@@ -513,7 +505,7 @@ function decodeMaster(
 }
 
 /**
- * Decode a parsed v2 compact payload into a validated PresetDocument.
+ * Decode a parsed compact payload (`v: 3`) into a validated PresetDocument.
  *
  * @throws {InvalidFileError} If the payload is not an object
  * @throws {UnsupportedVersionError} If the payload's `v` is not the single

--- a/src/features/preset/lib/serialization/pattern-codec.ts
+++ b/src/features/preset/lib/serialization/pattern-codec.ts
@@ -10,18 +10,19 @@ import {
 import { VARIATION_LABELS } from "@/features/sequencer/types/sequencer";
 
 /**
- * Pattern-data helpers shared by every version of the compact share codec:
- * bit-packed trigger/ratchet/flam/accent strings, sparse quantized
- * velocities, and the chain string grammar. Pattern data is already musical
- * (booleans, 0..1 velocities, nudge steps), so these encodings are identical
- * in the knob-space v1.5 codec and the domain-space v2 codec.
+ * Pattern-data helpers for the compact share codec (compact.ts, the single
+ * current `v: 3` shape): bit-packed trigger/ratchet/flam/accent strings,
+ * sparse quantized velocities, and the chain string grammar. Pattern data is
+ * already musical (booleans, 0..1 velocities, nudge steps), so this encoding
+ * was unchanged across the now-retired knob-space and domain-space codec
+ * generations that preceded it.
  */
 
 const PACKED_TRIGGER_HEX_LENGTH = Math.ceil(STEP_COUNT / 4);
 
 /**
  * Exactly one bit-packed step-flag string: 4 lowercase/uppercase hex chars
- * (16 steps). Used by the v2 decoder to reject corrupt payloads before
+ * (16 steps). Used by the current decoder to reject corrupt payloads before
  * unpacking (parseInt would silently produce NaN -> all-false).
  */
 const PACKED_TRIGGER_PATTERN = new RegExp(
@@ -69,8 +70,8 @@ function unpackTriggers(hex: string): boolean[] {
 
 /**
  * Strict chain grammar: 1-8 pairs of variation label (A-D) + repeat digit
- * (1-8), e.g. "A2B1D3". The v1.5 decoder predates this and parses leniently;
- * the v2 decoder validates against it before parsing.
+ * (1-8), e.g. "A2B1D3". The retired v1.5 share decoder predated this and
+ * parsed leniently; the current decoder validates against it before parsing.
  */
 const CHAIN_STRING_PATTERN = /^([A-D][1-8]){1,8}$/;
 
@@ -85,8 +86,9 @@ function stringifyChain(chain: PatternChain): string {
 /**
  * Parse a chain string back into a sanitized PatternChain. Lenient by
  * design (unknown labels skipped, malformed repeats default to 1): the
- * v1.5 decoder has always behaved this way. v2 rejects malformed strings
- * up front via CHAIN_STRING_PATTERN, so leniency never engages there.
+ * retired v1.5 share decoder always behaved this way. The current decoder
+ * rejects malformed strings up front via CHAIN_STRING_PATTERN, so leniency
+ * never engages there.
  */
 function parseChainString(chainString: string): PatternChain {
   const steps: PatternChain["steps"] = [];

--- a/src/features/preset/lib/serialization/url-codec-reorder.test.ts
+++ b/src/features/preset/lib/serialization/url-codec-reorder.test.ts
@@ -1,12 +1,12 @@
 /**
- * KIT_ORDER independence: the hazard the v2 codec kills.
+ * KIT_ORDER independence: the hazard the compact share codec (v: 3) kills.
  *
  * v1.5 payloads reference kits by their positional index in KIT_ORDER, so
  * inserting the reserved kit-1/kit-2 (or any reorder) silently repoints
- * every old link. v2 payloads carry the stable kit id string; the decoder
+ * every old link. v3 payloads carry the stable kit id string; the decoder
  * never consults KIT_ORDER. This file simulates a reorder by mocking the
  * positional code lookups while leaving the id-keyed loaders intact, and
- * proves a v2 link's kit survives while a positional lookup would not.
+ * proves a v3 link's kit survives while a positional lookup would not.
  */
 
 import { describe, expect, it, vi } from "vitest";
@@ -50,8 +50,8 @@ vi.mock("@/core/dhkit", async (importOriginal) => {
   };
 });
 
-describe("v2 kit references survive a KIT_ORDER reorder", () => {
-  it("decodes a v2 payload to the same kit id under the reordered registry", () => {
+describe("v3 kit references survive a KIT_ORDER reorder", () => {
+  it("decodes a v3 payload to the same kit id under the reordered registry", () => {
     const document = migrateV1ToDocument(buildDenseSharePreset());
     expect(document.kit.id).toBe("kit-3");
 
@@ -61,7 +61,7 @@ describe("v2 kit references survive a KIT_ORDER reorder", () => {
     expect(decoded.kit.id).toBe("kit-3");
   });
 
-  it("demonstrates the positional hazard the v2 format removes", async () => {
+  it("demonstrates the positional hazard the v3 format removes", async () => {
     // The reordered registry resolves the dense fixture's positional code
     // "1" (kit-3's index today) to a different kit: exactly the silent
     // corruption that v1.5 links in the wild remain exposed to.

--- a/src/features/preset/store/use-preset-meta-store.ts
+++ b/src/features/preset/store/use-preset-meta-store.ts
@@ -47,14 +47,16 @@ interface PresetMetaState {
   setKitMeta: (meta: Meta) => void;
 
   /**
-   * Load a preset's metadata (current preset and kit meta).
+   * Record a loaded preset's identity metadata (current preset and kit
+   * meta). This is identity bookkeeping only, not a load pipeline - it does
+   * not decode, migrate, or apply anything.
    *
    * Deliberately does NOT touch the clean baseline: this runs at the start
    * of applyPresetDocument's commit phase, before the musical stores are
    * written, and the baseline must hash the APPLIED state (the post-apply
    * snapshot), which applyPresetDocument sets via markPresetClean.
    */
-  loadPreset: (presetMeta: Meta, kitMeta: Meta) => void;
+  setLoadedPresetMeta: (presetMeta: Meta, kitMeta: Meta) => void;
 
   /**
    * Reset the clean baseline to the current store state: hash the live
@@ -189,7 +191,7 @@ const usePresetMetaStore = create<PresetMetaState>()(
           });
         },
 
-        loadPreset: (presetMeta, kitMeta) => {
+        setLoadedPresetMeta: (presetMeta, kitMeta) => {
           set((state) => {
             state.currentPresetMeta = presetMeta;
             state.currentKitMeta = kitMeta;
@@ -217,9 +219,10 @@ const usePresetMetaStore = create<PresetMetaState>()(
 
           if (cleanHash === null) return false;
 
-          // The canonical hash rounds away knob<->domain float noise and
-          // excludes meta.updatedAt (minted fresh on every snapshot), so
-          // this comparison is exactly "did the user edit anything".
+          // The canonical hash compares raw numbers bit-exact (no rounding
+          // needed - see canonical-hash.ts) and excludes meta.updatedAt
+          // (minted fresh on every snapshot), so this comparison is exactly
+          // "did the user edit anything".
           const currentHash = hashPresetDocument(
             snapshotPresetDocument(currentPresetMeta, currentKitMeta),
           );

--- a/src/features/preset/types/preset.ts
+++ b/src/features/preset/types/preset.ts
@@ -1,9 +1,8 @@
 import { InlineMeta } from "./meta";
 
-// The minimal shape a preset list needs: identity meta only. Both
-// PresetFileV1 (factory presets) and PresetDocument (library entries) satisfy
-// it, so list UIs and name helpers can take either without caring which
-// serialization family they hold.
+// The minimal shape a preset list needs: identity meta only. Factory presets
+// and library entries are both PresetDocument (2.1) values, so list UIs and
+// name helpers can take either without caring which one they hold.
 interface PresetListItem {
   meta: InlineMeta;
 }

--- a/src/features/sequencer/components/sequencer-control.tsx
+++ b/src/features/sequencer/components/sequencer-control.tsx
@@ -33,7 +33,8 @@ const TOOLTIPS = {
 } as const;
 
 /*
-TODO: Add the remaining control features
+TODO: Undo is not built yet - the button below is a "coming soon" tooltip
+placeholder (see ComingSoonTooltipContent).
  */
 function SequencerControl() {
   const variation = usePatternStore((state) => state.variation);

--- a/src/layout/screen.tsx
+++ b/src/layout/screen.tsx
@@ -11,11 +11,6 @@ import FrequencyAnalyzer from "@/shared/components/frequency-analyzer";
 import { LogoSweep } from "@/shared/components/logo-sweep";
 import { ScreenFlashOverlay } from "@/shared/components/screen-flash-overlay";
 
-/*
-TODO: Add remaining features
-
-- Dynamic screen right column changes based on current mode (pattern, groove, etc.)
- */
 function Screen() {
   const mode = usePatternStore((state) => state.mode);
 

--- a/src/shared/dialogs/about-dialog.tsx
+++ b/src/shared/dialogs/about-dialog.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { ArrowUpRight } from "lucide-react";
-import { getContext } from "tone";
 
+import { getAudioEngine } from "@/core/audio/engine";
 import {
   Dialog,
   DialogContent,
@@ -27,10 +27,10 @@ const getBrowserInfo = () => {
 };
 
 const getAudioContextInfo = () => {
-  const ctx = getContext();
+  const { sampleRate } = getAudioEngine().getDiagnostics();
 
   return {
-    sampleRate: ctx.sampleRate,
+    sampleRate,
     // can always add more later
   };
 };

--- a/src/shared/param-control/components/linear-slider.tsx
+++ b/src/shared/param-control/components/linear-slider.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/shared/lib/utils";
 import { Label, Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui";
 import { KNOB_DRAG_SENSITIVITY } from "../lib/descriptor";
 import { Knob, useKnob } from "../primitives/knob";
-import type { ParamDescriptor, RotaryKnobFutureSeams } from "../types";
+import type { ParamControlFutureSeams, ParamDescriptor } from "../types";
 
 type SliderOrientation = "horizontal" | "vertical";
 
@@ -41,7 +41,7 @@ type LinearSliderProps<T> = {
   /** Per-instance override for the normalized drag delta per pixel. */
   dragSensitivity?: number;
   className?: string;
-} & RotaryKnobFutureSeams;
+} & ParamControlFutureSeams;
 
 /** The styling-only props threaded from `LinearSlider` down to its body. */
 type LinearSliderBodyProps = {

--- a/src/shared/param-control/components/rotary-knob.tsx
+++ b/src/shared/param-control/components/rotary-knob.tsx
@@ -6,7 +6,7 @@ import { Label, Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui";
 import { useKnobGuidance } from "../hooks/use-knob-guidance";
 import { KNOB_DRAG_SENSITIVITY } from "../lib/descriptor";
 import { Knob, useKnob } from "../primitives/knob";
-import type { ParamDescriptor, RotaryKnobFutureSeams } from "../types";
+import type { ParamControlFutureSeams, ParamDescriptor } from "../types";
 import { KnobTicks } from "./knob-ticks";
 
 /** Diameter presets, matching the original hardware knob: 90px / 180px cells. */
@@ -47,7 +47,7 @@ type RotaryKnobProps<T> = {
   /** Per-instance override for the normalized drag delta per pixel. */
   dragSensitivity?: number;
   className?: string;
-} & RotaryKnobFutureSeams;
+} & ParamControlFutureSeams;
 
 /** The styling-only props threaded from `RotaryKnob` down to its body. */
 type RotaryKnobBodyProps = {

--- a/src/shared/param-control/index.ts
+++ b/src/shared/param-control/index.ts
@@ -2,7 +2,7 @@ export type {
   Taper,
   Detent,
   ParamDescriptor,
-  RotaryKnobFutureSeams,
+  ParamControlFutureSeams,
 } from "./types";
 export {
   clamp01,

--- a/src/shared/param-control/types.ts
+++ b/src/shared/param-control/types.ts
@@ -84,7 +84,7 @@ interface ParamDescriptor<T = number> {
  * These are declared so the presentation can grow into them without reworking
  * the primitive. They are intentionally NOT implemented yet.
  */
-interface RotaryKnobFutureSeams {
+interface ParamControlFutureSeams {
   /**
    * FUTURE: a modulation-range arc, rendered decoupled from the value
    * indicator so it can layer in later. Not rendered.
@@ -101,4 +101,4 @@ interface RotaryKnobFutureSeams {
   onContextMenuRequest?: () => void;
 }
 
-export type { Taper, Detent, ParamDescriptor, RotaryKnobFutureSeams };
+export type { Taper, Detent, ParamDescriptor, ParamControlFutureSeams };

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -4,17 +4,17 @@
  */
 
 import type { InstrumentRole } from "@/core/audio/engine/instrument/types";
-import type {
-  Pattern,
-  TimingNudge,
-  VariationId,
+import {
+  createEmptyPattern,
+  type Pattern,
+  type TimingNudge,
+  type VariationId,
 } from "@/core/audio/engine/pattern-types";
 import { encodeWav } from "@/core/audio/export/wav-encoder";
 import type {
   InstrumentData,
   InstrumentParams,
 } from "@/features/instrument/types/instrument";
-import { createEmptyPattern } from "@/features/sequencer/lib/helpers";
 
 const FIXTURE_SAMPLE_RATE = 44100;
 

--- a/src/test/render.ts
+++ b/src/test/render.ts
@@ -34,13 +34,6 @@ import type {
 import type { InstrumentData } from "@/features/instrument/types/instrument";
 
 /**
- * Historical extra render time after the last bar. Kept exported for
- * interface stability: renders go through engine.renderWav with
- * includeTail=false, so buffers end exactly on the bar line.
- */
-const RENDER_TAIL_SECONDS = 0.3;
-
-/**
  * Neutral canonical master chain: filter fully open (high-pass at 0 Hz), all
  * sends off, compressor threshold fully open (0 dB), unity volume (0 dB).
  *
@@ -184,10 +177,5 @@ async function renderFixture(opts: RenderFixtureOptions): Promise<AudioBuffer> {
   }
 }
 
-export {
-  createFixtureEngine,
-  renderFixture,
-  DEFAULT_MASTER_PARAMS,
-  RENDER_TAIL_SECONDS,
-};
+export { createFixtureEngine, renderFixture, DEFAULT_MASTER_PARAMS };
 export type { RenderFixtureOptions };


### PR DESCRIPTION
Closes #388.

Post-epic comment/naming drift sweep from the 2026-07-16 crack audit. The issue predates PRs #391-#398, so several items were already resolved or their files had moved; verified every item against current code before touching it.

## Per-section summary

### Comments that lie
- `audio-engine.ts` swing field + `setSwing` doc, `instrument-channel.ts`, `use-engine-bridge.ts`, `canonical/filter.ts` - fixed, canonical/pass-through end to end, no bridge-side conversion.
- `operations.ts` - fixed: shares write compact codec `v: 3`, exports write document `2.1` (two namespaces, was conflating them as "version 2").
- `compact.ts` precision contract (lines ~72-118) - rewritten. Restated per-field tolerances in canonical units (seconds/Hz/dB/semitones/fraction = `10^-p` grid step) derived from what `quantize()`/`sparse()` actually do, and removed the misattributed frozen-quadratic-curve reasoning (the live filter descriptor is exponential over [20, 15000] Hz and irrelevant to this codec - cutoffHz is carried directly).
- `file-v1.ts`, `parse.ts`, `migrate-v1.ts`, `__fixtures__/README.md` - fixed: point at `migrateV1ToDocument`/`applyPresetDocument`/`legacy-knob-migrators.ts`/`legacy-cycle-to-chain.ts`, not the deleted `loadPreset` pipeline or the pre-#398 file paths.
- `types/preset.ts`, `preset-select.tsx` - fixed: factory presets are `PresetDocument` (2.1), not `PresetFileV1`.
- `use-preset-meta-store.ts` 9-decimal hash comment - fixed: the hash compares raw numbers bit-exact now (see `canonical-hash.ts`), no rounding.
- `document.ts` "knob 0 = silence" (both occurrences) - fixed to "silence".
- `migrate-v1.ts:184` - fixed to name `LegacyKnobMasterChainParams`.
- Stale scaffold TODOs: `screen.tsx` and `groove-controls.tsx` TODOs deleted (dynamic screen switching and flam/ratchet both shipped). `sequencer-control.tsx`'s TODO is genuinely open (undo is a "coming soon" placeholder in the UI) - reworded to say so precisely rather than deleted.
- Bonus (found during the grep sweep, not in the original issue list): `pattern-codec.ts` and `url-codec-reorder.test.ts` mislabeled the current codec as "v2"; it's `v: 3`. `compact.ts`'s `encodeCompactDocument`/`decodeCompactDocument` docstrings had the same stale "v2" label.

### Names that lie
- `loadPreset` -> `setLoadedPresetMeta` on the preset-meta store, all call sites updated.
- `RotaryKnobFutureSeams` -> `ParamControlFutureSeams` (also composed into `LinearSlider`).
- `document/migrate.ts` -> `document/legacy-file-version.ts`; imports, tests, and its island membership in `docs/preset-versioning.md` (and the `migrate.ts` mention in `docs/preset-persistence.md`) all updated.
- `e2e/session-adoption.spec.ts` `swingKnobValue` -> `swingValue`.

### Dead exports
- `MASTER_COMP_ATTACK` - **skipped**, already renamed to `MASTER_COMP_ATTACK_DEFAULT` by #394.
- `RENDER_TAIL_SECONDS` (`src/test/render.ts`) - removed, zero consumers confirmed.

### Small code nits
- `about-dialog.tsx` - dropped the direct `getContext` import from `"tone"`. Added `sampleRate` to `engine.getDiagnostics()`, sourced from `transport.context.sampleRate` (the engine's own, already-obtained context reference) rather than a fresh ambient `getContext()` call.
- `split-filter.test.ts` - inlined the out-of-range Hz literal instead of importing the legacy-read island's `SPLIT_FILTER_MAX_CUTOFF_HZ` into an engine test; moved the frozen-curve-maximum pin into `frozen-split-filter.test.ts`.
- `midi-exporter.test.ts`, `stem-exporter.test.ts`, `src/test/fixtures.ts` - import `createEmptyPattern` directly from `@/core/audio/engine/pattern-types` instead of through the features shim.
- `kit-descriptors.test.ts` `volume: 30` -> a plausible dB value.
- `url-codec.test.ts` assertion-free "encoded size report" test - **already gone**, no such test exists in the current file (388 lines vs the issue's line ~407-418 reference).
- `midi-exporter.test.ts` "knob 100" comment and `url-codec-reorder.test.ts` "v2 codec" - both fixed.

## Sanctioned behavior changes (only two, both requested by the issue)
1. `AudioEngine.getDiagnostics()` gained a `sampleRate` field; `about-dialog.tsx` now reads it from there instead of calling `tone`'s `getContext()` directly.
2. `usePresetMetaStore.loadPreset` renamed to `setLoadedPresetMeta` (pure rename, same signature/behavior).

Everything else is comments, docs, test literals, and non-functional renames.

## Gates
- `pnpm test` - 827 passed, 4 skipped, 0 failed
- `pnpm build` - `tsc` + `vite build` clean
- `pnpm lint` - `oxlint src --max-warnings 0` clean
- `pnpm prettier . --check` - clean

## Grep sweep evidence
```
$ grep -rn "\.loadPreset(\|knobToDomain\|usePresetLoading\.loadPreset" src e2e | grep -v downloadPreset
(clean)

$ grep -rn '\bmigrate\.ts\b' src docs e2e
(clean)

$ grep -rn "RotaryKnobFutureSeams" src docs e2e
(clean)

$ grep -rn "v2 compact\|v2 codec\|v2 decoder\|v2 payload" src | grep -v "\.test\."
(clean)
```
A broader `"0-100"`/`"knob"` sweep across `src` was reviewed by hand: remaining hits are the `RotaryKnob` widget component name, honest negation statements ("no knob mapping", "not knob values" - confirming canonical purity, not lying), the legacy-read island's own history (`document/`, `session/`, `library/`, `types/legacy-v1.ts`), and honest percent/velocity displays (`0-100` velocity ints, which are pattern-codec quantization, not UI knob positions).