### PR TITLE
improve(menu): move undo/redo into their own section (#404)

### DIFF
--- a/src/layout/floating-menu.tsx
+++ b/src/layout/floating-menu.tsx
@@ -83,15 +83,6 @@ function FloatingMenu() {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" side="right">
-          <DropdownMenuItem onSelect={undo} disabled={!canUndo}>
-            Undo
-            <DropdownMenuShortcut>{UNDO_SHORTCUT_LABEL}</DropdownMenuShortcut>
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={redo} disabled={!canRedo}>
-            Redo
-            <DropdownMenuShortcut>{REDO_SHORTCUT_LABEL}</DropdownMenuShortcut>
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setIsAboutOpen(true)}>
             About Drumhaus
           </DropdownMenuItem>
@@ -116,6 +107,15 @@ function FloatingMenu() {
             }}
           >
             Report an Issue
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={undo} disabled={!canUndo}>
+            Undo
+            <DropdownMenuShortcut>{UNDO_SHORTCUT_LABEL}</DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={redo} disabled={!canRedo}>
+            Redo
+            <DropdownMenuShortcut>{REDO_SHORTCUT_LABEL}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuCheckboxItem


### PR DESCRIPTION
Fixes #404

Moves the Undo/Redo menu items out of the top of the floating menu and into their own separator-delimited section between "Report an Issue" and "Night Mode", restoring the original top 3 items to the top of the menu.

Final menu order, top to bottom:

1. About Drumhaus
2. Donate
3. Report an Issue
---
4. Undo (⌘Z)
5. Redo (⇧⌘Z)
---
6. Night Mode
7. Debug Mode
8. Potato Mode
---
9. Resize App

Pure reorder: no markup, styling, or behavior changes beyond item order and the one new separator section. The section separators reuse the existing `DropdownMenuSeparator` idiom already used in this menu.

Verified:
- `pnpm lint` clean
- `pnpm test`: 846 passed, 4 skipped
- `pnpm build` succeeds
- `pnpm test:e2e undo-redo`: 5 passed (spec drives this menu)
- Opened the menu in the running app via Playwright and confirmed the rendered order matches the list above