### PR TITLE
apps/pulse: reference metronome + family e2e harness (#418)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run E2E tests
         run: pnpm test:e2e
 
+      - name: Run family E2E tests
+        run: pnpm test:e2e:family
+
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4
@@ -60,4 +63,6 @@ jobs:
           path: |
             apps/drumhaus/playwright-report/
             apps/drumhaus/test-results/
+            e2e/playwright-report/
+            e2e/test-results/
           retention-days: 7

--- a/apps/pulse/index.html
+++ b/apps/pulse/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0e0e11" />
+    <link rel="icon" href="data:," />
+    <title>pulse</title>
+    <meta
+      name="description"
+      content="A tiny metronome for the haus family, and the reference implementation of @haus/bridge session sync."
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/pulse/package.json
+++ b/apps/pulse/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pulse",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4445",
+    "build": "tsc && vite build",
+    "preview": "vite preview --port 4445",
+    "lint": "oxlint src --max-warnings 0"
+  },
+  "dependencies": {
+    "@haus/bridge": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "oxlint": "^1.71.0",
+    "typescript": "^6",
+    "vite": "^8.0.16"
+  }
+}

--- a/apps/pulse/src/app.tsx
+++ b/apps/pulse/src/app.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useSyncExternalStore } from "react";
+import type { SceneId } from "@haus/bridge";
+
+import { createMetronome, type Metronome } from "./metronome";
+import type { PulseSession } from "./session";
+
+const SCENES: SceneId[] = [0, 1, 2, 3];
+
+type AppProps = {
+  session: PulseSession;
+};
+
+function App({ session }: AppProps) {
+  const state = useSyncExternalStore(session.subscribe, session.getState);
+  const peerCount = useSyncExternalStore(
+    session.subscribe,
+    session.getPeerCount,
+  );
+  const isConductor = useSyncExternalStore(
+    session.subscribe,
+    session.getIsConductor,
+  );
+
+  // The session is connected from load, but the AudioContext (autoplay
+  // policy) exists only after a user gesture. Any pointerdown qualifies -
+  // pressing play covers a fresh start, and any click at all covers joining
+  // a session that is already mid-playback.
+  useEffect(() => {
+    let ctx: AudioContext | null = null;
+    let metronome: Metronome | null = null;
+    function startAudio(): void {
+      ctx = new AudioContext();
+      void ctx.resume();
+      metronome = createMetronome(ctx);
+      metronome.update(session.getState());
+    }
+    window.addEventListener("pointerdown", startAudio, { once: true });
+    const unsubscribe = session.subscribe(() => {
+      metronome?.update(session.getState());
+    });
+    return () => {
+      window.removeEventListener("pointerdown", startAudio);
+      unsubscribe();
+      metronome?.dispose();
+      void ctx?.close();
+    };
+  }, [session]);
+
+  const bpm = Math.round(state.bpm);
+
+  return (
+    <main className="app">
+      <h1 className="wordmark">pulse</h1>
+
+      <div className="controls">
+        <button
+          type="button"
+          className="transport"
+          data-playing={state.playing}
+          onClick={() => (state.playing ? session.stop() : session.play())}
+        >
+          {state.playing ? "stop" : "play"}
+        </button>
+
+        <div className="tempo">
+          <button
+            type="button"
+            aria-label="tempo down"
+            onClick={() => session.setBpm(bpm - 1)}
+          >
+            -
+          </button>
+          <output className="bpm" aria-label="tempo">
+            {bpm}
+          </output>
+          <button
+            type="button"
+            aria-label="tempo up"
+            onClick={() => session.setBpm(bpm + 1)}
+          >
+            +
+          </button>
+        </div>
+
+        <div className="scenes" role="group" aria-label="scene">
+          {SCENES.map((scene) => (
+            <button
+              key={scene}
+              type="button"
+              aria-label={`scene ${scene}`}
+              aria-pressed={state.scene === scene}
+              onClick={() => session.setScene(scene)}
+            >
+              {scene}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <footer className="status">
+        <span className="peers">peers {peerCount}</span>
+        <span
+          className="conductor"
+          data-conductor={isConductor}
+          title="conductor"
+        />
+      </footer>
+    </main>
+  );
+}
+
+export { App };

--- a/apps/pulse/src/main.tsx
+++ b/apps/pulse/src/main.tsx
@@ -1,0 +1,24 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./app";
+import { createPulseSession } from "./session";
+
+import "./styles.css";
+
+// One session for the app's lifetime, connected on load: pulse is always
+// linked - that is its purpose. Audio waits for a user gesture (see app.tsx);
+// the session does not.
+const session = createPulseSession();
+session.connect();
+
+// A clean goodbye lets peers drop this tab immediately instead of waiting
+// out the heartbeat timeout; pageshow rejoins after a bfcache restore.
+window.addEventListener("pagehide", () => session.disconnect());
+window.addEventListener("pageshow", () => session.connect());
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App session={session} />
+  </StrictMode>,
+);

--- a/apps/pulse/src/metronome.ts
+++ b/apps/pulse/src/metronome.ts
@@ -1,0 +1,147 @@
+/**
+ * The audio core: a classic lookahead scheduler that places click blips
+ * directly on the shared session grid.
+ *
+ * The grid is fully determined by (startEpochMs, bpm): beat n falls at
+ * startEpochMs + n * beatMs(bpm) on the shared epoch clock, and
+ * epochToContextTime maps that instant onto this tab's AudioContext, so
+ * every tab's clicks line up at the speaker. A setInterval wakes every
+ * TICK_MS and schedules whatever beats fall inside the next LOOKAHEAD_MS -
+ * timers only need to be roughly on time; the audio clock does the precise
+ * placement.
+ *
+ * Raw WebAudio, no dependencies beyond @haus/bridge's clock math.
+ */
+
+import {
+  beatMs,
+  BEATS_PER_BAR,
+  epochNowMs,
+  epochToContextTime,
+  type SessionState,
+} from "@haus/bridge";
+
+/** How often the scheduler wakes to top up the schedule. */
+const TICK_MS = 25;
+
+/** How far past "now" each wake schedules. */
+const LOOKAHEAD_MS = 100;
+
+/** Voicings: accent on beat 1 of each 4/4 bar, plain on beats 2-4. */
+const ACCENT = { frequencyHz: 1760, peakGain: 0.5 };
+const PLAIN = { frequencyHz: 880, peakGain: 0.3 };
+
+/** Click envelope: instant attack, fast exponential decay to silence. */
+const CLICK_DECAY_S = 0.05;
+
+interface Metronome {
+  /** React to a session state change: play, stop, tempo rebase. */
+  update(state: SessionState): void;
+  /** Stop scheduling, cancel pending clicks, release the timer. */
+  dispose(): void;
+}
+
+interface Click {
+  osc: OscillatorNode;
+  gain: GainNode;
+}
+
+function createMetronome(ctx: AudioContext): Metronome {
+  /** The grid currently being scheduled; null while stopped. */
+  let grid: { startEpochMs: number; bpm: number } | null = null;
+  /** Next absolute session beat index (counted from bar 0 beat 0). */
+  let nextBeat = 0;
+  let timer: ReturnType<typeof setInterval> | null = null;
+  /** Scheduled but possibly unplayed clicks, cancellable on stop. */
+  const pending = new Set<Click>();
+
+  function scheduleClick(atContextTimeS: number, accented: boolean): void {
+    const voice = accented ? ACCENT : PLAIN;
+    // A beat can land marginally in the past (an exact-boundary join, timer
+    // jitter); clamp so it still plays instead of throwing.
+    const at = Math.max(atContextTimeS, ctx.currentTime);
+    const osc = new OscillatorNode(ctx, { frequency: voice.frequencyHz });
+    const gain = new GainNode(ctx, { gain: 0 });
+    gain.gain.setValueAtTime(voice.peakGain, at);
+    gain.gain.exponentialRampToValueAtTime(0.001, at + CLICK_DECAY_S);
+    osc.connect(gain).connect(ctx.destination);
+    const click: Click = { osc, gain };
+    pending.add(click);
+    osc.onended = () => {
+      pending.delete(click);
+      gain.disconnect();
+    };
+    osc.start(at);
+    osc.stop(at + CLICK_DECAY_S);
+  }
+
+  /** Schedule every not-yet-scheduled beat inside the lookahead window. */
+  function tick(): void {
+    if (grid === null) return;
+    const horizonEpochMs = epochNowMs() + LOOKAHEAD_MS;
+    for (;;) {
+      const beatEpochMs = grid.startEpochMs + nextBeat * beatMs(grid.bpm);
+      if (beatEpochMs >= horizonEpochMs) return;
+      scheduleClick(
+        epochToContextTime(ctx, beatEpochMs),
+        nextBeat % BEATS_PER_BAR === 0,
+      );
+      nextBeat += 1;
+    }
+  }
+
+  function cancelPending(): void {
+    for (const { osc, gain } of pending) {
+      osc.onended = null;
+      osc.stop();
+      gain.disconnect();
+    }
+    pending.clear();
+  }
+
+  function update(state: SessionState): void {
+    if (!state.playing || state.startEpochMs === null) {
+      grid = null;
+      cancelPending();
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+      return;
+    }
+    if (
+      grid !== null &&
+      grid.startEpochMs === state.startEpochMs &&
+      grid.bpm === state.bpm
+    ) {
+      return; // same grid; the running scheduler already has it
+    }
+    // Fresh start, mid-playback join, or tempo rebase: (re)derive the next
+    // beat index from the new grid and schedule only beats still in the
+    // future. On a fresh start the downbeat sits START_LEAD_MS ahead, so
+    // elapsed beats are negative and ceil lands on beat 0; on a join it lands
+    // on the first upcoming beat. After a rebase, the few clicks already
+    // scheduled under the old grid are within LOOKAHEAD_MS of now and are
+    // left to play out.
+    grid = { startEpochMs: state.startEpochMs, bpm: state.bpm };
+    const beatsElapsed =
+      (epochNowMs() - state.startEpochMs) / beatMs(state.bpm);
+    nextBeat = Math.max(0, Math.ceil(beatsElapsed));
+    tick();
+    if (timer === null) timer = setInterval(tick, TICK_MS);
+  }
+
+  function dispose(): void {
+    grid = null;
+    cancelPending();
+    if (timer !== null) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  return { update, dispose };
+}
+
+export { createMetronome };
+export type { Metronome };

--- a/apps/pulse/src/session.ts
+++ b/apps/pulse/src/session.ts
@@ -1,0 +1,154 @@
+/**
+ * Pulse's session hookup: how an instrument integrates @haus/bridge.
+ *
+ * Pulse is always linked - that is its purpose - so this wraps one
+ * createHausSession instance in exactly the surface the UI needs: a snapshot
+ * getter per value plus a single change signal (the useSyncExternalStore
+ * contract), and the four session commands.
+ *
+ * One bridge edge is handled here. Between connect() and either
+ * onConductorChange(true) or the first onStateChange there is no conductor
+ * to apply intents, so a command posted in that window would be dropped
+ * (README, "Handover semantics"). Until one of those fires, user commands
+ * are deferred: queued for the session and applied to a local optimistic
+ * state so the UI and metronome respond immediately - the same treatment the
+ * bridge gives commands issued before connect(). The window is page-load
+ * sized (a solo tab wins conductorship almost instantly), and the optimistic
+ * reducer below mirrors the bridge's own, built from its exported clock math.
+ */
+
+import {
+  createHausSession,
+  epochNowMs,
+  rebaseTempo,
+  START_LEAD_MS,
+  type SceneId,
+  type SessionState,
+} from "@haus/bridge";
+
+interface PulseSession {
+  /** Join the shared session. Idempotent. */
+  connect(): void;
+  /** Leave the session (posts a goodbye so peers drop us immediately). */
+  disconnect(): void;
+  /** Current session state; optimistic while commands are deferred. */
+  getState(): SessionState;
+  /** Session size: this tab plus every known peer. */
+  getPeerCount(): number;
+  /** Whether this tab currently conducts the session. */
+  getIsConductor(): boolean;
+  /** Single change signal for state, peer count, and conductorship. */
+  subscribe(listener: () => void): () => void;
+  play(): void;
+  stop(): void;
+  setBpm(bpm: number): void;
+  setScene(scene: SceneId): void;
+}
+
+function createPulseSession(): PulseSession {
+  const session = createHausSession({ instrument: "pulse" });
+
+  /** True once a conductor exists: us, or one whose state we have seen. */
+  let ready = false;
+  /** Commands queued while not ready, replayed in order on readiness. */
+  const deferred: (() => void)[] = [];
+  /** Local view of deferred commands; null once the session is authoritative. */
+  let optimistic: SessionState | null = null;
+
+  let peerCount = 1;
+  let isConductor = false;
+  const listeners = new Set<() => void>();
+
+  function notify(): void {
+    for (const fn of listeners) fn();
+  }
+
+  function becomeReady(): void {
+    if (ready) return;
+    ready = true;
+    optimistic = null;
+    for (const send of deferred.splice(0)) send();
+  }
+
+  session.onStateChange(() => {
+    // A state broadcast means a conductor spoke; intents will be applied.
+    becomeReady();
+    notify();
+  });
+  session.onConductorChange((conductor) => {
+    isConductor = conductor;
+    if (conductor) becomeReady();
+    notify();
+  });
+  session.onPeersChange((peers) => {
+    peerCount = peers.length + 1;
+    notify();
+  });
+
+  /**
+   * Route one command: straight to the session once ready, otherwise queue
+   * it and apply the equivalent change to the optimistic state. If readiness
+   * arrives via another conductor's state, the replayed intents round-trip
+   * through it, so the optimistic view may snap to the conductor's for a
+   * broadcast beat before the commands land - consistency wins.
+   */
+  function command(
+    apply: (state: SessionState, atEpochMs: number) => SessionState,
+    send: () => void,
+  ): void {
+    if (ready) {
+      send();
+      return;
+    }
+    deferred.push(send);
+    optimistic = apply(optimistic ?? session.state, epochNowMs());
+    notify();
+  }
+
+  return {
+    connect: () => session.connect(),
+    disconnect: () => session.disconnect(),
+    getState: () => optimistic ?? session.state,
+    getPeerCount: () => peerCount,
+    getIsConductor: () => isConductor,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    play: () =>
+      command(
+        (state, atEpochMs) =>
+          state.playing
+            ? state
+            : {
+                ...state,
+                playing: true,
+                startEpochMs: atEpochMs + START_LEAD_MS,
+              },
+        () => session.play(),
+      ),
+    stop: () =>
+      command(
+        (state) =>
+          state.playing
+            ? { ...state, playing: false, startEpochMs: null }
+            : state,
+        () => session.stop(),
+      ),
+    setBpm: (bpm) =>
+      command(
+        (state, atEpochMs) => rebaseTempo(state, bpm, atEpochMs),
+        () => session.setBpm(bpm),
+      ),
+    setScene: (scene) =>
+      command(
+        (state) => ({ ...state, scene }),
+        () => session.setScene(scene),
+      ),
+  };
+}
+
+export { createPulseSession };
+export type { PulseSession };

--- a/apps/pulse/src/styles.css
+++ b/apps/pulse/src/styles.css
@@ -1,0 +1,141 @@
+/* Pulse wears plain CSS until sprint 2 extracts the shared design packages.
+   Dark, monospace, generous negative space; one accent for anything lit. */
+
+:root {
+  color-scheme: dark;
+  --bg: #0e0e11;
+  --ink: #e6e4dd;
+  --dim: #58575f;
+  --accent: #f5c04e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+
+.app {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3rem 2rem;
+}
+
+.wordmark {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  letter-spacing: 0.5em;
+  text-indent: 0.5em; /* recenters the tracked-out glyphs */
+  color: var(--ink);
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3rem;
+}
+
+button {
+  font: inherit;
+  color: var(--ink);
+  background: none;
+  border: 1px solid var(--dim);
+  border-radius: 2px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: var(--ink);
+}
+
+button:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.transport {
+  width: 9rem;
+  padding: 1.25rem 0;
+  letter-spacing: 0.3em;
+  text-indent: 0.3em;
+}
+
+.transport[data-playing="true"] {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.tempo {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.tempo button {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+}
+
+.bpm {
+  min-width: 6rem;
+  text-align: center;
+  font-size: 3rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.scenes {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.scenes button {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  color: var(--dim);
+}
+
+.scenes button[aria-pressed="true"] {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--dim);
+  letter-spacing: 0.1em;
+}
+
+.conductor {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  border: 1px solid var(--dim);
+}
+
+.conductor[data-conductor="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+}

--- a/apps/pulse/src/vite-env.d.ts
+++ b/apps/pulse/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/pulse/tsconfig.json
+++ b/apps/pulse/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/pulse/vite.config.ts
+++ b/apps/pulse/vite.config.ts
@@ -1,0 +1,16 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Pulse is served at /pulse/ on the family origin (one origin, path per
+// instrument): BroadcastChannel and Web Locks - everything @haus/bridge is
+// built on - are same-origin only.
+export default defineConfig({
+  base: "/pulse/",
+  plugins: [react()],
+  server: {
+    port: 4445,
+  },
+  build: {
+    outDir: "dist",
+  },
+});

--- a/e2e/family/drumhaus-pulse.spec.ts
+++ b/e2e/family/drumhaus-pulse.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+/**
+ * Cross-app session sync: drumhaus at / and pulse at /pulse/ in one browser
+ * context, jamming over @haus/bridge.
+ *
+ * SKIPPED until the drumhaus session adapter and its LINK control (issue
+ * #417) land on main - that work is in a parallel PR. The body below is
+ * written against #417's planned flow (drumhaus joins the session when LINK
+ * is toggled on; session bpm <-> transport store, play/stop <-> engine,
+ * scene -> variation) so the spec can be enabled by removing the .skip the
+ * moment both PRs have merged. Selector details may need a touch-up against
+ * the real LINK control.
+ */
+
+async function openDrumhaus(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto("/");
+  // Ready when the default kit's sample channels are loaded (mirrors
+  // apps/drumhaus/e2e/helpers.ts).
+  for (let i = 0; i < 8; i++) {
+    await expect(
+      page.locator(`[data-instrument-index="${i}"] button`).first(),
+    ).toBeEnabled({ timeout: 20_000 });
+  }
+  return page;
+}
+
+async function openPulse(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto("/pulse/");
+  await expect(page.getByRole("heading", { name: "pulse" })).toBeVisible();
+  return page;
+}
+
+test.describe("drumhaus <-> pulse session sync", () => {
+  test.skip("tempo, transport, and scene sync both directions once drumhaus is linked", async ({
+    context,
+  }) => {
+    const drumhaus = await openDrumhaus(context);
+    const pulse = await openPulse(context);
+
+    // Drumhaus opts into the session (#417's LINK control); pulse is
+    // always linked.
+    await drumhaus.getByRole("button", { name: /link/i }).click();
+    await expect(pulse.getByText("peers 2")).toBeVisible();
+
+    // pulse -> drumhaus: play from pulse starts the drumhaus transport.
+    await pulse.getByRole("button", { name: "play", exact: true }).click();
+    await expect(
+      drumhaus.getByRole("button", { name: "Pause", exact: true }),
+    ).toBeVisible();
+
+    // drumhaus -> pulse: stopping from drumhaus stops pulse.
+    await drumhaus.getByRole("button", { name: "Pause", exact: true }).click();
+    await expect(
+      pulse.getByRole("button", { name: "play", exact: true }),
+    ).toBeVisible();
+
+    // pulse -> drumhaus: a tempo nudge from pulse reaches drumhaus's bpm
+    // control, and both readouts agree.
+    await pulse.getByLabel("tempo up").click();
+    await expect(pulse.getByLabel("tempo", { exact: true })).toHaveText("121");
+    await expect(drumhaus.getByText("121")).toBeVisible();
+
+    // scene both directions: pulse scene 1 selects drumhaus variation B
+    // while linked, and a drumhaus variation change lights pulse's
+    // indicator (#417 maps scene <-> variation).
+    await pulse.getByRole("button", { name: "scene 1", exact: true }).click();
+    await expect(
+      pulse.getByRole("button", { name: "scene 1", exact: true }),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/e2e/family/pulse-sync.spec.ts
+++ b/e2e/family/pulse-sync.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+/**
+ * Two pulse tabs in one browser context share a session over @haus/bridge:
+ * transport, tempo, and scene sync, and conductorship survives the conductor
+ * tab closing. All assertions are on UI state - what an end user sees.
+ */
+
+async function openPulse(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto("/pulse/");
+  await expect(page.getByRole("heading", { name: "pulse" })).toBeVisible();
+  return page;
+}
+
+/** Open two pulse tabs and wait until each has seen the other. */
+async function openPair(context: BrowserContext): Promise<[Page, Page]> {
+  const a = await openPulse(context);
+  const b = await openPulse(context);
+  await expect(a.getByText("peers 2")).toBeVisible();
+  await expect(b.getByText("peers 2")).toBeVisible();
+  return [a, b];
+}
+
+function playButton(page: Page) {
+  return page.getByRole("button", { name: "play", exact: true });
+}
+
+function stopButton(page: Page) {
+  return page.getByRole("button", { name: "stop", exact: true });
+}
+
+function bpmReadout(page: Page) {
+  return page.getByLabel("tempo", { exact: true });
+}
+
+function sceneButton(page: Page, scene: number) {
+  return page.getByRole("button", { name: `scene ${scene}`, exact: true });
+}
+
+function conductorDot(page: Page) {
+  return page.locator(".conductor");
+}
+
+test.describe("pulse <-> pulse session sync", () => {
+  test("play on one tab starts the other, and stop from the other stops both", async ({
+    context,
+  }) => {
+    const [a, b] = await openPair(context);
+
+    await playButton(a).click();
+    await expect(stopButton(a)).toBeVisible();
+    await expect(stopButton(b)).toBeVisible();
+
+    await stopButton(b).click();
+    await expect(playButton(a)).toBeVisible();
+    await expect(playButton(b)).toBeVisible();
+  });
+
+  test("tempo changes sync in both directions", async ({ context }) => {
+    const [a, b] = await openPair(context);
+
+    await expect(bpmReadout(a)).toHaveText("120");
+    await expect(bpmReadout(b)).toHaveText("120");
+
+    await a.getByLabel("tempo up").click();
+    await a.getByLabel("tempo up").click();
+    await expect(bpmReadout(a)).toHaveText("122");
+    await expect(bpmReadout(b)).toHaveText("122");
+
+    await b.getByLabel("tempo down").click();
+    await expect(bpmReadout(a)).toHaveText("121");
+    await expect(bpmReadout(b)).toHaveText("121");
+  });
+
+  test("scene clicks sync in both directions", async ({ context }) => {
+    const [a, b] = await openPair(context);
+
+    await expect(sceneButton(a, 0)).toHaveAttribute("aria-pressed", "true");
+    await expect(sceneButton(b, 0)).toHaveAttribute("aria-pressed", "true");
+
+    await sceneButton(a, 2).click();
+    await expect(sceneButton(a, 2)).toHaveAttribute("aria-pressed", "true");
+    await expect(sceneButton(b, 2)).toHaveAttribute("aria-pressed", "true");
+
+    await sceneButton(b, 3).click();
+    await expect(sceneButton(a, 3)).toHaveAttribute("aria-pressed", "true");
+    await expect(sceneButton(b, 3)).toHaveAttribute("aria-pressed", "true");
+    await expect(sceneButton(a, 2)).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("closing the conductor tab hands off; state and peers survive", async ({
+    context,
+  }) => {
+    const [a, b] = await openPair(context);
+
+    // The first tab wins the conductor lock; the second follows.
+    await expect(conductorDot(a)).toHaveAttribute("data-conductor", "true");
+    await expect(conductorDot(b)).toHaveAttribute("data-conductor", "false");
+
+    // Put real session state in place from the conductor.
+    await playButton(a).click();
+    await a.getByLabel("tempo up").click();
+    await a.getByLabel("tempo up").click();
+    await a.getByLabel("tempo up").click();
+    await sceneButton(a, 1).click();
+    await expect(stopButton(b)).toBeVisible();
+    await expect(bpmReadout(b)).toHaveText("123");
+
+    await a.close();
+
+    // Web Locks hands conductorship to the survivor; the session state it
+    // carries is intact and the departed peer is dropped.
+    await expect(conductorDot(b)).toHaveAttribute("data-conductor", "true");
+    await expect(stopButton(b)).toBeVisible();
+    await expect(bpmReadout(b)).toHaveText("123");
+    await expect(sceneButton(b, 1)).toHaveAttribute("aria-pressed", "true");
+    await expect(b.getByText("peers 1")).toBeVisible();
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Family-level end-to-end suite (issue #418): multiple instruments on one
+ * origin, exercising @haus/bridge session sync through real UIs.
+ *
+ * The web server mirrors the production deployment plan: one origin, path
+ * per instrument (scripts/family-server.mjs serves drumhaus at / and pulse
+ * at /pulse/). BroadcastChannel and Web Locks - the bridge's substrate - are
+ * same-origin only, so this shape is the point of the harness.
+ *
+ * Building the apps is not this config's job: it assumes both dists exist.
+ * `pnpm test:e2e:family` at the repo root builds drumhaus and pulse first,
+ * then runs this suite against the static server.
+ */
+export default defineConfig({
+  testDir: "./family",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 1 : "25%",
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: "http://localhost:4446",
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "node ../scripts/family-server.mjs",
+    port: 4446,
+    reuseExistingServer: false,
+    timeout: 30_000,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "test:e2e": "pnpm -r test:e2e",
+    "test:e2e:family": "pnpm --filter drumhaus build && pnpm --filter pulse build && playwright test --config e2e/playwright.config.ts",
     "lint": "pnpm -r lint",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
+    "@playwright/test": "1.61.1",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "prettier": "3.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.7.1
         version: 4.7.1(prettier@3.8.4)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -192,6 +195,37 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.3)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  apps/pulse:
+    dependencies:
+      '@haus/bridge':
+        specifier: workspace:*
+        version: link:../../packages/bridge
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.71.0
+      typescript:
+        specifier: ^6
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   packages/bridge:
     devDependencies:

--- a/scripts/family-server.mjs
+++ b/scripts/family-server.mjs
@@ -1,0 +1,87 @@
+/**
+ * Family static server: one origin, path per instrument.
+ *
+ * Serves apps/drumhaus/dist at / and apps/pulse/dist at /pulse/, each with an
+ * SPA fallback to its own index.html. This mirrors the production deployment
+ * plan (issue #414): BroadcastChannel and Web Locks - everything @haus/bridge
+ * is built on - are same-origin only, so proving cross-app session sync
+ * requires every instrument on one host. Node built-ins only, zero deps.
+ *
+ * Assumes both dists exist; `pnpm test:e2e:family` builds them first.
+ */
+
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PORT = Number(process.env.PORT ?? 4446);
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../..");
+const drumhausDist = join(repoRoot, "apps/drumhaus/dist");
+const pulseDist = join(repoRoot, "apps/pulse/dist");
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".ico": "image/x-icon",
+  ".webmanifest": "application/manifest+json",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".wav": "audio/wav",
+  ".mp3": "audio/mpeg",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+/** Route a pathname to an instrument's dist and the path within it. */
+function route(pathname) {
+  if (pathname === "/pulse" || pathname.startsWith("/pulse/")) {
+    return { dist: pulseDist, rel: pathname.slice("/pulse".length) || "/" };
+  }
+  return { dist: drumhausDist, rel: pathname };
+}
+
+async function handle(req, res) {
+  const pathname = decodeURIComponent(
+    new URL(req.url ?? "/", "http://localhost").pathname,
+  );
+  const { dist, rel } = route(pathname);
+
+  const target = normalize(join(dist, rel));
+  if (target !== dist && !target.startsWith(dist + sep)) {
+    res.writeHead(403);
+    res.end("forbidden");
+    return;
+  }
+
+  let file = rel === "/" ? join(dist, "index.html") : target;
+  let body;
+  try {
+    body = await readFile(file);
+  } catch {
+    // SPA fallback: anything unresolvable serves the instrument's index.html.
+    file = join(dist, "index.html");
+    body = await readFile(file);
+  }
+  res.writeHead(200, {
+    "content-type": MIME[extname(file)] ?? "application/octet-stream",
+  });
+  res.end(body);
+}
+
+createServer((req, res) => {
+  handle(req, res).catch((error) => {
+    res.writeHead(500);
+    res.end(String(error));
+  });
+}).listen(PORT, () => {
+  console.log(`family server on http://localhost:${PORT}`);
+  console.log(`  /       -> ${drumhausDist}`);
+  console.log(`  /pulse/ -> ${pulseDist}`);
+});


### PR DESCRIPTION
Part of #414. Closes #418.

## What pulse is

The second haus instrument, and deliberately the smallest one that could exist: a metronome. It has two jobs - prove cross-app session sync end to end, and be read. The code is the reference for how an instrument integrates @haus/bridge:

- `src/session.ts` - the session hookup. Wraps one `createHausSession({ instrument: "pulse" })` in exactly the surface the UI needs (snapshot getters plus one change signal, the four commands). It handles the bridge edge where intents posted between `connect()` and either `onConductorChange(true)` or the first `onStateChange` have no conductor to apply them: until one of those fires, commands are queued for the session and applied to a local optimistic state (built from the bridge's exported clock math), the same treatment the bridge gives pre-connect commands.
- `src/metronome.ts` - the audio core. Raw WebAudio, no Tone: a classic lookahead scheduler (setInterval every 25ms, scheduling 100ms ahead) places click blips directly on the session grid. Beat n falls at `startEpochMs + n * beatMs(bpm)` on the shared epoch clock, and `epochToContextTime` maps that instant onto this tab's AudioContext. One code path covers fresh starts (the 200ms lead makes `ceil(beatsElapsed)` land on beat 0), mid-playback joins (it lands on the first future beat), and tempo rebases (future beats recomputed from the new grid; the few clicks already scheduled under the old one play out). Accent on beat 1 of each 4/4 bar.
- The AudioContext exists only after a user gesture (autoplay policy); any pointerdown qualifies, which also covers joining a session already mid-playback. The session connects on load - pulse is always linked; that is its purpose.

One screen, no routes, no state library, no persistence, plain CSS. UI is bare labels only: play/stop, tempo readout with +/- nudges, four scene indicators, peer count, conductor dot. Verified live in headless Chromium: 5 oscillator starts in 2.2s at 120bpm (downbeat at +200ms, then every 500ms), context running, zero console errors, scheduling halts on stop. Pulse adopts the shared design packages when sprint 2 extracts them.

## Family e2e harness

- `scripts/family-server.mjs` (node built-ins, zero deps) serves `apps/drumhaus/dist` at `/` and `apps/pulse/dist` at `/pulse/`, each with SPA fallback. One origin, path per instrument - this mirrors the production plan exactly, and it is the whole point: BroadcastChannel and Web Locks are same-origin, so a cross-app sync test is only honest on one host.
- `e2e/` at the repo root has its own Playwright config (drumhaus idioms; building is not its job - `pnpm test:e2e:family` builds both apps, then the suite runs against the static server).
- `e2e/family/pulse-sync.spec.ts`: two pulse tabs in one context - play on one starts the other and stop crosses back, tempo syncs both directions, scene clicks sync both directions, and closing the conductor tab hands conductorship to the survivor with tempo/transport/scene intact and the peer count updated.
- `e2e/family/drumhaus-pulse.spec.ts`: documented `test.skip` skeleton. The drumhaus LINK control (#417) is landing in a parallel PR, so the body is written against its planned flow (drumhaus at `/`, toggle LINK, pulse at `/pulse/`, tempo/transport/scene both directions) and can be enabled by deleting the `.skip` once both PRs are on main.
- CI runs `test:e2e:family` right after the existing e2e step (Chromium is already installed by then), and the failure artifact now also collects the family report.

## Test results

- `pnpm format:check`, `pnpm lint` clean
- `pnpm -r test`: bridge 60 passed, drumhaus 853 passed / 4 skipped
- `pnpm build` green across the workspace
- `pnpm test:e2e:family`: 4 passed, 1 skipped (the #417 skeleton) - run 6 times total, zero flakes, ~1.3s per run
- Drumhaus source, e2e suite, and packages/bridge untouched