### PR TITLE
@haus/bridge: serverless cross-instrument session sync (#416)

### DIFF
--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -1,0 +1,176 @@
+# @haus/bridge
+
+Serverless cross-instrument session sync for the haus family.
+A framework-free, zero-runtime-dependency TypeScript library that lets multiple browser instruments open on the same origin share a musical session: tempo, transport, and scene.
+This README is the protocol's document of record (protocol v1).
+
+## Summary
+
+Instruments in different tabs join one session over a `BroadcastChannel`.
+One tab, elected via the Web Locks API, is the conductor and owns the session state; everyone else follows.
+The session's musical grid is fully determined by `(startEpochMs, bpm)`: no position or phase messages exist, every tab derives the grid deterministically from the shared epoch clock and self-corrects locally.
+
+```ts
+import { createHausSession, epochToContextTime } from "@haus/bridge";
+
+const session = createHausSession({ instrument: "drumhaus" });
+session.connect();
+
+session.onStateChange((state) => {
+  if (state.playing && state.startEpochMs !== null) {
+    // Schedule bar 0 beat 0 on your own AudioContext.
+    const downbeat = epochToContextTime(audioContext, state.startEpochMs);
+    engine.startAt(downbeat, state.bpm);
+  } else {
+    engine.stop();
+  }
+});
+
+session.play(); // any peer may request; the conductor applies
+session.setBpm(150);
+session.setScene(2);
+session.disconnect();
+```
+
+## Timing model
+
+### The shared epoch clock
+
+Every peer reads the same clock:
+
+```
+epochNowMs() = performance.timeOrigin + performance.now()
+```
+
+Same-machine, same-browser tabs agree on this clock to about 1ms, which is what makes a purely derived grid possible.
+This is also the session boundary: the protocol only works where that clock (and `BroadcastChannel`, and Web Locks) is shared, i.e. same origin, same browser, same machine.
+
+### The grid
+
+The session is fixed 4/4 in v1: one bar is four beats at the session bpm.
+This is deliberate and carries no protocol field; a future protocol version would add one.
+
+Given `SessionState`:
+
+```ts
+{
+  rev: number; // conductor-owned revision counter
+  bpm: number; // clamped to [40, 300]
+  playing: boolean;
+  startEpochMs: number | null; // epoch instant of bar 0 beat 0; null when stopped
+  scene: 0 | 1 | 2 | 3;
+}
+```
+
+the grid is:
+
+```
+beatMs(bpm)  = 60000 / bpm
+barMs(bpm)   = 4 * beatMs(bpm)
+beats(t)     = (t - startEpochMs) / beatMs(bpm)
+bars(t)      = beats(t) / 4
+```
+
+`playing` and `startEpochMs` are always consistent: a derivable grid exists exactly while playing, and messages violating that invariant are rejected as malformed.
+
+### Play and stop
+
+On play, the conductor sets `startEpochMs = epochNowMs() + START_LEAD_MS` (200ms of lead), so every tab receives the state and schedules the downbeat ahead of time.
+`beats(t)` is negative during the lead window; it is a count-in.
+On stop, `playing = false` and `startEpochMs = null`.
+
+### Tempo change while playing
+
+The conductor rebases the grid so the beat position at the decision instant `t` is identical under both tempos:
+
+```
+B            = (t - startEpochMs) / beatMs(oldBpm)   // beats elapsed at t
+startEpochMs' = t - B * beatMs(newBpm)
+```
+
+The change is immediate, not bar-quantized; phase is continuous, so followers glide to the new rate without a jump.
+While stopped, a tempo change just sets `bpm`.
+
+### Scene
+
+`scene` is a bare index 0-3.
+Its semantics (which pattern, which kit, which anything) belong to each instrument, not to the protocol.
+
+### AudioContext mapping
+
+Instruments schedule on their own `AudioContext`, so the library maps between epoch time and context time:
+
+```
+epochToContextTime(ctx, epochMs)  -> seconds on ctx's clock
+contextTimeToEpochMs(ctx, s)      -> epoch milliseconds
+```
+
+The mapping anchors on `ctx.getOutputTimestamp()`, which pairs a context time with the `performance.now()` instant at which that audio reaches the output, so epoch-scheduled events line up at the speaker.
+Fallback: when `getOutputTimestamp` is unavailable (older WebKit) or returns zeros (a context that has not produced output yet, e.g. suspended), the anchor is `ctx.currentTime` sampled against the epoch clock directly.
+The fallback ignores output latency but stays within a few milliseconds, consistent with the library's contract below.
+
+## Roles and election
+
+Conductor election uses the Web Locks API: every connected peer requests the `haus:conductor` lock and holds it for the session instance's lifetime once granted.
+The lock holder is the conductor.
+On tab close, crash, or navigation, the browser releases the lock and the next waiter is granted it, with no protocol traffic involved.
+On acquiring conductorship, the new conductor rebroadcasts the last-seen state with the same `rev`, so late joiners and peers in the handover window converge on its view.
+
+A solo tab acquires the lock immediately and is its own conductor; the library is near-zero-cost in this mode (one heartbeat broadcast every 2s).
+
+Web Locks are same-origin, per-browser, per-machine - the same boundary as the rest of the protocol - and require a secure context.
+Supported in Chrome 69+, Edge 79+, Firefox 96+, and Safari 15.4+.
+If the API is missing entirely, the election degrades to each tab conducting itself; cross-tab conductor dedup requires Web Locks.
+
+## Messages
+
+All messages travel on one `BroadcastChannel` (`haus-session`) with the envelope `{ v: 1, type, from: peerId, ... }`.
+Peer identity is a random id per session instance (`crypto.randomUUID`), plus a caller-provided `{ instrument, label? }` descriptor.
+
+| type        | sender    | payload  | purpose                                                                        |
+| ----------- | --------- | -------- | ------------------------------------------------------------------------------ |
+| `hello`     | any       | `peer`   | announce joining; peers reply with `heartbeat`, the conductor replies `state`  |
+| `heartbeat` | any       | `peer`   | liveness, every 2000ms; peers are dropped after 5500ms of silence              |
+| `intent`    | any       | `intent` | request `setBpm` \| `play` \| `stop` \| `setScene`; only the conductor applies |
+| `state`     | conductor | `state`  | the full `SessionState`; followers adopt it when `rev >=` their local `rev`    |
+| `goodbye`   | any       | -        | leave immediately, without waiting for the timeout                             |
+
+Rules:
+
+- The conductor bumps `rev` on every change it applies (its own commands and accepted intents) and broadcasts the full state.
+- Followers never self-apply; their commands become intents and take effect when the conductor's state comes back.
+- The `rev >= local rev` guard makes duplicate and handover-window rebroadcasts harmless.
+- Messages that are not well-formed protocol v1 (`v !== 1`, unknown type, malformed payload, out-of-range values) are rejected defensively; peers speaking a future protocol version may share the channel someday.
+
+### Handover semantics
+
+Conductorship transfer is not atomic: between the old conductor releasing the lock and the new one acquiring it, intents have no one to apply them.
+Intents arriving in that window may be lost.
+This is an accepted v1 tradeoff: intents are user gestures (a knob turn, a play press) and the user simply repeats one in the rare case it lands in a handover.
+
+## v1 boundaries
+
+These are design decisions, not omissions:
+
+- **Same origin only.** The transport, the election, and the epoch clock are all same-origin, same-browser, same-machine. Nothing crosses the network.
+- **Fixed 4/4.** No time-signature field exists in v1.
+- **No swing in the protocol.** Swing is instrument-local feel by design: the session shares the straight grid, and each instrument applies its own groove against it.
+- **Musically tight, not sample-locked.** The epoch clock aligns tabs to about a millisecond, which is tight enough to feel like one instrument. Sample-accurate cross-tab alignment is out of scope; each instrument owns its own AudioContext.
+- **Scene semantics are instrument-owned.** The protocol moves an index, nothing more.
+- **Intents may be lost during a conductor handover** (see above).
+
+## Package layout
+
+| module         | contents                                                                       |
+| -------------- | ------------------------------------------------------------------------------ |
+| `types.ts`     | protocol types, constants, and the defensive envelope parser                   |
+| `clock.ts`     | pure grid math, tempo rebase, epoch and AudioContext time mapping              |
+| `transport.ts` | the `BridgeTransport` seam: `broadcastChannelTransport`, `memoryHub` for tests |
+| `election.ts`  | conductor election over Web Locks                                              |
+| `session.ts`   | `createHausSession`, the facade wiring all of the above together               |
+
+`createHausSession({ instrument, label?, transport?, now?, locks? })` accepts injectable transport, clock, and locks, so the whole session is deterministic under test; the defaults are the real `BroadcastChannel`, `epochNowMs`, and `navigator.locks`.
+
+## Testing
+
+`pnpm test` runs two vitest projects: pure node tests for grid math, reducer logic, envelope validation, election, and peer bookkeeping, and browser-mode tests (real Chromium via Playwright) where multiple sessions in one page converge over a real `BroadcastChannel` and hand off conductorship over real Web Locks.

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@haus/bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "oxlint src --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@vitest/browser-playwright": "^4.1.10",
+    "oxlint": "^1.71.0",
+    "playwright": "^1.61.1",
+    "typescript": "^6",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/bridge/src/__tests__/clock.browser.test.ts
+++ b/packages/bridge/src/__tests__/clock.browser.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The AudioContext clock mapping against a real AudioContext. A fresh
+ * context in an automated browser may be suspended (no gesture), which is
+ * exactly the environment the getOutputTimestamp-zeros fallback exists for -
+ * these assertions hold on either anchor path.
+ */
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { contextTimeToEpochMs, epochNowMs, epochToContextTime } from "../clock";
+
+const ctx = new AudioContext();
+
+afterAll(async () => {
+  await ctx.close();
+});
+
+describe("AudioContext mapping with a real context", () => {
+  it("maps epoch time to context time with unit slope", () => {
+    const target = epochNowMs() + 500;
+    const t1 = epochToContextTime(ctx, target);
+    const t2 = epochToContextTime(ctx, target + 1000);
+    expect(Number.isFinite(t1)).toBe(true);
+    // 1000ms of epoch time is 1s of context time (allow anchor re-sampling).
+    expect(t2 - t1).toBeCloseTo(1, 3);
+  });
+
+  it("round-trips epoch -> context -> epoch within a few milliseconds", () => {
+    const target = epochNowMs() + 500;
+    const contextTime = epochToContextTime(ctx, target);
+    const roundTrip = contextTimeToEpochMs(ctx, contextTime);
+    expect(Math.abs(roundTrip - target)).toBeLessThan(50);
+  });
+});

--- a/packages/bridge/src/__tests__/clock.test.ts
+++ b/packages/bridge/src/__tests__/clock.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure grid math: beat/bar durations, position derivation, phase-preserving
+ * tempo rebase (property-style over random bpm pairs and instants), and the
+ * AudioContext clock mapping including the getOutputTimestamp fallback.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  barMs,
+  barsAt,
+  beatMs,
+  beatsAt,
+  clampBpm,
+  contextTimeToEpochMs,
+  epochNowMs,
+  epochToContextTime,
+  nextBarStartEpochMs,
+  rebaseTempo,
+  type BridgeAudioContext,
+} from "../clock";
+import type { SessionState } from "../types";
+
+function playingState(bpm: number, startEpochMs: number): SessionState {
+  return { rev: 0, bpm, playing: true, startEpochMs, scene: 0 };
+}
+
+const STOPPED: SessionState = {
+  rev: 0,
+  bpm: 120,
+  playing: false,
+  startEpochMs: null,
+  scene: 0,
+};
+
+describe("epochNowMs", () => {
+  it("is finite and monotonically non-decreasing", () => {
+    const a = epochNowMs();
+    const b = epochNowMs();
+    expect(Number.isFinite(a)).toBe(true);
+    expect(b).toBeGreaterThanOrEqual(a);
+  });
+});
+
+describe("durations", () => {
+  it("derives beat and bar durations from bpm", () => {
+    expect(beatMs(120)).toBe(500);
+    expect(beatMs(60)).toBe(1000);
+    expect(barMs(120)).toBe(2000);
+  });
+
+  it("clamps bpm to the protocol range", () => {
+    expect(clampBpm(10)).toBe(40);
+    expect(clampBpm(1000)).toBe(300);
+    expect(clampBpm(174)).toBe(174);
+  });
+});
+
+describe("position derivation", () => {
+  const state = playingState(120, 1000);
+
+  it("derives beats and bars from (startEpochMs, bpm)", () => {
+    expect(beatsAt(state, 1000)).toBe(0);
+    expect(beatsAt(state, 2000)).toBe(2);
+    expect(barsAt(state, 3000)).toBe(1);
+  });
+
+  it("is negative during the start lead window", () => {
+    expect(beatsAt(state, 900)).toBeCloseTo(-0.2, 10);
+  });
+
+  it("returns null while stopped", () => {
+    expect(beatsAt(STOPPED, 1000)).toBeNull();
+    expect(barsAt(STOPPED, 1000)).toBeNull();
+    expect(nextBarStartEpochMs(STOPPED, 1000)).toBeNull();
+  });
+
+  it("finds the first bar boundary strictly after the instant", () => {
+    expect(nextBarStartEpochMs(state, 1001)).toBe(3000);
+    expect(nextBarStartEpochMs(state, 2999)).toBe(3000);
+    // Exactly on a boundary: strictly after means the following bar.
+    expect(nextBarStartEpochMs(state, 3000)).toBe(5000);
+    // During the lead window the next boundary is bar 0's downbeat.
+    expect(nextBarStartEpochMs(state, 900)).toBe(1000);
+  });
+});
+
+describe("rebaseTempo", () => {
+  it("preserves phase continuity at the decision instant", () => {
+    const state = playingState(120, 10_000);
+    const rebased = rebaseTempo(state, 150, 14_000);
+    expect(rebased.bpm).toBe(150);
+    expect(beatsAt(rebased, 14_000)).toBeCloseTo(beatsAt(state, 14_000)!, 9);
+  });
+
+  it("preserves phase over random bpm pairs and instants", () => {
+    for (let i = 0; i < 250; i++) {
+      const oldBpm = 40 + Math.random() * 260;
+      const newBpm = 40 + Math.random() * 260;
+      const start = 1.7e12 + Math.random() * 1e7;
+      // Instants both after the downbeat and inside the lead window.
+      const at = start + (Math.random() - 0.1) * 600_000;
+      const state = playingState(oldBpm, start);
+      const rebased = rebaseTempo(state, newBpm, at);
+      expect(rebased.playing).toBe(true);
+      expect(beatsAt(rebased, at)!).toBeCloseTo(beatsAt(state, at)!, 5);
+      // Past the decision instant the new grid advances at the new rate.
+      const later = at + 10_000;
+      expect(beatsAt(rebased, later)!).toBeCloseTo(
+        beatsAt(state, at)! + 10_000 / beatMs(newBpm),
+        5,
+      );
+    }
+  });
+
+  it("only sets bpm while stopped", () => {
+    const rebased = rebaseTempo(STOPPED, 90, 5000);
+    expect(rebased).toEqual({ ...STOPPED, bpm: 90 });
+  });
+
+  it("clamps the new bpm", () => {
+    const state = playingState(120, 1000);
+    expect(rebaseTempo(state, 9999, 2000).bpm).toBe(300);
+    expect(rebaseTempo(STOPPED, 1, 2000).bpm).toBe(40);
+  });
+
+  it("does not bump rev (rev is the conductor's job)", () => {
+    const state = { ...playingState(120, 1000), rev: 7 };
+    expect(rebaseTempo(state, 90, 2000).rev).toBe(7);
+  });
+});
+
+describe("AudioContext clock mapping", () => {
+  it("anchors on getOutputTimestamp when it reports real output", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 99, // must be ignored when the timestamp is valid
+      getOutputTimestamp: () => ({ contextTime: 1.5, performanceTime: 2500 }),
+    };
+    const anchorEpochMs = performance.timeOrigin + 2500;
+    expect(epochToContextTime(ctx, anchorEpochMs)).toBeCloseTo(1.5, 9);
+    expect(epochToContextTime(ctx, anchorEpochMs + 1000)).toBeCloseTo(2.5, 9);
+    expect(contextTimeToEpochMs(ctx, 2.5)).toBeCloseTo(anchorEpochMs + 1000, 6);
+  });
+
+  it("falls back to currentTime when getOutputTimestamp is unavailable", () => {
+    const ctx: BridgeAudioContext = { currentTime: 3 };
+    const epochNow = () => 50_000;
+    expect(epochToContextTime(ctx, 51_000, epochNow)).toBeCloseTo(4, 9);
+    expect(contextTimeToEpochMs(ctx, 2, epochNow)).toBeCloseTo(49_000, 9);
+  });
+
+  it("falls back when getOutputTimestamp returns zeros (no output yet)", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 0,
+      getOutputTimestamp: () => ({ contextTime: 0, performanceTime: 0 }),
+    };
+    const epochNow = () => 10_000;
+    expect(epochToContextTime(ctx, 10_200, epochNow)).toBeCloseTo(0.2, 9);
+  });
+
+  it("falls back when getOutputTimestamp returns an empty object", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 1,
+      getOutputTimestamp: () => ({}),
+    };
+    const epochNow = () => 10_000;
+    expect(epochToContextTime(ctx, 10_500, epochNow)).toBeCloseTo(1.5, 9);
+  });
+
+  it("round-trips epoch to context time and back", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 12.25,
+      getOutputTimestamp: () => ({ contextTime: 12.5, performanceTime: 700 }),
+    };
+    const target = performance.timeOrigin + 12_345;
+    const contextTime = epochToContextTime(ctx, target);
+    expect(contextTimeToEpochMs(ctx, contextTime)).toBeCloseTo(target, 6);
+  });
+});

