### PR TITLE
fix(param-control): end knob drag when primary button releases mid-chord (#402)

### DIFF
--- a/src/shared/param-control/__tests__/linear-slider.browser.test.ts
+++ b/src/shared/param-control/__tests__/linear-slider.browser.test.ts
@@ -135,6 +135,9 @@ async function pointer(
         bubbles: true,
         cancelable: true,
         shiftKey,
+        // Match a real left-button gesture: bit 0 of `buttons` is held
+        // through down and move and cleared on up.
+        buttons: type === "pointerup" ? 0 : 1,
       }),
     );
   });

--- a/src/shared/param-control/__tests__/rotary-knob.browser.test.ts
+++ b/src/shared/param-control/__tests__/rotary-knob.browser.test.ts
@@ -104,7 +104,12 @@ function last(): number {
   return recorded.changes[recorded.changes.length - 1];
 }
 
-async function pointer(type: string, clientY: number, shiftKey = false) {
+async function pointer(
+  type: string,
+  clientY: number,
+  shiftKey = false,
+  init: PointerEventInit = {},
+) {
   await act(async () => {
     const target = type === "pointerdown" ? slider() : window;
     target.dispatchEvent(
@@ -115,6 +120,10 @@ async function pointer(type: string, clientY: number, shiftKey = false) {
         bubbles: true,
         cancelable: true,
         shiftKey,
+        // Match a real left-button gesture: bit 0 of `buttons` is held through
+        // down and move and cleared on up. Chord tests override via `init`.
+        buttons: type === "pointerup" ? 0 : 1,
+        ...init,
       }),
     );
   });
@@ -155,6 +164,58 @@ describe("RotaryKnob interactions (canonical-only public API)", () => {
     await pointer("pointerup", 80);
     expect(recorded.gestureStarts).toBe(1);
     expect(recorded.gestureEnds).toBe(1);
+  });
+
+  it("ends the drag when the primary button releases mid-chord (#402)", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 95); // promote (no change)
+    await pointer("pointermove", 75); // +20px -> 60
+    // Chord: right button pressed, then left released. Per the pointer events
+    // spec neither transition fires pointerdown/pointerup on this pointer;
+    // the left release arrives as a pointermove with buttons=2.
+    await pointer("pointermove", 70, false, { buttons: 2 });
+    expect(recorded.gestureEnds).toBe(1);
+    const settled = last();
+    expect(settled).toBeCloseTo(60, 6);
+    // Further movement with no button held must not turn the knob.
+    await pointer("pointermove", 40, false, { buttons: 0 });
+    expect(last()).toBe(settled);
+    expect(recorded.gestureStarts).toBe(1);
+    expect(recorded.gestureEnds).toBe(1);
+  });
+
+  it("a right-button press never starts a drag (#402)", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100, false, { button: 2, buttons: 2 });
+    await pointer("pointermove", 80, false, { buttons: 2 });
+    await pointer("pointerup", 80, false, { button: 2 });
+    expect(recorded.changes).toHaveLength(0);
+    expect(recorded.gestureStarts).toBe(0);
+    expect(recorded.gestureEnds).toBe(0);
+  });
+
+  it("suppresses the context menu while a drag is live (#402)", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 90);
+    const during = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      window.dispatchEvent(during);
+    });
+    expect(during.defaultPrevented).toBe(true);
+    await pointer("pointerup", 90);
+    const after = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    await act(async () => {
+      window.dispatchEvent(after);
+    });
+    expect(after.defaultPrevented).toBe(false);
   });
 
   it("resets to default on double-click of the body", async () => {

--- a/src/shared/param-control/__tests__/value-field.browser.test.ts
+++ b/src/shared/param-control/__tests__/value-field.browser.test.ts
@@ -99,7 +99,12 @@ function last(): number {
   return recorded.changes[recorded.changes.length - 1];
 }
 
-async function pointer(type: string, clientY: number, shiftKey = false) {
+async function pointer(
+  type: string,
+  clientY: number,
+  shiftKey = false,
+  init: PointerEventInit = {},
+) {
   await act(async () => {
     const target = type === "pointerdown" ? field() : window;
     target.dispatchEvent(
@@ -110,6 +115,10 @@ async function pointer(type: string, clientY: number, shiftKey = false) {
         bubbles: true,
         cancelable: true,
         shiftKey,
+        // Match a real left-button gesture: bit 0 of `buttons` is held through
+        // down and move and cleared on up. Chord tests override via `init`.
+        buttons: type === "pointerup" ? 0 : 1,
+        ...init,
       }),
     );
   });
@@ -149,6 +158,23 @@ describe("ValueField interactions (canonical-only public API)", () => {
     expect(input()).not.toBeNull();
     // No value change on a pure tap.
     expect(recorded.changes).toHaveLength(0);
+  });
+
+  it("a chorded release of the primary button is not a tap: no editor (#402)", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    // Right button pressed, then left released before any movement: the
+    // release arrives as a pointermove with buttons=2 and cancels the press
+    // rather than opening the type-in editor.
+    await pointer("pointermove", 100, false, { buttons: 2 });
+    expect(input()).toBeNull();
+    // The press is already over, so the right button's eventual pointerup
+    // (the last button up on this pointer) must not read as a tap either.
+    await pointer("pointerup", 100, false, { button: 2 });
+    expect(input()).toBeNull();
+    expect(recorded.changes).toHaveLength(0);
+    expect(recorded.gestureStarts).toBe(0);
+    expect(recorded.gestureEnds).toBe(0);
   });
 
   it("fires onGestureStart / onGestureEnd exactly once per drag", async () => {

--- a/src/shared/param-control/components/rotary-knob.tsx
+++ b/src/shared/param-control/components/rotary-knob.tsx
@@ -102,6 +102,9 @@ function RotaryKnobBody({
   const handlePointerDown = useCallback(
     (event: React.PointerEvent) => {
       if (disabled) return;
+      // Mirror the engine: non-primary presses never start a gesture (#402),
+      // so guidance must not track one either.
+      if (event.button !== 0) return;
       updateTooltipSide();
 
       guidance.handleStart({ x: event.clientX, y: event.clientY });

--- a/src/shared/param-control/hooks/use-param-control.ts
+++ b/src/shared/param-control/hooks/use-param-control.ts
@@ -257,54 +257,6 @@ function useParamControl<T>({
 
   // --- Drag ---
 
-  const handlePointerMove = useCallback((event: PointerEvent) => {
-    event.preventDefault();
-    const {
-      descriptor: d,
-      onChange: emit,
-      dragAxis: axis,
-      dragThreshold: threshold,
-    } = latest.current;
-
-    const x = event.clientX;
-    const y = event.clientY;
-
-    // Pending press: promote to a drag only once movement clears the threshold.
-    if (phaseRef.current === "pending") {
-      const moved =
-        axis === "horizontal"
-          ? Math.abs(x - startPointRef.current.x)
-          : Math.abs(y - startPointRef.current.y);
-      if (moved < threshold) return;
-      phaseRef.current = "dragging";
-      lastPointRef.current = { x, y };
-      setIsDragging(true);
-      latest.current.onGestureStart?.();
-      return;
-    }
-
-    if (phaseRef.current !== "dragging") return;
-
-    // Up (vertical) or right (horizontal) increases the value.
-    const increment =
-      axis === "horizontal"
-        ? x - lastPointRef.current.x
-        : lastPointRef.current.y - y;
-    lastPointRef.current = { x, y };
-
-    const sensitivity =
-      latest.current.dragSensitivity ??
-      d.dragSensitivity ??
-      DEFAULT_DRAG_SENSITIVITY;
-    const fine = event.shiftKey;
-    const factor = fine ? (d.fineDragFactor ?? DEFAULT_FINE_DRAG_FACTOR) : 1;
-
-    rawPositionRef.current = clamp01(
-      rawPositionRef.current + increment * sensitivity * factor,
-    );
-    emit(normalizedToCanonical(d, rawPositionRef.current, { fine }));
-  }, []);
-
   const endGesture = useCallback((cancelled: boolean) => {
     const phase = phaseRef.current;
     phaseRef.current = "idle";
@@ -322,9 +274,76 @@ function useParamControl<T>({
     }
   }, []);
 
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      // Chorded button presses on one pointer don't fire pointerdown/pointerup
+      // per the pointer events spec: only the first button down and the last
+      // button up do. Releasing the primary button while another is held (e.g.
+      // a right-click chord) arrives as a pointermove with bit 0 of `buttons`
+      // cleared, so end the gesture here or the drag outlives the button
+      // (#402). This also self-heals any other missed-pointerup path. Touch
+      // and pen keep bit 0 set while in contact, so they are unaffected.
+      // Cancelled (not a tap): a chorded press should never open the editor.
+      if ((event.buttons & 1) === 0) {
+        endGesture(true);
+        return;
+      }
+
+      event.preventDefault();
+      const {
+        descriptor: d,
+        onChange: emit,
+        dragAxis: axis,
+        dragThreshold: threshold,
+      } = latest.current;
+
+      const x = event.clientX;
+      const y = event.clientY;
+
+      // Pending press: promote to a drag only once movement clears the threshold.
+      if (phaseRef.current === "pending") {
+        const moved =
+          axis === "horizontal"
+            ? Math.abs(x - startPointRef.current.x)
+            : Math.abs(y - startPointRef.current.y);
+        if (moved < threshold) return;
+        phaseRef.current = "dragging";
+        lastPointRef.current = { x, y };
+        setIsDragging(true);
+        latest.current.onGestureStart?.();
+        return;
+      }
+
+      if (phaseRef.current !== "dragging") return;
+
+      // Up (vertical) or right (horizontal) increases the value.
+      const increment =
+        axis === "horizontal"
+          ? x - lastPointRef.current.x
+          : lastPointRef.current.y - y;
+      lastPointRef.current = { x, y };
+
+      const sensitivity =
+        latest.current.dragSensitivity ??
+        d.dragSensitivity ??
+        DEFAULT_DRAG_SENSITIVITY;
+      const fine = event.shiftKey;
+      const factor = fine ? (d.fineDragFactor ?? DEFAULT_FINE_DRAG_FACTOR) : 1;
+
+      rawPositionRef.current = clamp01(
+        rawPositionRef.current + increment * sensitivity * factor,
+      );
+      emit(normalizedToCanonical(d, rawPositionRef.current, { fine }));
+    },
+    [endGesture],
+  );
+
   const handlePointerDown = useCallback(
     (event: React.PointerEvent) => {
       if (disabled) return;
+      // Only the primary button (or touch/pen contact, also button 0) starts a
+      // gesture: a right- or middle-click never begins a drag or edit (#402).
+      if (event.button !== 0) return;
       event.preventDefault();
       rawPositionRef.current = canonicalToNormalized(descriptor, value);
       startPointRef.current = { x: event.clientX, y: event.clientY };
@@ -353,15 +372,20 @@ function useParamControl<T>({
     const onMove = (event: PointerEvent) => handlePointerMove(event);
     const onUp = () => endGesture(false);
     const onCancel = () => endGesture(true);
+    // While a gesture is live, a right-click is part of the chord, not a menu
+    // request: suppress the context menu, matching hardware feel (#402).
+    const onContextMenu = (event: Event) => event.preventDefault();
     const options: AddEventListenerOptions = { passive: false };
 
     window.addEventListener("pointermove", onMove, options);
     window.addEventListener("pointerup", onUp);
     window.addEventListener("pointercancel", onCancel);
+    window.addEventListener("contextmenu", onContextMenu);
     return () => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("contextmenu", onContextMenu);
     };
   }, [tracking, handlePointerMove, endGesture]);
 


### PR DESCRIPTION
Fixes #402

## Mechanism

Per the pointer events spec, chorded button presses on a single pointer do not fire `pointerdown`/`pointerup` per button: only the FIRST button down fires `pointerdown` and the LAST button up fires `pointerup`. Intermediate transitions arrive as `pointermove` with a changed `buttons` bitmask.

The drag lifecycle in `use-param-control.ts` attached window listeners while tracking and only ended the gesture on `pointerup`/`pointercancel`. So: left-hold a knob, press right mid-drag, release left - the release arrives as a `pointermove` with `buttons === 2`, no `pointerup` fires, and the gesture never ends. The right button's eventual release is consumed by the context menu, orphaning the drag: the knob keeps turning with no button held until the next click.

## Fix

All three directions from the issue:

1. **Move handler ends the gesture when `(event.buttons & 1) === 0`** - the primary button is no longer down. This goes through the same `endGesture` path as `pointerup`, so `onGestureEnd` fires and the history undo unit (#240/#400) commits correctly. It also self-heals any other missed-pointerup path. Touch and pen keep bit 0 of `buttons` set while in contact, so those input types are unaffected. The chorded release is treated as a cancel for tap purposes, so a pending press on a value field does not open the type-in editor.
2. **`handlePointerDown` ignores non-primary presses** (`event.button !== 0`), so a right- or middle-click never starts a drag or edit gesture. Touch and pen contact are button 0, so they still start gestures. The knob-guidance tracker in `rotary-knob.tsx` composes its own window listeners with the engine's pointer-down, so it gets the same guard - otherwise guidance would track a drag the engine never started.
3. **`contextmenu` is `preventDefault`ed while a gesture is live**, matching hardware feel (no browser menu mid-gesture). The listener attaches and detaches with the existing tracking effect.

## Tests

New browser tests (real Chromium, real events), all verified to FAIL against the unfixed hook and pass with it:

- RotaryKnob: chorded right-press then left-release (pointermove with `buttons: 2`) ends the gesture, fires `onGestureEnd` exactly once, and further motion no longer turns the knob
- RotaryKnob: a right-button `pointerdown` never starts a drag
- RotaryKnob: contextmenu is suppressed during a drag and allowed again after
- ValueField: a chorded release in the pending (pre-threshold) phase is not a tap - neither it nor the right button's later `pointerup` opens the editor

The test pointer helpers in all three param-control browser test files now dispatch realistic `buttons` bitmasks (bit 0 held through down/move, cleared on up), matching what browsers actually send, so the existing left-drag coverage exercises the new check on every move.

## Verification

- `pnpm lint` clean
- `pnpm test`: 850 passed, 4 skipped (57 files + 1 skipped)
- `pnpm build` clean