--- a/packages/bridge/src/__tests__/election.test.ts
+++ b/packages/bridge/src/__tests__/election.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Conductor election over an injectable lock manager: FIFO acquisition,
+ * handoff on stop, withdrawn requests never acquiring, and the solo fallback
+ * when no Web Locks API exists at all.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { createConductorElection } from "../election";
+import { flushMicrotasks, memoryLocks } from "./helpers/memory-locks";
+
+describe("createConductorElection", () => {
+  it("grants the first requester", async () => {
+    const locks = memoryLocks();
+    let acquired = 0;
+    const election = createConductorElection({
+      locks,
+      onAcquired: () => acquired++,
+    });
+    election.start();
+    await flushMicrotasks();
+    expect(acquired).toBe(1);
+    election.stop();
+  });
+
+  it("queues a second requester until the holder stops", async () => {
+    const locks = memoryLocks();
+    let first = 0;
+    let second = 0;
+    const a = createConductorElection({ locks, onAcquired: () => first++ });
+    const b = createConductorElection({ locks, onAcquired: () => second++ });
+    a.start();
+    await flushMicrotasks();
+    b.start();
+    await flushMicrotasks();
+    expect(first).toBe(1);
+    expect(second).toBe(0);
+
+    a.stop();
+    await flushMicrotasks();
+    expect(second).toBe(1);
+    b.stop();
+  });
+
+  it("never grants a request withdrawn while pending", async () => {
+    const locks = memoryLocks();
+    let second = 0;
+    const a = createConductorElection({ locks, onAcquired: () => {} });
+    const b = createConductorElection({ locks, onAcquired: () => second++ });
+    a.start();
+    await flushMicrotasks();
+    b.start();
+    b.stop();
+    a.stop();
+    await flushMicrotasks();
+    expect(second).toBe(0);
+  });
+
+  it("is idempotent while running", async () => {
+    const locks = memoryLocks();
+    let acquired = 0;
+    const election = createConductorElection({
+      locks,
+      onAcquired: () => acquired++,
+    });
+    election.start();
+    election.start();
+    await flushMicrotasks();
+    expect(acquired).toBe(1);
+    election.stop();
+    election.stop();
+  });
+
+  it("falls back to solo conductorship without a Web Locks API", async () => {
+    // No injected locks and (in node) no usable navigator.locks: the
+    // documented degradation is that this peer conducts itself immediately.
+    let acquired = 0;
+    const election = createConductorElection({ onAcquired: () => acquired++ });
+    election.start();
+    await flushMicrotasks();
+    expect(acquired).toBe(1);
+    election.stop();
+  });
+});

--- a/packages/bridge/src/__tests__/helpers/memory-locks.ts
+++ b/packages/bridge/src/__tests__/helpers/memory-locks.ts
@@ -1,0 +1,73 @@
+/**
+ * A deterministic in-memory Web Locks stand-in for node unit tests: FIFO
+ * grant order per name, held until the callback's promise settles, abortable
+ * while pending, abort ignored after grant - the semantics the election
+ * relies on.
+ */
+
+import type { HausLockManager } from "../../election";
+
+interface Waiter {
+  granted: boolean;
+  aborted: boolean;
+  run: () => void;
+}
+
+function memoryLocks(): HausLockManager {
+  const held = new Set<string>();
+  const queues = new Map<string, Waiter[]>();
+
+  function pump(name: string): void {
+    if (held.has(name)) return;
+    const queue = queues.get(name);
+    while (queue !== undefined && queue.length > 0) {
+      const waiter = queue.shift()!;
+      if (waiter.aborted) continue;
+      waiter.granted = true;
+      held.add(name);
+      queueMicrotask(waiter.run);
+      return;
+    }
+  }
+
+  return {
+    request(name, options, callback) {
+      return new Promise((resolve, reject) => {
+        const waiter: Waiter = {
+          granted: false,
+          aborted: false,
+          run: () => {
+            void (async () => {
+              try {
+                resolve(await callback());
+              } catch (error) {
+                reject(error);
+              } finally {
+                held.delete(name);
+                pump(name);
+              }
+            })();
+          },
+        };
+        options.signal?.addEventListener("abort", () => {
+          if (waiter.granted || waiter.aborted) return;
+          waiter.aborted = true;
+          reject(new DOMException("The request was aborted.", "AbortError"));
+        });
+        const queue = queues.get(name) ?? [];
+        queue.push(waiter);
+        queues.set(name, queue);
+        pump(name);
+      });
+    },
+  };
+}
+
+/** Drain chained microtasks (memory transport delivery, lock grants). */
+async function flushMicrotasks(rounds = 25): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
+export { flushMicrotasks, memoryLocks };

--- a/packages/bridge/src/__tests__/protocol.test.ts
+++ b/packages/bridge/src/__tests__/protocol.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Envelope validation: parseBridgeMessage must accept well-formed protocol v1
+ * messages and defensively reject everything else - other protocol versions
+ * may share the channel someday, and a malformed peer must never corrupt
+ * session state.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { parseBridgeMessage, type SessionState } from "../types";
+
+const VALID_STATE: SessionState = {
+  rev: 3,
+  bpm: 120,
+  playing: true,
+  startEpochMs: 1_000_000,
+  scene: 2,
+};
+
+describe("parseBridgeMessage", () => {
+  it("accepts every well-formed message type", () => {
+    const peer = { id: "p1", instrument: "drumhaus", label: "left" };
+    const messages = [
+      { v: 1, type: "hello", from: "p1", peer },
+      { v: 1, type: "heartbeat", from: "p1", peer },
+      { v: 1, type: "goodbye", from: "p1" },
+      { v: 1, type: "intent", from: "p1", intent: { kind: "setBpm", bpm: 90 } },
+      { v: 1, type: "intent", from: "p1", intent: { kind: "play" } },
+      { v: 1, type: "intent", from: "p1", intent: { kind: "stop" } },
+      {
+        v: 1,
+        type: "intent",
+        from: "p1",
+        intent: { kind: "setScene", scene: 3 },
+      },
+      { v: 1, type: "state", from: "p1", state: VALID_STATE },
+    ];
+    for (const msg of messages) {
+      expect(parseBridgeMessage(msg), JSON.stringify(msg)).toEqual(msg);
+    }
+  });
+
+  it("accepts a peer without a label", () => {
+    const msg = {
+      v: 1,
+      type: "hello",
+      from: "p1",
+      peer: { id: "p1", instrument: "drumhaus" },
+    };
+    expect(parseBridgeMessage(msg)).toEqual(msg);
+  });
+
+  it("rejects non-object data", () => {
+    expect(parseBridgeMessage(null)).toBeNull();
+    expect(parseBridgeMessage(undefined)).toBeNull();
+    expect(parseBridgeMessage(42)).toBeNull();
+    expect(parseBridgeMessage("hello")).toBeNull();
+  });
+
+  it("rejects any protocol version other than 1", () => {
+    const base = { type: "goodbye", from: "p1" };
+    expect(parseBridgeMessage({ ...base })).toBeNull();
+    expect(parseBridgeMessage({ ...base, v: 0 })).toBeNull();
+    expect(parseBridgeMessage({ ...base, v: 2 })).toBeNull();
+    expect(parseBridgeMessage({ ...base, v: "1" })).toBeNull();
+  });
+
+  it("rejects unknown types and missing senders", () => {
+    expect(
+      parseBridgeMessage({ v: 1, type: "position", from: "p1" }),
+    ).toBeNull();
+    expect(parseBridgeMessage({ v: 1, type: "goodbye" })).toBeNull();
+    expect(parseBridgeMessage({ v: 1, type: "goodbye", from: "" })).toBeNull();
+    expect(parseBridgeMessage({ v: 1, type: "goodbye", from: 7 })).toBeNull();
+  });
+
+  it("rejects hello/heartbeat whose peer contradicts the envelope", () => {
+    const peer = { id: "someone-else", instrument: "drumhaus" };
+    expect(
+      parseBridgeMessage({ v: 1, type: "hello", from: "p1", peer }),
+    ).toBeNull();
+    expect(parseBridgeMessage({ v: 1, type: "hello", from: "p1" })).toBeNull();
+    expect(
+      parseBridgeMessage({
+        v: 1,
+        type: "heartbeat",
+        from: "p1",
+        peer: { id: "p1" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects malformed intents", () => {
+    const intents = [
+      undefined,
+      {},
+      { kind: "warp" },
+      { kind: "setBpm" },
+      { kind: "setBpm", bpm: "90" },
+      { kind: "setBpm", bpm: Number.NaN },
+      { kind: "setBpm", bpm: Number.POSITIVE_INFINITY },
+      { kind: "setScene", scene: 4 },
+      { kind: "setScene", scene: 1.5 },
+      { kind: "setScene", scene: "1" },
+    ];
+    for (const intent of intents) {
+      expect(
+        parseBridgeMessage({ v: 1, type: "intent", from: "p1", intent }),
+        JSON.stringify(intent),
+      ).toBeNull();
+    }
+  });
+
+  it("rejects malformed states", () => {
+    const states = [
+      undefined,
+      {},
+      { ...VALID_STATE, rev: 1.5 },
+      { ...VALID_STATE, rev: "3" },
+      { ...VALID_STATE, bpm: 39 },
+      { ...VALID_STATE, bpm: 301 },
+      { ...VALID_STATE, bpm: Number.NaN },
+      { ...VALID_STATE, playing: "yes" },
+      { ...VALID_STATE, scene: 5 },
+      // Grid consistency: playing implies a start instant and vice versa.
+      { ...VALID_STATE, startEpochMs: null },
+      { ...VALID_STATE, playing: false },
+      { ...VALID_STATE, startEpochMs: Number.NaN },
+    ];
+    for (const state of states) {
+      expect(
+        parseBridgeMessage({ v: 1, type: "state", from: "p1", state }),
+        JSON.stringify(state),
+      ).toBeNull();
+    }
+  });
+});

--- a/packages/bridge/src/__tests__/session.browser.test.ts
+++ b/packages/bridge/src/__tests__/session.browser.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Real-browser integration: multiple createHausSession instances in one page
+ * over a real BroadcastChannel and real Web Locks. BroadcastChannel delivers
+ * between channel instances in the same context and Web Locks queue within
+ * one context exactly as across tabs, so this exercises the production code
+ * paths end to end. Lock names and channel names are scoped per test so
+ * suites cannot contend with each other.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { beatMs, beatsAt, epochNowMs } from "../clock";
+import type { HausLockManager } from "../election";
+import { createHausSession, type HausSession } from "../session";
+import { broadcastChannelTransport } from "../transport";
+import type { SessionState } from "../types";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+/** Scope the real Web Locks to this test so suites cannot interfere. */
+function scopedLocks(scope: string): HausLockManager {
+  return {
+    request: (name, options, callback) =>
+      navigator.locks.request(`${scope}:${name}`, options, callback),
+  };
+}
+
+function createScope(): (instrument: string, label?: string) => HausSession {
+  const scope = `haus-bridge-test-${crypto.randomUUID()}`;
+  return (instrument, label) => {
+    const transport = broadcastChannelTransport(`${scope}:channel`);
+    const session = createHausSession({
+      instrument,
+      ...(label !== undefined ? { label } : {}),
+      transport,
+      locks: scopedLocks(scope),
+    });
+    cleanups.push(() => {
+      session.disconnect();
+      transport.close();
+    });
+    return session;
+  };
+}
+
+function until(
+  condition: () => boolean,
+  label: string,
+  timeoutMs = 4000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = performance.now();
+    const tick = () => {
+      if (condition()) {
+        resolve();
+        return;
+      }
+      if (performance.now() - startedAt > timeoutMs) {
+        reject(new Error(`timed out waiting for: ${label}`));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+describe("haus session in a real browser", () => {
+  it("converges two sessions over a real BroadcastChannel", async () => {
+    const create = createScope();
+    const a = create("drumhaus", "left");
+    const b = create("basshaus", "right");
+    a.connect();
+    await until(() => a.isConductor, "first session conducting");
+    b.connect();
+
+    a.setBpm(150);
+    await until(() => b.state.bpm === 150, "follower adopting bpm");
+    expect(b.state).toEqual(a.state);
+    expect(b.isConductor).toBe(false);
+
+    await until(
+      () => a.peers.length === 1 && b.peers.length === 1,
+      "peer discovery",
+    );
+    expect(a.peers[0]).toMatchObject({
+      instrument: "basshaus",
+      label: "right",
+    });
+    expect(b.peers[0]).toMatchObject({ instrument: "drumhaus", label: "left" });
+  });
+
+  it("elects via real Web Locks and hands off on disconnect with state intact", async () => {
+    const create = createScope();
+    const a = create("drumhaus");
+    const b = create("basshaus");
+    a.connect();
+    await until(() => a.isConductor, "first session conducting");
+    b.connect();
+
+    a.setBpm(132);
+    a.setScene(2);
+    await until(() => b.state.scene === 2, "follower catching up");
+    const settled = b.state;
+    expect(b.isConductor).toBe(false);
+
+    a.disconnect();
+    await until(() => b.isConductor, "handover to second session");
+    expect(b.state).toEqual(settled);
+  });
+
+  it("lets a late joiner adopt state after hello", async () => {
+    const create = createScope();
+    const a = create("drumhaus");
+    a.connect();
+    await until(() => a.isConductor, "conductor ready");
+    a.setBpm(150);
+    a.setScene(3);
+
+    const c = create("synthhaus");
+    c.connect();
+    await until(() => c.state.bpm === 150, "late joiner adopting state");
+    expect(c.state).toEqual(a.state);
+  });
+
+  it("round-trips a follower's setBpm intent through the conductor", async () => {
+    const create = createScope();
+    const a = create("drumhaus");
+    const b = create("basshaus");
+    a.connect();
+    await until(() => a.isConductor, "conductor ready");
+    b.connect();
+    await until(() => b.peers.length === 1, "follower joined");
+
+    b.setBpm(96);
+    await until(
+      () => a.state.bpm === 96 && b.state.bpm === 96,
+      "intent round-trip",
+    );
+    expect(b.state).toEqual(a.state);
+    expect(a.state.rev).toBeGreaterThanOrEqual(1);
+  });
+
+  it("keeps the derived grid continuous across peers through a mid-play rebase", async () => {
+    const create = createScope();
+    const a = create("drumhaus");
+    const b = create("basshaus");
+    a.connect();
+    await until(() => a.isConductor, "conductor ready");
+    b.connect();
+
+    a.play();
+    await until(() => b.state.playing, "follower playing");
+    const before: SessionState = b.state;
+    // Let the downbeat land so the rebase happens mid-play, not in the lead.
+    await until(
+      () => epochNowMs() > (before.startEpochMs ?? 0) + 100,
+      "past the downbeat",
+    );
+
+    const tBefore = epochNowMs();
+    a.setBpm(180);
+    await until(() => b.state.bpm === 180, "follower adopting rebase");
+    const tAfter = epochNowMs();
+    const after = b.state;
+    expect(after).toEqual(a.state);
+    expect(after.playing).toBe(true);
+
+    // The old and new grids are lines in (time, beats); phase continuity
+    // means they intersect exactly at the conductor's decision instant.
+    const b1 = beatMs(before.bpm);
+    const b2 = beatMs(after.bpm);
+    const s1 = before.startEpochMs!;
+    const s2 = after.startEpochMs!;
+    const decisionInstant = (s1 * b2 - s2 * b1) / (b2 - b1);
+    expect(decisionInstant).toBeGreaterThanOrEqual(tBefore - 10);
+    expect(decisionInstant).toBeLessThanOrEqual(tAfter + 10);
+    expect(beatsAt(after, decisionInstant)!).toBeCloseTo(
+      beatsAt(before, decisionInstant)!,
+      6,
+    );
+  });
+});

--- a/packages/bridge/src/__tests__/session.test.ts
+++ b/packages/bridge/src/__tests__/session.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Session behavior over deterministic injected seams (memory transport,
+ * memory locks, fake clock): conductor/follower roles, the reducer and rev
+ * discipline, adoption guards, peer bookkeeping and timeouts, and defensive
+ * handling of malformed wire data.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createHausSession, reduceIntent, type HausSession } from "../session";
+import { memoryHub, type BridgeTransport } from "../transport";
+import { START_LEAD_MS, type SessionState } from "../types";
+import { flushMicrotasks, memoryLocks } from "./helpers/memory-locks";
+
+interface Rig {
+  nowMs: { value: number };
+  createSession(instrument: string, label?: string): HausSession;
+  createWire(): BridgeTransport;
+}
+
+const sessions: HausSession[] = [];
+
+/** One shared hub + lock manager + fake clock per test. */
+function createRig(): Rig {
+  const hub = memoryHub();
+  const locks = memoryLocks();
+  const nowMs = { value: 1_000_000 };
+  return {
+    nowMs,
+    createSession(instrument, label) {
+      const session = createHausSession({
+        instrument,
+        ...(label !== undefined ? { label } : {}),
+        transport: hub.createTransport(),
+        locks,
+        now: () => nowMs.value,
+      });
+      sessions.push(session);
+      return session;
+    },
+    createWire: () => hub.createTransport(),
+  };
+}
+
+afterEach(() => {
+  for (const session of sessions.splice(0)) session.disconnect();
+  vi.useRealTimers();
+});
+
+describe("reduceIntent", () => {
+  const stopped: SessionState = {
+    rev: 4,
+    bpm: 120,
+    playing: false,
+    startEpochMs: null,
+    scene: 0,
+  };
+
+  it("starts playback START_LEAD_MS in the future", () => {
+    const next = reduceIntent(stopped, { kind: "play" }, 5000);
+    expect(next).toEqual({
+      ...stopped,
+      playing: true,
+      startEpochMs: 5000 + START_LEAD_MS,
+    });
+  });
+
+  it("stops playback and clears the grid origin", () => {
+    const playing = { ...stopped, playing: true, startEpochMs: 5200 };
+    expect(reduceIntent(playing, { kind: "stop" }, 9000)).toEqual(stopped);
+  });
+
+  it("treats redundant play/stop/scene/bpm as no-ops", () => {
+    const playing = { ...stopped, playing: true, startEpochMs: 5200 };
+    expect(reduceIntent(playing, { kind: "play" }, 9000)).toBeNull();
+    expect(reduceIntent(stopped, { kind: "stop" }, 9000)).toBeNull();
+    expect(
+      reduceIntent(stopped, { kind: "setScene", scene: 0 }, 9000),
+    ).toBeNull();
+    expect(
+      reduceIntent(stopped, { kind: "setBpm", bpm: 120 }, 9000),
+    ).toBeNull();
+  });
+
+  it("rejects invalid values", () => {
+    expect(
+      reduceIntent(stopped, { kind: "setBpm", bpm: Number.NaN }, 0),
+    ).toBeNull();
+    expect(
+      reduceIntent(stopped, { kind: "setScene", scene: 9 as never }, 0),
+    ).toBeNull();
+  });
+
+  it("rebases the grid on tempo change while playing", () => {
+    const playing = { ...stopped, playing: true, startEpochMs: 5000 };
+    // 4 beats elapsed at 120 bpm (2000ms); at 60 bpm those take 4000ms.
+    const next = reduceIntent(playing, { kind: "setBpm", bpm: 60 }, 7000);
+    expect(next).toEqual({ ...playing, bpm: 60, startEpochMs: 3000 });
+  });
+});
+
+describe("solo session", () => {
+  it("conducts itself immediately after connect", async () => {
+    const rig = createRig();
+    const session = rig.createSession("drumhaus");
+    const conductorEvents: boolean[] = [];
+    session.onConductorChange((isConductor) =>
+      conductorEvents.push(isConductor),
+    );
+
+    expect(session.isConductor).toBe(false);
+    session.connect();
+    await flushMicrotasks();
+
+    expect(session.isConductor).toBe(true);
+    expect(conductorEvents).toEqual([true]);
+  });
+
+  it("applies its own commands with rev bumps", async () => {
+    const rig = createRig();
+    const session = rig.createSession("drumhaus");
+    session.connect();
+    await flushMicrotasks();
+
+    session.setBpm(150);
+    expect(session.state).toMatchObject({ rev: 1, bpm: 150 });
+
+    session.play();
+    expect(session.state).toMatchObject({
+      rev: 2,
+      playing: true,
+      startEpochMs: rig.nowMs.value + START_LEAD_MS,
+    });
+
+    session.setScene(2);
+    expect(session.state).toMatchObject({ rev: 3, scene: 2 });
+
+    session.stop();
+    expect(session.state).toMatchObject({
+      rev: 4,
+      playing: false,
+      startEpochMs: null,
+    });
+
+    // No-ops do not bump rev.
+    session.stop();
+    session.setScene(2);
+    expect(session.state.rev).toBe(4);
+  });
+
+  it("clamps bpm commands", async () => {
+    const rig = createRig();
+    const session = rig.createSession("drumhaus");
+    session.connect();
+    await flushMicrotasks();
+    session.setBpm(9999);
+    expect(session.state.bpm).toBe(300);
+  });
+});
+
+describe("standalone (never connected)", () => {
+  it("applies commands locally without bumping rev", () => {
+    const rig = createRig();
+    const session = rig.createSession("drumhaus");
+    session.setBpm(90);
+    session.play();
+    expect(session.state).toMatchObject({
+      rev: 0,
+      bpm: 90,
+      playing: true,
+      startEpochMs: rig.nowMs.value + START_LEAD_MS,
+    });
+  });
+});
+
+describe("conductor and follower", () => {
+  async function connectPair(rig: Rig): Promise<[HausSession, HausSession]> {
+    const a = rig.createSession("drumhaus", "a");
+    const b = rig.createSession("basshaus", "b");
+    a.connect();
+    await flushMicrotasks();
+    b.connect();
+    await flushMicrotasks();
+    expect(a.isConductor).toBe(true);
+    expect(b.isConductor).toBe(false);
+    return [a, b];
+  }
+
+  it("propagates conductor changes to followers", async () => {
+    const rig = createRig();
+    const [a, b] = await connectPair(rig);
+    a.setBpm(150);
+    await flushMicrotasks();
+    expect(b.state).toEqual(a.state);
+    expect(b.state).toMatchObject({ rev: 1, bpm: 150 });
+  });
+
+  it("round-trips a follower intent through the conductor", async () => {
+    const rig = createRig();
+    const [a, b] = await connectPair(rig);
+    b.setBpm(90);
+    // The follower does not self-apply; it waits for the conductor's state.
+    expect(b.state.bpm).toBe(120);
+    await flushMicrotasks();
+    expect(a.state.bpm).toBe(90);
+    expect(b.state).toEqual(a.state);
+  });
+
+  it("lets a late joiner adopt state via hello", async () => {
+    const rig = createRig();
+    const a = rig.createSession("drumhaus");
+    a.connect();
+    await flushMicrotasks();
+    a.setBpm(150);
+    a.setScene(3);
+
+    const c = rig.createSession("synthhaus");
+    c.connect();
+    await flushMicrotasks();
+    expect(c.state).toEqual(a.state);
+    expect(c.state).toMatchObject({ bpm: 150, scene: 3 });
+  });
+
+  it("hands conductorship off on disconnect with state intact", async () => {
+    const rig = createRig();
+    const [a, b] = await connectPair(rig);
+    a.setBpm(132);
+    a.setScene(1);
+    await flushMicrotasks();
+    const settled = b.state;
+
+    a.disconnect();
+    await flushMicrotasks();
+    expect(b.isConductor).toBe(true);
+    // The rebroadcast keeps the same rev; nothing regresses.
+    expect(b.state).toEqual(settled);
+    expect(b.peers).toEqual([]);
+  });
+
+  it("tracks peers symmetrically and honors goodbye", async () => {
+    const rig = createRig();
+    const [a, b] = await connectPair(rig);
+    expect(a.peers.map((p) => p.instrument)).toEqual(["basshaus"]);
+    expect(b.peers.map((p) => p.instrument)).toEqual(["drumhaus"]);
+
+    b.disconnect();
+    await flushMicrotasks();
+    expect(a.peers).toEqual([]);
+  });
+
+  it("ignores state messages older than the local rev", async () => {
+    const rig = createRig();
+    const [a, b] = await connectPair(rig);
+    a.setBpm(90);
+    a.setBpm(96);
+    await flushMicrotasks();
+    expect(b.state.rev).toBe(2);
+
+    const wire = rig.createWire();
+    wire.post({
+      v: 1,
+      type: "state",
+      from: "stale-conductor",
+      state: { rev: 1, bpm: 55, playing: false, startEpochMs: null, scene: 0 },
+    });
+    await flushMicrotasks();
+    expect(b.state).toMatchObject({ rev: 2, bpm: 96 });
+  });
+
+  it("ignores malformed and foreign-version wire data", async () => {
+    const rig = createRig();
+    const [a, b] = await connectPair(rig);
+    const wire = rig.createWire();
+    const before = b.state;
+
+    wire.post("garbage" as never);
+    wire.post({ v: 2, type: "state", from: "future" } as never);
+    wire.post({
+      v: 1,
+      type: "intent",
+      from: "x",
+      intent: { kind: "warp" },
+    } as never);
+    wire.post({
+      v: 1,
+      type: "state",
+      from: "x",
+      state: {
+        rev: 99,
+        bpm: 9000,
+        playing: false,
+        startEpochMs: null,
+        scene: 0,
+      },
+    } as never);
+    await flushMicrotasks();
+
+    expect(a.state).toEqual(before);
+    expect(b.state).toEqual(before);
+  });
+});
+
+describe("peer timeout bookkeeping", () => {
+  it("drops peers after PEER_TIMEOUT_MS of silence, keeps live ones", async () => {
+    vi.useFakeTimers();
+    const rig = createRig();
+    const session = rig.createSession("drumhaus");
+    session.connect();
+    await flushMicrotasks();
+
+    const wire = rig.createWire();
+    const hello = (peerId: string) => {
+      wire.post({
+        v: 1,
+        type: "hello",
+        from: peerId,
+        peer: { id: peerId, instrument: "basshaus" },
+      });
+    };
+    const heartbeat = (peerId: string) => {
+      wire.post({
+        v: 1,
+        type: "heartbeat",
+        from: peerId,
+        peer: { id: peerId, instrument: "basshaus" },
+      });
+    };
+
+    hello("quiet");
+    hello("chatty");
+    await flushMicrotasks();
+    expect(session.peers.map((p) => p.id).sort()).toEqual(["chatty", "quiet"]);
+
+    // "chatty" keeps heartbeating; "quiet" goes silent.
+    for (let i = 0; i < 4; i++) {
+      rig.nowMs.value += 2000;
+      heartbeat("chatty");
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushMicrotasks();
+    }
+
+    expect(session.peers.map((p) => p.id)).toEqual(["chatty"]);
+  });
+});
+
+describe("subscriptions", () => {
+  it("returns working unsubscribers", async () => {
+    const rig = createRig();
+    const session = rig.createSession("drumhaus");
+    session.connect();
+    await flushMicrotasks();
+
+    let stateEvents = 0;
+    const unsubscribe = session.onStateChange(() => stateEvents++);
+    session.setBpm(100);
+    unsubscribe();
+    session.setBpm(110);
+    expect(stateEvents).toBe(1);
+  });
+});

--- a/packages/bridge/src/__tests__/transport.test.ts
+++ b/packages/bridge/src/__tests__/transport.test.ts
@@ -1,0 +1,102 @@
+/**
+ * memoryHub transport semantics, which must match BroadcastChannel: delivery
+ * to every other transport but never back to the poster, structured-cloned
+ * payloads, and closed transports dropping out of the mesh.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { memoryHub } from "../transport";
+import type { BridgeMessage } from "../types";
+import { flushMicrotasks } from "./helpers/memory-locks";
+
+function goodbye(from: string): BridgeMessage {
+  return { v: 1, type: "goodbye", from };
+}
+
+describe("memoryHub", () => {
+  it("delivers to every other transport but not the poster", async () => {
+    const hub = memoryHub();
+    const [a, b, c] = [
+      hub.createTransport(),
+      hub.createTransport(),
+      hub.createTransport(),
+    ];
+    const seen: Record<string, unknown[]> = { a: [], b: [], c: [] };
+    a.subscribe((data) => seen.a.push(data));
+    b.subscribe((data) => seen.b.push(data));
+    c.subscribe((data) => seen.c.push(data));
+
+    a.post(goodbye("peer-a"));
+    await flushMicrotasks();
+
+    expect(seen.a).toEqual([]);
+    expect(seen.b).toEqual([goodbye("peer-a")]);
+    expect(seen.c).toEqual([goodbye("peer-a")]);
+  });
+
+  it("delivers asynchronously (no synchronous reentrancy)", () => {
+    const hub = memoryHub();
+    const a = hub.createTransport();
+    const b = hub.createTransport();
+    let received = false;
+    b.subscribe(() => {
+      received = true;
+    });
+    a.post(goodbye("peer-a"));
+    expect(received).toBe(false);
+  });
+
+  it("delivers structured clones, not shared references", async () => {
+    const hub = memoryHub();
+    const a = hub.createTransport();
+    const b = hub.createTransport();
+    const received: BridgeMessage[] = [];
+    b.subscribe((data) => received.push(data as BridgeMessage));
+
+    const original = {
+      v: 1,
+      type: "hello",
+      from: "peer-a",
+      peer: { id: "peer-a", instrument: "drumhaus" },
+    } as const;
+    a.post(original);
+    await flushMicrotasks();
+
+    expect(received[0]).toEqual(original);
+    expect(received[0]).not.toBe(original);
+    expect((received[0] as { peer: object }).peer).not.toBe(original.peer);
+  });
+
+  it("stops delivering to and from closed transports", async () => {
+    const hub = memoryHub();
+    const a = hub.createTransport();
+    const b = hub.createTransport();
+    const seen: unknown[] = [];
+    b.subscribe((data) => seen.push(data));
+
+    b.close();
+    a.post(goodbye("peer-a"));
+    a.close();
+    a.post(goodbye("peer-a"));
+    await flushMicrotasks();
+
+    expect(seen).toEqual([]);
+  });
+
+  it("honors unsubscribe", async () => {
+    const hub = memoryHub();
+    const a = hub.createTransport();
+    const b = hub.createTransport();
+    const seen: unknown[] = [];
+    const unsubscribe = b.subscribe((data) => seen.push(data));
+
+    a.post(goodbye("peer-a"));
+    await flushMicrotasks();
+    unsubscribe();
+    a.post(goodbye("peer-a"));
+    await flushMicrotasks();
+
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/packages/bridge/src/clock.ts
+++ b/packages/bridge/src/clock.ts
@@ -1,0 +1,181 @@
+/**
+ * Grid math for the shared musical clock.
+ *
+ * The session's grid is fully determined by (startEpochMs, bpm) in fixed 4/4:
+ * beat n falls at startEpochMs + n * beatMs(bpm), bar k at
+ * startEpochMs + k * barMs(bpm). Every function here is pure; anything that
+ * needs "now" takes the instant as an argument (or an injectable clock), so
+ * the math is deterministic and testable.
+ */
+
+import { BPM_MAX, BPM_MIN, type SessionState } from "./types";
+
+/** Beats per bar; v1 is fixed 4/4 by design (see README). */
+const BEATS_PER_BAR = 4;
+
+/**
+ * The shared epoch clock: performance.timeOrigin + performance.now().
+ * Comparable across same-machine same-browser tabs to about 1ms, which is
+ * what makes (startEpochMs, bpm) a shared grid at all.
+ */
+function epochNowMs(): number {
+  return performance.timeOrigin + performance.now();
+}
+
+/** Clamp a tempo into the protocol's [BPM_MIN, BPM_MAX] range. */
+function clampBpm(bpm: number): number {
+  return Math.min(BPM_MAX, Math.max(BPM_MIN, bpm));
+}
+
+/** Duration of one beat in milliseconds at the given tempo. */
+function beatMs(bpm: number): number {
+  return 60_000 / bpm;
+}
+
+/** Duration of one 4/4 bar in milliseconds at the given tempo. */
+function barMs(bpm: number): number {
+  return BEATS_PER_BAR * beatMs(bpm);
+}
+
+/**
+ * Beats elapsed since bar 0 beat 0 at the given epoch instant, or null when
+ * the session is stopped. Negative during the start lead window (the count-in
+ * before the downbeat lands).
+ */
+function beatsAt(state: SessionState, epochMs: number): number | null {
+  if (!state.playing || state.startEpochMs === null) return null;
+  return (epochMs - state.startEpochMs) / beatMs(state.bpm);
+}
+
+/** Bars elapsed since bar 0 at the given epoch instant, or null when stopped. */
+function barsAt(state: SessionState, epochMs: number): number | null {
+  const beats = beatsAt(state, epochMs);
+  return beats === null ? beats : beats / BEATS_PER_BAR;
+}
+
+/**
+ * Epoch instant of the first bar boundary strictly after the given instant,
+ * or null when stopped. During the start lead window this is bar 0's downbeat
+ * itself (startEpochMs).
+ */
+function nextBarStartEpochMs(
+  state: SessionState,
+  epochMs: number,
+): number | null {
+  const bars = barsAt(state, epochMs);
+  if (bars === null || state.startEpochMs === null) return null;
+  return state.startEpochMs + (Math.floor(bars) + 1) * barMs(state.bpm);
+}
+
+/**
+ * Change tempo preserving phase continuity: the beat position at the decision
+ * instant is identical under the old and new grids. With beats elapsed
+ * B = (atEpochMs - startEpochMs) / beatMs(oldBpm), the rebased origin is
+ * startEpochMs' = atEpochMs - B * beatMs(newBpm). While stopped this reduces
+ * to setting bpm. The rev is left untouched; bumping it is the conductor's
+ * job.
+ */
+function rebaseTempo(
+  state: SessionState,
+  newBpm: number,
+  atEpochMs: number,
+): SessionState {
+  const bpm = clampBpm(newBpm);
+  if (!state.playing || state.startEpochMs === null) {
+    return { ...state, bpm };
+  }
+  const beatsElapsed = (atEpochMs - state.startEpochMs) / beatMs(state.bpm);
+  return {
+    ...state,
+    bpm,
+    startEpochMs: atEpochMs - beatsElapsed * beatMs(bpm),
+  };
+}
+
+/**
+ * The subset of AudioContext the epoch mapping needs. Structural, so tests
+ * can fake it and any AudioContext (or Tone.js rawContext) satisfies it.
+ */
+interface BridgeAudioContext {
+  currentTime: number;
+  getOutputTimestamp?: () => {
+    contextTime?: number;
+    performanceTime?: number;
+  };
+}
+
+interface ClockAnchor {
+  contextTimeS: number;
+  epochMs: number;
+}
+
+/**
+ * Sample one (contextTime, epoch) pair to anchor the linear mapping between
+ * the AudioContext clock and the epoch clock.
+ *
+ * Preferred source is ctx.getOutputTimestamp(), which pairs a context time
+ * with the performance.now() instant at which that audio actually reaches the
+ * output - so epoch-scheduled events line up at the speaker across tabs.
+ * Fallback (documented, not a hack): when getOutputTimestamp is unavailable
+ * (older WebKit) or returns zeros (contexts that have not produced output
+ * yet, e.g. suspended), sample ctx.currentTime against the epoch clock
+ * directly. The fallback ignores output latency but keeps the mapping honest
+ * to within a few milliseconds, consistent with the library's
+ * musically-tight-not-sample-locked contract.
+ */
+function contextClockAnchor(
+  ctx: BridgeAudioContext,
+  epochNow: () => number = epochNowMs,
+): ClockAnchor {
+  const ts = ctx.getOutputTimestamp?.();
+  if (
+    ts &&
+    typeof ts.contextTime === "number" &&
+    typeof ts.performanceTime === "number" &&
+    (ts.contextTime !== 0 || ts.performanceTime !== 0)
+  ) {
+    return {
+      contextTimeS: ts.contextTime,
+      epochMs: performance.timeOrigin + ts.performanceTime,
+    };
+  }
+  return { contextTimeS: ctx.currentTime, epochMs: epochNow() };
+}
+
+/**
+ * Map an epoch instant (ms) to the given AudioContext's time (seconds), for
+ * scheduling: schedule bar 0 at epochToContextTime(ctx, state.startEpochMs).
+ */
+function epochToContextTime(
+  ctx: BridgeAudioContext,
+  epochMs: number,
+  epochNow: () => number = epochNowMs,
+): number {
+  const anchor = contextClockAnchor(ctx, epochNow);
+  return anchor.contextTimeS + (epochMs - anchor.epochMs) / 1000;
+}
+
+/** Inverse of epochToContextTime: context seconds to an epoch instant (ms). */
+function contextTimeToEpochMs(
+  ctx: BridgeAudioContext,
+  contextTimeS: number,
+  epochNow: () => number = epochNowMs,
+): number {
+  const anchor = contextClockAnchor(ctx, epochNow);
+  return anchor.epochMs + (contextTimeS - anchor.contextTimeS) * 1000;
+}
+
+export {
+  barMs,
+  barsAt,
+  beatMs,
+  beatsAt,
+  BEATS_PER_BAR,
+  clampBpm,
+  contextTimeToEpochMs,
+  epochNowMs,
+  epochToContextTime,
+  nextBarStartEpochMs,
+  rebaseTempo,
+};
+export type { BridgeAudioContext };

--- a/packages/bridge/src/election.ts
+++ b/packages/bridge/src/election.ts
@@ -1,0 +1,105 @@
+/**
+ * Conductor election over the Web Locks API.
+ *
+ * Every connected session requests the same lock; the holder is the
+ * conductor. Web Locks queue waiters and release automatically when the
+ * holding context goes away (tab close, crash, navigation), so failover needs
+ * no protocol traffic: the next waiter is simply granted the lock and calls
+ * onAcquired.
+ *
+ * Scope and support: Web Locks are shared across same-origin browsing
+ * contexts in one browser on one machine - exactly the bridge's session
+ * boundary - and require a secure context. Supported in Chrome 69+, Edge 79+,
+ * Firefox 96+, and Safari 15.4+. If the API is missing entirely, the election
+ * degrades to granting immediately (each tab conducts itself); cross-tab
+ * dedup of conductorship requires Web Locks.
+ */
+
+import { LOCK_NAME } from "./types";
+
+/**
+ * The subset of navigator.locks the election needs; injectable for
+ * deterministic tests and for lock-name scoping.
+ */
+interface HausLockManager {
+  request(
+    name: string,
+    options: { signal?: AbortSignal },
+    callback: () => Promise<void> | void,
+  ): Promise<unknown>;
+}
+
+interface ConductorElectionOptions {
+  /** Called exactly once per start() cycle, when this peer becomes conductor. */
+  onAcquired: () => void;
+  /** Lock name; defaults to LOCK_NAME. */
+  name?: string;
+  /** Lock manager; defaults to navigator.locks (with the fallback above). */
+  locks?: HausLockManager;
+}
+
+interface ConductorElection {
+  /** Join the election (request the lock). Idempotent while running. */
+  start(): void;
+  /**
+   * Leave the election: withdraw a pending request, or release the lock if
+   * held so the next waiter takes over.
+   */
+  stop(): void;
+}
+
+/** Immediate-grant stand-in for environments without Web Locks. */
+function soloLocks(): HausLockManager {
+  return {
+    async request(_name, _options, callback) {
+      return await callback();
+    },
+  };
+}
+
+function defaultLocks(): HausLockManager {
+  const locks = globalThis.navigator?.locks;
+  return locks ?? soloLocks();
+}
+
+function createConductorElection(
+  options: ConductorElectionOptions,
+): ConductorElection {
+  const name = options.name ?? LOCK_NAME;
+  const locks = options.locks ?? defaultLocks();
+  let running = false;
+  let controller: AbortController | null = null;
+  let releaseHeld: (() => void) | null = null;
+
+  return {
+    start() {
+      if (running) return;
+      running = true;
+      const cycle = new AbortController();
+      controller = cycle;
+      void locks
+        .request(name, { signal: cycle.signal }, () => {
+          // stop() may have raced the grant; hold nothing in that case.
+          if (!running || controller !== cycle) return;
+          options.onAcquired();
+          return new Promise<void>((resolve) => {
+            releaseHeld = resolve;
+          });
+        })
+        .catch(() => {
+          // AbortError from stop() before the grant; nothing to do.
+        });
+    },
+    stop() {
+      if (!running) return;
+      running = false;
+      releaseHeld?.();
+      releaseHeld = null;
+      controller?.abort();
+      controller = null;
+    },
+  };
+}
+
+export { createConductorElection };
+export type { ConductorElection, ConductorElectionOptions, HausLockManager };

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @haus/bridge - serverless cross-instrument session sync for the haus
+ * family. See README.md for the protocol specification (document of record).
+ */
+
+export {
+  barMs,
+  barsAt,
+  beatMs,
+  beatsAt,
+  BEATS_PER_BAR,
+  clampBpm,
+  contextTimeToEpochMs,
+  epochNowMs,
+  epochToContextTime,
+  nextBarStartEpochMs,
+  rebaseTempo,
+} from "./clock";
+export type { BridgeAudioContext } from "./clock";
+export { createConductorElection } from "./election";
+export type {
+  ConductorElection,
+  ConductorElectionOptions,
+  HausLockManager,
+} from "./election";
+export { createHausSession } from "./session";
+export type { CreateHausSessionOptions, HausSession } from "./session";
+export { broadcastChannelTransport, memoryHub } from "./transport";
+export type { BridgeTransport, MemoryHub } from "./transport";
+export {
+  BPM_MAX,
+  BPM_MIN,
+  CHANNEL_NAME,
+  DEFAULT_BPM,
+  HEARTBEAT_MS,
+  LOCK_NAME,
+  parseBridgeMessage,
+  PEER_TIMEOUT_MS,
+  PROTOCOL_VERSION,
+  START_LEAD_MS,
+} from "./types";
+export type {
+  BridgeMessage,
+  HausPeer,
+  SceneId,
+  SessionIntent,
+  SessionState,
+} from "./types";

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -1,0 +1,336 @@
+/**
+ * The session facade: one object per instrument instance that joins the
+ * shared musical session and exposes tempo, transport, and scene.
+ *
+ * Roles: the Web Locks holder is the conductor and owns the state - it
+ * applies intents, bumps rev, and broadcasts. Everyone else follows: commands
+ * become intent messages, and state messages with rev >= the local rev are
+ * adopted. A solo tab wins the lock immediately and conducts itself, so the
+ * library is near-zero-cost in that mode (one heartbeat every 2s).
+ *
+ * Transport, clock, and locks are injectable for deterministic tests; the
+ * defaults are the real BroadcastChannel, epoch clock, and navigator.locks.
+ */
+
+import { epochNowMs, rebaseTempo } from "./clock";
+import {
+  createConductorElection,
+  type ConductorElection,
+  type HausLockManager,
+} from "./election";
+import { broadcastChannelTransport, type BridgeTransport } from "./transport";
+import {
+  DEFAULT_BPM,
+  HEARTBEAT_MS,
+  isSceneId,
+  parseBridgeMessage,
+  PEER_TIMEOUT_MS,
+  PROTOCOL_VERSION,
+  START_LEAD_MS,
+  type HausPeer,
+  type SceneId,
+  type SessionIntent,
+  type SessionState,
+} from "./types";
+
+interface CreateHausSessionOptions {
+  /** Instrument name announced to peers, e.g. "drumhaus". */
+  instrument: string;
+  /** Optional human-facing label to distinguish multiple instances. */
+  label?: string;
+  /** Message transport; defaults to a BroadcastChannel on CHANNEL_NAME. */
+  transport?: BridgeTransport;
+  /** Epoch clock; defaults to epochNowMs. */
+  now?: () => number;
+  /** Lock manager for conductor election; defaults to navigator.locks. */
+  locks?: HausLockManager;
+}
+
+interface HausSession {
+  /** Current session state (immutable snapshot; never mutated in place). */
+  readonly state: SessionState;
+  /** Other currently-known peers (self excluded). */
+  readonly peers: HausPeer[];
+  /** Whether this instance currently holds conductorship. */
+  readonly isConductor: boolean;
+  /** Join the shared session. Idempotent. */
+  connect(): void;
+  /** Leave the session: goodbye, release conductorship, stop timers. */
+  disconnect(): void;
+  /** Request a tempo change (clamped to [BPM_MIN, BPM_MAX]). */
+  setBpm(bpm: number): void;
+  /** Request playback start (bar 0 lands START_LEAD_MS in the future). */
+  play(): void;
+  /** Request playback stop. */
+  stop(): void;
+  /** Request a scene change (0-3). */
+  setScene(scene: SceneId): void;
+  onStateChange(fn: (state: SessionState) => void): () => void;
+  onPeersChange(fn: (peers: HausPeer[]) => void): () => void;
+  onConductorChange(fn: (isConductor: boolean) => void): () => void;
+}
+
+/**
+ * Apply one intent to the state at the given instant. Pure; returns null for
+ * no-ops (redundant play/stop, unchanged bpm or scene, invalid values) so
+ * callers only bump rev and broadcast on real changes. Rev is untouched here;
+ * the conductor owns it.
+ */
+function reduceIntent(
+  state: SessionState,
+  intent: SessionIntent,
+  atEpochMs: number,
+): SessionState | null {
+  switch (intent.kind) {
+    case "setBpm": {
+      if (!Number.isFinite(intent.bpm)) return null;
+      const next = rebaseTempo(state, intent.bpm, atEpochMs);
+      return next.bpm === state.bpm ? null : next;
+    }
+    case "play":
+      if (state.playing) return null;
+      return {
+        ...state,
+        playing: true,
+        startEpochMs: atEpochMs + START_LEAD_MS,
+      };
+    case "stop":
+      if (!state.playing) return null;
+      return { ...state, playing: false, startEpochMs: null };
+    case "setScene":
+      if (!isSceneId(intent.scene) || intent.scene === state.scene) return null;
+      return { ...state, scene: intent.scene };
+  }
+}
+
+/** A message body before the envelope (v, from) is stamped on. */
+type OutgoingBody =
+  | { type: "intent"; intent: SessionIntent }
+  | { type: "state"; state: SessionState }
+  | { type: "hello"; peer: HausPeer }
+  | { type: "heartbeat"; peer: HausPeer }
+  | { type: "goodbye" };
+
+function statesEqual(a: SessionState, b: SessionState): boolean {
+  return (
+    a.rev === b.rev &&
+    a.bpm === b.bpm &&
+    a.playing === b.playing &&
+    a.startEpochMs === b.startEpochMs &&
+    a.scene === b.scene
+  );
+}
+
+function createHausSession(options: CreateHausSessionOptions): HausSession {
+  const now = options.now ?? epochNowMs;
+  const id = crypto.randomUUID();
+  const self: HausPeer = {
+    id,
+    instrument: options.instrument,
+    ...(options.label !== undefined ? { label: options.label } : {}),
+  };
+
+  let state: SessionState = {
+    rev: 0,
+    bpm: DEFAULT_BPM,
+    playing: false,
+    startEpochMs: null,
+    scene: 0,
+  };
+
+  const peerEntries = new Map<string, { peer: HausPeer; lastSeenMs: number }>();
+  const stateListeners = new Set<(state: SessionState) => void>();
+  const peersListeners = new Set<(peers: HausPeer[]) => void>();
+  const conductorListeners = new Set<(isConductor: boolean) => void>();
+
+  let connected = false;
+  let conductor = false;
+  let transport: BridgeTransport | null = null;
+  let ownsTransport = false;
+  let unsubscribe: (() => void) | null = null;
+  let election: ConductorElection | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  function subscribeTo<T>(
+    listeners: Set<(value: T) => void>,
+    fn: (value: T) => void,
+  ) {
+    listeners.add(fn);
+    return () => {
+      listeners.delete(fn);
+    };
+  }
+
+  function peersSnapshot(): HausPeer[] {
+    return [...peerEntries.values()].map((entry) => entry.peer);
+  }
+
+  function notifyPeers(): void {
+    const snapshot = peersSnapshot();
+    for (const fn of peersListeners) fn(snapshot);
+  }
+
+  function notifyConductor(): void {
+    for (const fn of conductorListeners) fn(conductor);
+  }
+
+  function setState(next: SessionState): void {
+    if (statesEqual(state, next)) return;
+    state = next;
+    for (const fn of stateListeners) fn(state);
+  }
+
+  function post(body: OutgoingBody): void {
+    transport?.post({ v: PROTOCOL_VERSION, from: id, ...body });
+  }
+
+  function broadcastState(): void {
+    post({ type: "state", state });
+  }
+
+  /**
+   * Command entry point. Conductor (and a not-yet-connected standalone
+   * session) applies locally; a connected follower posts an intent and waits
+   * for the conductor's state broadcast. Standalone changes do not bump rev -
+   * rev is a coordination counter owned by whoever conducts - so a later
+   * conductor state at any rev is still adopted.
+   */
+  function command(intent: SessionIntent): void {
+    if (connected && !conductor) {
+      post({ type: "intent", intent });
+      return;
+    }
+    const next = reduceIntent(state, intent, now());
+    if (next === null) return;
+    setState(conductor ? { ...next, rev: state.rev + 1 } : next);
+    if (conductor) broadcastState();
+  }
+
+  function upsertPeer(peer: HausPeer): void {
+    const existing = peerEntries.get(peer.id);
+    peerEntries.set(peer.id, { peer, lastSeenMs: now() });
+    if (
+      !existing ||
+      existing.peer.instrument !== peer.instrument ||
+      existing.peer.label !== peer.label
+    ) {
+      notifyPeers();
+    }
+  }
+
+  function sweepPeers(): void {
+    const cutoff = now() - PEER_TIMEOUT_MS;
+    let dropped = false;
+    for (const [peerId, entry] of peerEntries) {
+      if (entry.lastSeenMs < cutoff) {
+        peerEntries.delete(peerId);
+        dropped = true;
+      }
+    }
+    if (dropped) notifyPeers();
+  }
+
+  function handleMessage(data: unknown): void {
+    const msg = parseBridgeMessage(data);
+    if (msg === null || msg.from === id) return;
+    const known = peerEntries.get(msg.from);
+    if (known) known.lastSeenMs = now();
+    switch (msg.type) {
+      case "hello":
+        upsertPeer(msg.peer);
+        // Reply so the joiner learns us without waiting a heartbeat period.
+        post({ type: "heartbeat", peer: self });
+        if (conductor) broadcastState();
+        break;
+      case "heartbeat":
+        upsertPeer(msg.peer);
+        break;
+      case "goodbye":
+        if (peerEntries.delete(msg.from)) notifyPeers();
+        break;
+      case "intent":
+        if (conductor) {
+          const next = reduceIntent(state, msg.intent, now());
+          if (next !== null) {
+            setState({ ...next, rev: state.rev + 1 });
+            broadcastState();
+          }
+        }
+        break;
+      case "state":
+        // The rev guard makes stale rebroadcasts during handover harmless.
+        if (!conductor && msg.state.rev >= state.rev) setState(msg.state);
+        break;
+    }
+  }
+
+  function connect(): void {
+    if (connected) return;
+    connected = true;
+    ownsTransport = options.transport === undefined;
+    transport = options.transport ?? broadcastChannelTransport();
+    unsubscribe = transport.subscribe(handleMessage);
+    election = createConductorElection({
+      ...(options.locks !== undefined ? { locks: options.locks } : {}),
+      onAcquired: () => {
+        conductor = true;
+        notifyConductor();
+        // Rebroadcast the last-seen state (same rev) so late joiners and the
+        // handover window converge on the new conductor's view.
+        broadcastState();
+      },
+    });
+    election.start();
+    post({ type: "hello", peer: self });
+    heartbeatTimer = setInterval(() => {
+      post({ type: "heartbeat", peer: self });
+      sweepPeers();
+    }, HEARTBEAT_MS);
+  }
+
+  function disconnect(): void {
+    if (!connected) return;
+    post({ type: "goodbye" });
+    connected = false;
+    if (heartbeatTimer !== null) clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+    election?.stop();
+    election = null;
+    unsubscribe?.();
+    unsubscribe = null;
+    if (ownsTransport) transport?.close();
+    transport = null;
+    if (conductor) {
+      conductor = false;
+      notifyConductor();
+    }
+    if (peerEntries.size > 0) {
+      peerEntries.clear();
+      notifyPeers();
+    }
+  }
+
+  return {
+    get state() {
+      return state;
+    },
+    get peers() {
+      return peersSnapshot();
+    },
+    get isConductor() {
+      return conductor;
+    },
+    connect,
+    disconnect,
+    setBpm: (bpm) => command({ kind: "setBpm", bpm }),
+    play: () => command({ kind: "play" }),
+    stop: () => command({ kind: "stop" }),
+    setScene: (scene) => command({ kind: "setScene", scene }),
+    onStateChange: (fn) => subscribeTo(stateListeners, fn),
+    onPeersChange: (fn) => subscribeTo(peersListeners, fn),
+    onConductorChange: (fn) => subscribeTo(conductorListeners, fn),
+  };
+}
+
+export { createHausSession, reduceIntent };
+export type { CreateHausSessionOptions, HausSession };

--- a/packages/bridge/src/transport.ts
+++ b/packages/bridge/src/transport.ts
@@ -1,0 +1,106 @@
+/**
+ * The message transport seam.
+ *
+ * Production uses a BroadcastChannel; tests use memoryHub() for linked
+ * in-memory transports with the same semantics. Both deliver structured
+ * clones to every OTHER transport on the channel - never back to the poster -
+ * which is exactly how BroadcastChannel behaves between instances in the same
+ * browsing context.
+ *
+ * A transport is a dumb pipe: it delivers raw unknown data and does no
+ * validation. Callers (the session) validate with parseBridgeMessage.
+ */
+
+import { CHANNEL_NAME, type BridgeMessage } from "./types";
+
+interface BridgeTransport {
+  /** Post a message to every other transport on the channel. */
+  post(msg: BridgeMessage): void;
+  /** Subscribe to incoming raw data; returns an unsubscriber. */
+  subscribe(fn: (data: unknown) => void): () => void;
+  /** Release underlying resources; posting and delivery stop. */
+  close(): void;
+}
+
+/** A BroadcastChannel-backed transport (the production default). */
+function broadcastChannelTransport(
+  name: string = CHANNEL_NAME,
+): BridgeTransport {
+  const channel = new BroadcastChannel(name);
+  const listeners = new Set<(data: unknown) => void>();
+  let closed = false;
+  channel.onmessage = (event: MessageEvent) => {
+    for (const fn of listeners) fn(event.data);
+  };
+  return {
+    post(msg) {
+      if (closed) return;
+      channel.postMessage(msg);
+    },
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => {
+        listeners.delete(fn);
+      };
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      listeners.clear();
+      channel.close();
+    },
+  };
+}
+
+interface MemoryHub {
+  /** Create a new transport linked to every other transport from this hub. */
+  createTransport(): BridgeTransport;
+}
+
+/**
+ * An in-memory BroadcastChannel stand-in for deterministic tests. Delivery is
+ * asynchronous (microtask) and payloads are structured-cloned, matching the
+ * real channel's semantics: no self-delivery, no shared references, no
+ * synchronous reentrancy.
+ */
+function memoryHub(): MemoryHub {
+  const transports = new Set<{
+    listeners: Set<(data: unknown) => void>;
+    closed: boolean;
+  }>();
+  return {
+    createTransport() {
+      const node = {
+        listeners: new Set<(data: unknown) => void>(),
+        closed: false,
+      };
+      transports.add(node);
+      return {
+        post(msg) {
+          if (node.closed) return;
+          const payload = structuredClone(msg);
+          queueMicrotask(() => {
+            for (const other of transports) {
+              if (other === node || other.closed) continue;
+              for (const fn of other.listeners) fn(structuredClone(payload));
+            }
+          });
+        },
+        subscribe(fn) {
+          node.listeners.add(fn);
+          return () => {
+            node.listeners.delete(fn);
+          };
+        },
+        close() {
+          node.closed = true;
+          node.listeners.clear();
+          transports.delete(node);
+        },
+      };
+    },
+  };
+}
+
+export { broadcastChannelTransport, memoryHub };
+export type { BridgeTransport, MemoryHub };

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -1,0 +1,234 @@
+/**
+ * Protocol v1 types, constants, and the defensive envelope parser.
+ *
+ * The package README is the protocol's document of record; this module is its
+ * executable shape. Everything here is framework-free and has zero runtime
+ * dependencies.
+ */
+
+/** Protocol version carried in every message envelope. */
+const PROTOCOL_VERSION = 1;
+
+/** Default BroadcastChannel name shared by every instrument on the origin. */
+const CHANNEL_NAME = "haus-session";
+
+/** Web Locks resource name whose holder is the session conductor. */
+const LOCK_NAME = "haus:conductor";
+
+/**
+ * Lead applied when starting playback: the conductor places bar 0 beat 0 this
+ * far in the future so every tab can schedule ahead of the downbeat.
+ */
+const START_LEAD_MS = 200;
+
+/** Interval between heartbeat broadcasts from each connected peer. */
+const HEARTBEAT_MS = 2000;
+
+/**
+ * Silence threshold after which a peer is presumed gone and dropped from the
+ * peer list (just over two missed heartbeats).
+ */
+const PEER_TIMEOUT_MS = 5500;
+
+/** Inclusive tempo bounds; every bpm entering the session state is clamped. */
+const BPM_MIN = 40;
+const BPM_MAX = 300;
+
+/** Session state defaults before any conductor has spoken. */
+const DEFAULT_BPM = 120;
+
+/**
+ * Scene index 0-3. The protocol carries only the bare index; what a scene
+ * means belongs to each instrument, not to the bridge.
+ */
+type SceneId = 0 | 1 | 2 | 3;
+
+/** Identity of one session participant (one instrument in one tab). */
+interface HausPeer {
+  /** Random per-session-instance id (crypto.randomUUID). */
+  id: string;
+  /** Instrument name, e.g. "drumhaus". */
+  instrument: string;
+  /** Optional human-facing label to distinguish multiple instances. */
+  label?: string;
+}
+
+/**
+ * The full shared session state. The musical grid is fully determined by
+ * (startEpochMs, bpm) in fixed 4/4: no position or phase messages exist, and
+ * every tab derives the grid deterministically (see clock.ts).
+ */
+interface SessionState {
+  /** Monotonic revision counter; the conductor bumps it on every change. */
+  rev: number;
+  /** Tempo in beats per minute, clamped to [BPM_MIN, BPM_MAX]. */
+  bpm: number;
+  /** Whether the shared transport is running. */
+  playing: boolean;
+  /**
+   * Epoch instant (ms) of bar 0 beat 0, or null when stopped. Playing and
+   * startEpochMs are always consistent: playing implies non-null and vice
+   * versa.
+   */
+  startEpochMs: number | null;
+  /** Current scene index. */
+  scene: SceneId;
+}
+
+/** A change request; any peer may issue one, only the conductor applies it. */
+type SessionIntent =
+  | { kind: "setBpm"; bpm: number }
+  | { kind: "play" }
+  | { kind: "stop" }
+  | { kind: "setScene"; scene: SceneId };
+
+interface EnvelopeBase {
+  v: typeof PROTOCOL_VERSION;
+  /** Sender peer id. */
+  from: string;
+}
+
+/** Any peer: request a change; the conductor applies it and broadcasts. */
+interface IntentMessage extends EnvelopeBase {
+  type: "intent";
+  intent: SessionIntent;
+}
+
+/** Conductor only: the full session state. */
+interface StateMessage extends EnvelopeBase {
+  type: "state";
+  state: SessionState;
+}
+
+/** Any peer: announce joining; triggers heartbeat and state replies. */
+interface HelloMessage extends EnvelopeBase {
+  type: "hello";
+  peer: HausPeer;
+}
+
+/** Any peer: periodic liveness, carrying the peer descriptor. */
+interface HeartbeatMessage extends EnvelopeBase {
+  type: "heartbeat";
+  peer: HausPeer;
+}
+
+/** Any peer: leaving cleanly. */
+interface GoodbyeMessage extends EnvelopeBase {
+  type: "goodbye";
+}
+
+type BridgeMessage =
+  | IntentMessage
+  | StateMessage
+  | HelloMessage
+  | HeartbeatMessage
+  | GoodbyeMessage;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isSceneId(value: unknown): value is SceneId {
+  return value === 0 || value === 1 || value === 2 || value === 3;
+}
+
+function isHausPeer(value: unknown): value is HausPeer {
+  if (!isRecord(value)) return false;
+  if (typeof value.id !== "string" || value.id.length === 0) return false;
+  if (typeof value.instrument !== "string") return false;
+  if (value.label !== undefined && typeof value.label !== "string")
+    return false;
+  return true;
+}
+
+function isSessionState(value: unknown): value is SessionState {
+  if (!isRecord(value)) return false;
+  if (!isFiniteNumber(value.rev) || !Number.isInteger(value.rev)) return false;
+  if (
+    !isFiniteNumber(value.bpm) ||
+    value.bpm < BPM_MIN ||
+    value.bpm > BPM_MAX
+  ) {
+    return false;
+  }
+  if (typeof value.playing !== "boolean") return false;
+  if (value.startEpochMs !== null && !isFiniteNumber(value.startEpochMs))
+    return false;
+  // The v1 invariant: a derivable grid exists exactly while playing.
+  if (value.playing !== (value.startEpochMs !== null)) return false;
+  if (!isSceneId(value.scene)) return false;
+  return true;
+}
+
+function isSessionIntent(value: unknown): value is SessionIntent {
+  if (!isRecord(value)) return false;
+  switch (value.kind) {
+    case "setBpm":
+      return isFiniteNumber(value.bpm);
+    case "play":
+    case "stop":
+      return true;
+    case "setScene":
+      return isSceneId(value.scene);
+    default:
+      return false;
+  }
+}
+
+/**
+ * Validate one raw message off the wire. Returns null for anything that is
+ * not a well-formed protocol v1 message: other protocol versions (peers
+ * speaking a future version may share the channel someday), unknown types,
+ * and malformed payloads are all rejected defensively rather than trusted.
+ */
+function parseBridgeMessage(data: unknown): BridgeMessage | null {
+  if (!isRecord(data)) return null;
+  if (data.v !== PROTOCOL_VERSION) return null;
+  if (typeof data.from !== "string" || data.from.length === 0) return null;
+  switch (data.type) {
+    case "hello":
+    case "heartbeat":
+      if (!isHausPeer(data.peer) || data.peer.id !== data.from) return null;
+      return data as unknown as HelloMessage | HeartbeatMessage;
+    case "goodbye":
+      return data as unknown as GoodbyeMessage;
+    case "intent":
+      if (!isSessionIntent(data.intent)) return null;
+      return data as unknown as IntentMessage;
+    case "state":
+      if (!isSessionState(data.state)) return null;
+      return data as unknown as StateMessage;
+    default:
+      return null;
+  }
+}
+
+export {
+  BPM_MAX,
+  BPM_MIN,
+  CHANNEL_NAME,
+  DEFAULT_BPM,
+  HEARTBEAT_MS,
+  isSceneId,
+  LOCK_NAME,
+  parseBridgeMessage,
+  PEER_TIMEOUT_MS,
+  PROTOCOL_VERSION,
+  START_LEAD_MS,
+};
+export type {
+  BridgeMessage,
+  GoodbyeMessage,
+  HausPeer,
+  HeartbeatMessage,
+  HelloMessage,
+  IntentMessage,
+  SceneId,
+  SessionIntent,
+  SessionState,
+  StateMessage,
+};

--- a/packages/bridge/tsconfig.json
+++ b/packages/bridge/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/bridge/vitest.config.ts
+++ b/packages/bridge/vitest.config.ts
@@ -1,0 +1,29 @@
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: "unit",
+          environment: "node",
+          include: ["src/**/*.test.ts"],
+          exclude: ["src/**/*.browser.test.ts"],
+        },
+      },
+      {
+        test: {
+          name: "browser",
+          include: ["src/**/*.browser.test.ts"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,24 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.3)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/bridge:
+    devDependencies:
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.61.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.71.0
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
+      typescript:
+        specifier: ^6
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.3)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
 packages:
 
   '@babel/code-frame@7.29.7':


### PR DESCRIPTION
Part of #414. Closes #416.

First package in the umbrella workspace: `packages/bridge`, a framework-free, zero-runtime-dependency TypeScript library that lets browser instruments on the same origin share a musical session (tempo, transport, scene). The package README is the protocol's document of record.

## Protocol summary (v1)

- One BroadcastChannel (`haus-session`), enveloped messages `{ v: 1, type, from }`: `hello`, `heartbeat` (2000ms, peers time out after 5500ms), `intent`, `state`, `goodbye`. Malformed and other-version messages are rejected defensively.
- Conductor election via Web Locks (`haus:conductor`): the lock holder owns the state, applies intents, bumps `rev`, and broadcasts. Tab close/crash releases the lock; the next waiter conducts and rebroadcasts the last-seen state at the same rev.
- Session state: `{ rev, bpm, playing, startEpochMs, scene }`. bpm clamped to [40, 300], scene a bare 0-3 index (semantics are instrument-owned), fixed 4/4.

## Design decisions

- Deterministic grid, no position messages: the grid is fully determined by `(startEpochMs, bpm)` against the shared epoch clock (`performance.timeOrigin + performance.now()`). Every tab derives beats/bars locally and self-corrects; nothing chases a moving playhead.
- Play with 200ms lead: `startEpochMs = epochNowMs() + START_LEAD_MS`, so every tab schedules the downbeat ahead of time.
- Immediate phase-preserving tempo rebase: with `B = (t - start) / beatMs(old)` at decision instant `t`, the new origin is `t - B * beatMs(new)`. Not bar-quantized; followers glide with no phase jump.
- Web Locks handover: no election traffic, no leases. Intents landing in the handover window may be lost - an accepted, documented v1 tradeoff.
- AudioContext mapping anchors on `getOutputTimestamp()` (output-latency-aware) with a documented `currentTime`-vs-epoch fallback when it is unavailable or returns zeros.
- Everything injectable at the seams (`transport`, `now`, `locks`), so sessions are fully deterministic under test; a solo tab wins the lock immediately and is near-zero-cost.

## Tests

60 tests in two vitest projects, mirroring the app's setup:

- Node (53): grid math and property-style rebase continuity over random bpm pairs/instants, AudioContext mapping incl. both fallback triggers, envelope validation, memoryHub transport semantics, election over an in-memory lock manager, and full session behavior (roles, rev discipline, adoption guard, peer timeout bookkeeping with fake timers, malformed wire data).
- Browser (7, real Chromium via @vitest/browser-playwright): two sessions converge over a real BroadcastChannel; real Web Locks election with disconnect handover preserving state; late joiner adopts state after hello; follower setBpm intent round-trips; mid-play rebase keeps the derived grid continuous across peers (the old and new grids intersect exactly inside the measured decision window); epoch/context mapping against a real AudioContext.

## Verification

From the repo root: `pnpm install`, `pnpm format:check`, `pnpm lint`, `pnpm -r test` (bridge 60 passed; drumhaus 853 passed, 4 skipped), `pnpm build` - all green. `ci.yml` needs no changes: both packages resolve playwright 1.61.1, so the chromium binary installed for drumhaus serves the bridge browser tests from the shared cache. Bridge browser suite ran 4x locally with no flakes.