### PR TITLE
drumhaus session adapter: LINK (#417)

### DIFF
--- a/apps/drumhaus/e2e/link.spec.ts
+++ b/apps/drumhaus/e2e/link.spec.ts
@@ -152,6 +152,47 @@ test.describe("session link", () => {
     await expect(screenBpm(pageB)).toContainText("132");
   });
 
+  test("re-linking after unlink joins from the current local state", async ({
+    page,
+  }) => {
+    const pageB = await openTwoPages(page);
+
+    await enableLink(page);
+    await enableLink(pageB);
+    await expect(linkControl(page)).toHaveAttribute("data-peers", "1");
+
+    // Play while linked: both transports run.
+    await startPlayback(page);
+    await expect(
+      pageB.getByRole("button", { name: "Pause", exact: true }),
+    ).toBeVisible();
+
+    // A leaves the session; its local playback keeps running.
+    await linkControl(page).click();
+    await expect(linkControl(page)).toHaveAttribute("data-linked", "false");
+    await expect(
+      page.getByRole("button", { name: "Pause", exact: true }),
+    ).toBeVisible();
+
+    // Stop everywhere: A locally, B (still linked) through the session.
+    await stopPlayback(page);
+    await stopPlayback(pageB);
+
+    // Re-link A: the fresh join must not resurrect the previous period's
+    // playing grid - both pages stay stopped.
+    await enableLink(page);
+    await expect(linkControl(page)).toHaveAttribute("data-peers", "1");
+    await page.waitForTimeout(500);
+    await expect(
+      page.getByRole("button", { name: "Play", exact: true }),
+    ).toBeVisible();
+    await expect(
+      pageB.getByRole("button", { name: "Play", exact: true }),
+    ).toBeVisible();
+    expect(await litIndicatorIndex(page)).toBe(-1);
+    expect(await litIndicatorIndex(pageB)).toBe(-1);
+  });
+
   test("an unlinked tab is never affected by (and never affects) the session", async ({
     page,
   }) => {

--- a/apps/drumhaus/e2e/link.spec.ts
+++ b/apps/drumhaus/e2e/link.spec.ts
@@ -1,0 +1,182 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  gotoApp,
+  litIndicatorIndex,
+  startPlayback,
+  stopPlayback,
+  waitForAppReady,
+} from "./helpers";
+
+/**
+ * The LINK session feature (issue #417): two drumhaus pages in one browser
+ * context share a @haus/bridge session over BroadcastChannel + Web Locks
+ * (both same-origin, so two pages in one context is exactly the session
+ * boundary). Assertions go through UI state: the floating LINK control's
+ * data attributes, the transport affordances, and the screen readouts.
+ */
+
+const linkControl = (page: Page) =>
+  page.getByRole("button", { name: "LINK", exact: true });
+
+/** Opt a page into the session and wait until it reports linked. */
+async function enableLink(page: Page): Promise<void> {
+  await linkControl(page).click();
+  await expect(linkControl(page)).toHaveAttribute("data-linked", "true");
+}
+
+/**
+ * The tempo screen's bpm readout: click-to-edit via keyboard. Scoped to the
+ * screen value field: the hardware tempo knob is also a slider named "bpm".
+ */
+const screenBpm = (page: Page) =>
+  page.locator('[data-slot="value-field"][aria-label="bpm"]');
+
+async function setBpmViaScreen(page: Page, bpm: number): Promise<void> {
+  const bpmControl = screenBpm(page);
+  await bpmControl.press("Enter");
+  const input = bpmControl.locator("input");
+  await input.fill(String(bpm));
+  await input.press("Enter");
+  await expect(bpmControl).toContainText(String(bpm));
+}
+
+/** A variation pad (A-D) in the pattern module. */
+const variationPad = (page: Page, label: "A" | "B" | "C" | "D") =>
+  page.getByRole("button", { name: label, exact: true });
+
+/** The selected variation pad carries the active border. */
+async function expectVariationSelected(
+  page: Page,
+  label: "A" | "B" | "C" | "D",
+): Promise<void> {
+  await expect(variationPad(page, label)).toHaveClass(/border-primary/);
+}
+
+async function openTwoPages(page: Page): Promise<Page> {
+  await gotoApp(page);
+  const pageB = await page.context().newPage();
+  await pageB.goto("/");
+  await waitForAppReady(pageB);
+  return pageB;
+}
+
+test.describe("session link", () => {
+  test("linked tabs share tempo changes in both directions", async ({
+    page,
+  }) => {
+    const pageB = await openTwoPages(page);
+
+    await enableLink(page);
+    await enableLink(pageB);
+
+    // Both tabs see one other peer; exactly one conducts.
+    await expect(linkControl(page)).toHaveAttribute("data-peers", "1");
+    await expect(linkControl(pageB)).toHaveAttribute("data-peers", "1");
+    await expect(linkControl(page)).toHaveAttribute("data-conductor", "true");
+    await expect(linkControl(pageB)).toHaveAttribute("data-conductor", "false");
+
+    // Conductor -> follower.
+    await setBpmViaScreen(page, 140);
+    await expect(screenBpm(pageB)).toContainText("140");
+
+    // Follower -> conductor (an intent round-trip).
+    await setBpmViaScreen(pageB, 96);
+    await expect(screenBpm(page)).toContainText("96");
+  });
+
+  test("play on one tab starts both; stop on the other stops both", async ({
+    page,
+  }) => {
+    const pageB = await openTwoPages(page);
+
+    await enableLink(page);
+    await enableLink(pageB);
+    await expect(linkControl(page)).toHaveAttribute("data-peers", "1");
+
+    // Play on A: both transports run (the playhead only advances once the
+    // audio clock does, so this asserts real playback on both pages).
+    await startPlayback(page);
+    await expect(
+      pageB.getByRole("button", { name: "Pause", exact: true }),
+    ).toBeVisible();
+    await expect
+      .poll(() => litIndicatorIndex(pageB), { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(0);
+
+    // Stop from B (the follower posts a stop intent): both go idle.
+    await stopPlayback(pageB);
+    await expect(
+      page.getByRole("button", { name: "Play", exact: true }),
+    ).toBeVisible();
+    await expect.poll(() => litIndicatorIndex(page)).toBe(-1);
+  });
+
+  test("variation pads sync through the session scene", async ({ page }) => {
+    const pageB = await openTwoPages(page);
+
+    await enableLink(page);
+    await enableLink(pageB);
+    await expect(linkControl(page)).toHaveAttribute("data-peers", "1");
+
+    // Follower pad -> conductor selection.
+    await variationPad(pageB, "B").click();
+    await expectVariationSelected(pageB, "B");
+    await expectVariationSelected(page, "B");
+
+    // Conductor pad -> follower selection.
+    await variationPad(page, "D").click();
+    await expectVariationSelected(page, "D");
+    await expectVariationSelected(pageB, "D");
+  });
+
+  test("closing the conductor hands conductorship over and state survives", async ({
+    page,
+  }) => {
+    const pageB = await openTwoPages(page);
+
+    // A links first and conducts.
+    await enableLink(page);
+    await enableLink(pageB);
+    await expect(linkControl(page)).toHaveAttribute("data-conductor", "true");
+
+    await setBpmViaScreen(page, 132);
+    await expect(screenBpm(pageB)).toContainText("132");
+
+    // Closing A releases the conductor lock; B takes over with the state
+    // intact and stays linked.
+    await page.close();
+    await expect(linkControl(pageB)).toHaveAttribute("data-conductor", "true");
+    await expect(linkControl(pageB)).toHaveAttribute("data-linked", "true");
+    await expect(linkControl(pageB)).toHaveAttribute("data-peers", "0");
+    await expect(screenBpm(pageB)).toContainText("132");
+  });
+
+  test("an unlinked tab is never affected by (and never affects) the session", async ({
+    page,
+  }) => {
+    const pageB = await openTwoPages(page);
+
+    // Only A opts in. B stays fully local.
+    await enableLink(page);
+    await expect(linkControl(pageB)).toHaveAttribute("data-linked", "false");
+
+    // A's tempo change stays on A.
+    await setBpmViaScreen(page, 150);
+    await expect(screenBpm(pageB)).toContainText("100");
+
+    // B's tempo change stays on B.
+    await setBpmViaScreen(pageB, 80);
+    await expect(screenBpm(page)).toContainText("150");
+
+    // A's playback does not start B.
+    await startPlayback(page);
+    await page.waitForTimeout(500);
+    await expect(
+      pageB.getByRole("button", { name: "Play", exact: true }),
+    ).toBeVisible();
+    expect(await litIndicatorIndex(pageB)).toBe(-1);
+
+    await stopPlayback(page);
+  });
+});

--- a/apps/drumhaus/package.json
+++ b/apps/drumhaus/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@fontsource-variable/albert-sans": "^5.2.8",
+    "@haus/bridge": "workspace:*",
+    "@haus/bridge-react": "workspace:*",
     "@hookform/resolvers": "^5.4.0",
     "@radix-ui/react-checkbox": "^1.3.5",
     "@radix-ui/react-dialog": "^1.1.17",

--- a/apps/drumhaus/src/core/audio/engine/audio-engine.ts
+++ b/apps/drumhaus/src/core/audio/engine/audio-engine.ts
@@ -69,6 +69,7 @@ import {
   configureTransportTiming,
   getCurrentStepFromTransport,
   getCurrentTime,
+  getLiveRawContext,
   setTransportBpm,
   setTransportSwing,
   startTransport,
@@ -148,6 +149,22 @@ interface RenderWavOptions {
    * master-bus-level) and plays at unity master volume.
    */
   masterTap?: "master" | "preMaster";
+}
+
+/**
+ * Options for starting playback.
+ */
+interface PlayOptions {
+  /**
+   * Absolute time on the live context's clock (seconds) at which the
+   * transport starts, with position 0 landing exactly at that instant. If
+   * playback is already running, it is stopped and restarted at that same
+   * instant (a scheduled realign; the bar in flight keeps sounding from
+   * already-scheduled hits). Omitted: the transport starts immediately,
+   * exactly as before. Used by the session adapter (core/session) to start
+   * on the shared session grid.
+   */
+  atContextTime?: number;
 }
 
 /**
@@ -767,8 +784,13 @@ class AudioEngine {
    * the live sequence from pushed state, and starts the transport. Emits
    * onPlaybackStateChange. If a stop() (or newer play()) lands while the
    * context is unlocking, this play stands down as a no-op.
+   *
+   * With options.atContextTime the transport start is scheduled at that
+   * live-context instant instead of now (see PlayOptions); if the context
+   * cannot start (suspended without a user gesture), the returned promise
+   * rejects and playback state is left untouched.
    */
-  async play(): Promise<void> {
+  async play(options?: PlayOptions): Promise<void> {
     const intent = ++this.intentSeq;
     await ensureAudioContextIsRunning("transport");
     if (intent !== this.intentSeq) return;
@@ -777,7 +799,7 @@ class AudioEngine {
     setTransportSwing(this.swing);
 
     this.createLiveSequence();
-    startTransport();
+    startTransport(options?.atContextTime);
     this.setIsPlayingAndNotify(true);
   }
 
@@ -922,6 +944,17 @@ class AudioEngine {
    */
   getCurrentStep(): number {
     return getCurrentStepFromTransport();
+  }
+
+  /**
+   * The LIVE context's underlying AudioContext, via Tone's public
+   * Context.rawContext and the retained live transport (never the offline
+   * one). Read-only clock access for callers that map external clocks onto
+   * the audio clock - the session adapter's epoch-to-context-time mapping
+   * (core/session) is the consumer. Not a mutation surface.
+   */
+  getLiveAudioContext(): BaseAudioContext {
+    return getLiveRawContext();
   }
 
   /**
@@ -1154,5 +1187,6 @@ export type {
   KitLoadResult,
   KitSampleDescriptor,
   PlaybackConfig,
+  PlayOptions,
   RenderWavOptions,
 };

--- a/apps/drumhaus/src/core/audio/engine/transport/transport.ts
+++ b/apps/drumhaus/src/core/audio/engine/transport/transport.ts
@@ -22,9 +22,39 @@ const liveTransport = getTransport();
 
 /**
  * Start the live transport and all sources synced to it.
+ *
+ * With no argument the transport starts immediately (the local path). With
+ * atContextTime (absolute seconds on the live context's clock) it starts -
+ * or restarts - exactly at that instant: the transport is first stopped at
+ * that same instant, which cancels any pending scheduled start and resets
+ * the position, so the downbeat lands at atContextTime with position 0
+ * whether the transport was running or not. This is the session adapter's
+ * grid-aligned start (core/session); Tone's Clock.stop is a safe no-op on
+ * a stopped transport.
  */
-function startTransport(): void {
-  liveTransport.start();
+function startTransport(atContextTime?: number): void {
+  if (atContextTime === undefined) {
+    liveTransport.start();
+    return;
+  }
+  liveTransport.stop(atContextTime);
+  liveTransport.start(atContextTime);
+}
+
+/**
+ * The LIVE context's underlying AudioContext, reached through the retained
+ * live transport (so a call landing mid-offline-render can never hand out
+ * the offline context) and Tone's public Context.rawContext surface - no
+ * private internals involved (tone-internals.ts keeps its monopoly).
+ *
+ * Used by the session adapter to map the shared epoch clock onto the audio
+ * clock for grid-aligned starts. Note: Tone's default context is a
+ * standardized-audio-context wrapper without getOutputTimestamp, so epoch
+ * mapping consumers fall back to currentTime anchoring (a few ms, uniform
+ * across same-machine tabs - see @haus/bridge clock.ts).
+ */
+function getLiveRawContext(): BaseAudioContext {
+  return liveTransport.context.rawContext;
 }
 
 /**
@@ -99,4 +129,5 @@ export {
   configureTransportTiming,
   getCurrentTime,
   getCurrentStepFromTransport,
+  getLiveRawContext,
 };

--- a/apps/drumhaus/src/core/providers/drumhaus-provider/drumhaus-provider.tsx
+++ b/apps/drumhaus/src/core/providers/drumhaus-provider/drumhaus-provider.tsx
@@ -1,5 +1,6 @@
 import { useEngineBridge } from "@/core/audio/bridge/use-engine-bridge";
 import { useKitLoadFailureToast } from "@/core/audio/bridge/use-kit-load-failure";
+import { useSessionBridge } from "@/core/session/use-session-bridge";
 import { usePresetLoading } from "@/features/preset/hooks/use-preset-loading";
 import { DrumhausContext, type DrumhausContextValue } from "./drumhaus-context";
 
@@ -8,8 +9,9 @@ interface DrumhausProviderProps {
 }
 
 const DrumhausProvider = ({ children }: DrumhausProviderProps) => {
-  // --- Audio Engine Bridge and Preset Loading ---
+  // --- Audio Engine Bridge, Session Bridge, and Preset Loading ---
   useEngineBridge();
+  useSessionBridge();
   useKitLoadFailureToast();
   const { loadPresetDocument, importPresetFileText } = usePresetLoading();
 

--- a/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Session adapter behavior over deterministic injected seams: @haus/bridge
+ * memoryHub transports, an in-memory Web Locks stand-in, a frozen epoch
+ * clock, and a fake engine. Covers the drumhaus-specific wiring from issue
+ * #417: seed-then-connect (conduct vs adopt), the inbound echo-loop guard,
+ * scene <-> variation in both directions, the chain-as-conductor path,
+ * grid-aligned play/stop, and the deferred-command window end to end (the
+ * queue/optimistic logic itself is unit-tested in @haus/bridge-react).
+ *
+ * Browser-mode because the real stores' actions reach the AudioEngine
+ * (which owns Tone.js objects); the adapter itself only ever talks to the
+ * injected fake engine here.
+ */
+
+import {
+  createHausSession,
+  memoryHub,
+  START_LEAD_MS,
+  type BridgeMessage,
+  type BridgeTransport,
+  type HausLockManager,
+  type HausSession,
+} from "@haus/bridge";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
+import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import {
+  createSessionAdapter,
+  type SessionAdapter,
+  type SessionEngine,
+} from "./session-adapter";
+
+// -----------------------------------------------------------------------------
+// Deterministic seams
+// -----------------------------------------------------------------------------
+
+interface LockWaiter {
+  granted: boolean;
+  aborted: boolean;
+  run: () => void;
+}
+
+/**
+ * In-memory Web Locks stand-in (mirrors the bridge's own test helper):
+ * FIFO grant order, held until the callback's promise settles, abortable
+ * while pending.
+ */
+function memoryLocks(): HausLockManager {
+  const held = new Set<string>();
+  const queues = new Map<string, LockWaiter[]>();
+
+  function pump(name: string): void {
+    if (held.has(name)) return;
+    const queue = queues.get(name);
+    while (queue !== undefined && queue.length > 0) {
+      const waiter = queue.shift()!;
+      if (waiter.aborted) continue;
+      waiter.granted = true;
+      held.add(name);
+      queueMicrotask(waiter.run);
+      return;
+    }
+  }
+
+  return {
+    request(name, options, callback) {
+      return new Promise((resolve, reject) => {
+        const waiter: LockWaiter = {
+          granted: false,
+          aborted: false,
+          run: () => {
+            void (async () => {
+              try {
+                resolve(await callback());
+              } catch (error) {
+                reject(error);
+              } finally {
+                held.delete(name);
+                pump(name);
+              }
+            })();
+          },
+        };
+        options.signal?.addEventListener("abort", () => {
+          if (waiter.granted || waiter.aborted) return;
+          waiter.aborted = true;
+          reject(new DOMException("The request was aborted.", "AbortError"));
+        });
+        const queue = queues.get(name) ?? [];
+        queue.push(waiter);
+        queues.set(name, queue);
+        pump(name);
+      });
+    },
+  };
+}
+
+/** Drain chained microtasks (memory transport delivery, lock grants). */
+async function flushMicrotasks(rounds = 25): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
+/** Let the adapter's deferred (macrotask) playback sync run too. */
+async function flushAll(): Promise<void> {
+  await flushMicrotasks();
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  await flushMicrotasks();
+}
+
+interface FakeEngine extends SessionEngine {
+  playCalls: ({ atContextTime?: number } | undefined)[];
+  stopCalls: number;
+  contextTime: number;
+  emitVariation(variation: number): void;
+}
+
+function createFakeEngine(): FakeEngine {
+  const listeners = new Set<(variation: number) => void>();
+  const engine: FakeEngine = {
+    playCalls: [],
+    stopCalls: 0,
+    contextTime: 5,
+    play(options) {
+      engine.playCalls.push(options);
+      return Promise.resolve();
+    },
+    stop() {
+      engine.stopCalls += 1;
+    },
+    getLiveAudioContext() {
+      return { currentTime: engine.contextTime };
+    },
+    onPlaybackVariationChange(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emitVariation(variation) {
+      listeners.forEach((listener) => listener(variation));
+    },
+  };
+  return engine;
+}
+
+interface Rig {
+  nowMs: { value: number };
+  engine: FakeEngine;
+  /** The session instance the adapter wraps. */
+  adapterSession: HausSession;
+  adapter: SessionAdapter;
+  /** A raw peer session on the same hub/locks (auto-tracked for cleanup). */
+  createPeer(instrument?: string): HausSession;
+  /** A bare wire on the hub, for observing raw protocol traffic. */
+  createWire(): BridgeTransport;
+  locks: HausLockManager;
+}
+
+const cleanups: (() => void)[] = [];
+
+function createRig(locks: HausLockManager = memoryLocks()): Rig {
+  const hub = memoryHub();
+  const nowMs = { value: 1_000_000 };
+  const now = () => nowMs.value;
+  const engine = createFakeEngine();
+
+  const session = createHausSession({
+    instrument: "drumhaus",
+    transport: hub.createTransport(),
+    locks,
+    now,
+  });
+  const adapter = createSessionAdapter({
+    engine,
+    now,
+    createSession: () => session,
+  });
+  cleanups.push(() => adapter.unlink());
+
+  return {
+    nowMs,
+    engine,
+    adapter,
+    adapterSession: session,
+    createPeer(instrument = "peer") {
+      const peer = createHausSession({
+        instrument,
+        transport: hub.createTransport(),
+        locks,
+        now,
+      });
+      cleanups.push(() => peer.disconnect());
+      return peer;
+    },
+    createWire: () => hub.createTransport(),
+    locks,
+  };
+}
+
+beforeEach(() => {
+  useTransportStore.setState({ bpm: 100, isPlaying: false });
+  usePatternStore.setState({ variation: 0, chainEnabled: false });
+});
+
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup());
+});
+
+// -----------------------------------------------------------------------------
+// Seed then connect
+// -----------------------------------------------------------------------------
+
+describe("seed then connect", () => {
+  it("a lone tab conducts and its seeded state becomes the session's", async () => {
+    const rig = createRig();
+    useTransportStore.setState({ bpm: 128 });
+    usePatternStore.setState({ variation: 2 });
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
+    expect(rig.adapterSession.state.bpm).toBe(128);
+    expect(rig.adapterSession.state.scene).toBe(2);
+
+    // A late joiner adopts the seeded state.
+    const joiner = rig.createPeer();
+    joiner.connect();
+    await flushMicrotasks();
+    expect(joiner.state.bpm).toBe(128);
+    expect(joiner.state.scene).toBe(2);
+    expect(rig.adapter.controller.getSnapshot().peers).toHaveLength(1);
+  });
+
+  it("adopts the existing conductor's state when a session already exists", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.setBpm(90);
+    conductor.setScene(1);
+    conductor.connect();
+    await flushMicrotasks();
+
+    useTransportStore.setState({ bpm: 128 });
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    // The conductor's state wins; the local bpm jumps. Correct behavior.
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(false);
+    expect(useTransportStore.getState().bpm).toBe(90);
+    expect(usePatternStore.getState().variation).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Echo-loop guard
+// -----------------------------------------------------------------------------
+
+describe("echo-loop guard", () => {
+  it("inbound session bpm reaches the store without re-emitting an intent", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    const intents: BridgeMessage[] = [];
+    const wire = rig.createWire();
+    wire.subscribe((data) => {
+      const message = data as BridgeMessage;
+      if (message.type === "intent") intents.push(message);
+    });
+
+    conductor.setBpm(150);
+    await flushAll();
+
+    expect(useTransportStore.getState().bpm).toBe(150);
+    expect(intents).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Scene <-> variation
+// -----------------------------------------------------------------------------
+
+describe("scene and variation", () => {
+  it("inbound scene selects the variation; local selection posts setScene", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    // Inbound: session scene -> pattern store variation.
+    conductor.setScene(2);
+    await flushMicrotasks();
+    expect(usePatternStore.getState().variation).toBe(2);
+
+    // Outbound: local pad selection -> session scene (via intent).
+    usePatternStore.getState().setVariation(3);
+    await flushMicrotasks();
+    expect(conductor.state.scene).toBe(3);
+    // And the echo back leaves the local selection untouched.
+    expect(usePatternStore.getState().variation).toBe(3);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Chain as conductor
+// -----------------------------------------------------------------------------
+
+describe("chain-driven scenes", () => {
+  it("a conducting tab with the chain enabled broadcasts playback variations as scenes", async () => {
+    const rig = createRig();
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
+
+    const follower = rig.createPeer();
+    follower.connect();
+    await flushMicrotasks();
+
+    // Chain disabled: bar-boundary variation changes stay local.
+    rig.engine.emitVariation(1);
+    await flushMicrotasks();
+    expect(rig.adapterSession.state.scene).toBe(0);
+
+    usePatternStore.setState({ chainEnabled: true });
+    rig.engine.emitVariation(1);
+    await flushMicrotasks();
+    expect(rig.adapterSession.state.scene).toBe(1);
+    expect(follower.state.scene).toBe(1);
+  });
+
+  it("a following tab never broadcasts chain variations", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+    usePatternStore.setState({ chainEnabled: true });
+
+    rig.engine.emitVariation(2);
+    await flushAll();
+    expect(conductor.state.scene).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Deferred-command window (end to end through the adapter)
+// -----------------------------------------------------------------------------
+
+describe("deferred-command window", () => {
+  it("a command right after connect is not lost: local immediately, session once ready", async () => {
+    const locks = memoryLocks();
+    // Hold the conductor lock externally so the adapter's grant is pending
+    // and no conductor exists to apply intents.
+    let releaseBlocker!: () => void;
+    void locks.request(
+      "haus:conductor",
+      {},
+      () => new Promise<void>((resolve) => (releaseBlocker = resolve)),
+    );
+    await flushMicrotasks();
+
+    const rig = createRig(locks);
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(false);
+
+    const intents: BridgeMessage[] = [];
+    const wire = rig.createWire();
+    wire.subscribe((data) => {
+      const message = data as BridgeMessage;
+      if (message.type === "intent") intents.push(message);
+    });
+
+    // A user command right after connect: no conductor yet, so posting an
+    // intent would drop it. Locally it applies immediately (the store owns
+    // it), and the controller defers the session command.
+    useTransportStore.setState({ bpm: 133 });
+    await flushAll();
+    expect(intents).toHaveLength(0);
+    expect(useTransportStore.getState().bpm).toBe(133);
+
+    // Once this tab conducts, the deferred command lands in the session
+    // rather than being lost.
+    releaseBlocker();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
+    expect(rig.adapterSession.state.bpm).toBe(133);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Grid-aligned playback
+// -----------------------------------------------------------------------------
+
+describe("grid-aligned playback", () => {
+  it("inbound play starts the engine at the shared downbeat; stop stops it", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    conductor.play();
+    await flushAll();
+
+    expect(rig.engine.playCalls).toHaveLength(1);
+    // During the start lead window the next bar boundary is bar 0's
+    // downbeat itself: startEpochMs = now + START_LEAD_MS, mapped onto the
+    // fake context whose clock reads 5s at the frozen epoch instant.
+    const expected = rig.engine.contextTime + START_LEAD_MS / 1000;
+    expect(rig.engine.playCalls[0]?.atContextTime).toBeCloseTo(expected, 6);
+
+    // The engine reports the start; the bridge mirror would normally set
+    // this - simulate it so the stop path sees a playing transport.
+    useTransportStore.setState({ isPlaying: true });
+
+    conductor.stop();
+    await flushAll();
+    expect(rig.engine.stopCalls).toBe(1);
+  });
+
+  it("a tempo rebase while playing glides instead of restarting", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    conductor.play();
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(1);
+    useTransportStore.setState({ isPlaying: true });
+
+    conductor.setBpm(160);
+    await flushAll();
+
+    // The bpm reached the store (and through it the live transport), but
+    // the phase-continuous rebase never restarts local playback.
+    expect(useTransportStore.getState().bpm).toBe(160);
+    expect(rig.engine.playCalls).toHaveLength(1);
+    expect(rig.engine.stopCalls).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Unlink
+// -----------------------------------------------------------------------------
+
+describe("unlink", () => {
+  it("disconnects and stops reacting to the session", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    // Same tempo as the local store, so linking itself changes nothing and
+    // the assertion below isolates the unlink behavior.
+    conductor.setBpm(100);
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().peers).toHaveLength(1);
+
+    rig.adapter.unlink();
+    expect(rig.adapter.isLinked()).toBe(false);
+    expect(rig.adapter.controller.getSnapshot().linked).toBe(false);
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(false);
+
+    conductor.setBpm(180);
+    await flushAll();
+    expect(useTransportStore.getState().bpm).toBe(100);
+  });
+});

--- a/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
@@ -147,8 +147,8 @@ function createFakeEngine(): FakeEngine {
 interface Rig {
   nowMs: { value: number };
   engine: FakeEngine;
-  /** The session instance the adapter wraps. */
-  adapterSession: HausSession;
+  /** The session instance the adapter currently wraps (fresh per link). */
+  adapterSession: () => HausSession;
   adapter: SessionAdapter;
   /** A raw peer session on the same hub/locks (auto-tracked for cleanup). */
   createPeer(instrument?: string): HausSession;
@@ -165,16 +165,22 @@ function createRig(locks: HausLockManager = memoryLocks()): Rig {
   const now = () => nowMs.value;
   const engine = createFakeEngine();
 
-  const session = createHausSession({
-    instrument: "drumhaus",
-    transport: hub.createTransport(),
-    locks,
-    now,
-  });
+  // The adapter creates a FRESH session per link(); track them so tests can
+  // address the current one.
+  const sessions: HausSession[] = [];
   const adapter = createSessionAdapter({
     engine,
     now,
-    createSession: () => session,
+    createSession: () => {
+      const session = createHausSession({
+        instrument: "drumhaus",
+        transport: hub.createTransport(),
+        locks,
+        now,
+      });
+      sessions.push(session);
+      return session;
+    },
   });
   cleanups.push(() => adapter.unlink());
 
@@ -182,7 +188,7 @@ function createRig(locks: HausLockManager = memoryLocks()): Rig {
     nowMs,
     engine,
     adapter,
-    adapterSession: session,
+    adapterSession: () => sessions[sessions.length - 1],
     createPeer(instrument = "peer") {
       const peer = createHausSession({
         instrument,
@@ -221,8 +227,8 @@ describe("seed then connect", () => {
     await flushMicrotasks();
 
     expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
-    expect(rig.adapterSession.state.bpm).toBe(128);
-    expect(rig.adapterSession.state.scene).toBe(2);
+    expect(rig.adapterSession().state.bpm).toBe(128);
+    expect(rig.adapterSession().state.scene).toBe(2);
 
     // A late joiner adopts the seeded state.
     const joiner = rig.createPeer();
@@ -327,12 +333,12 @@ describe("chain-driven scenes", () => {
     // Chain disabled: bar-boundary variation changes stay local.
     rig.engine.emitVariation(1);
     await flushMicrotasks();
-    expect(rig.adapterSession.state.scene).toBe(0);
+    expect(rig.adapterSession().state.scene).toBe(0);
 
     usePatternStore.setState({ chainEnabled: true });
     rig.engine.emitVariation(1);
     await flushMicrotasks();
-    expect(rig.adapterSession.state.scene).toBe(1);
+    expect(rig.adapterSession().state.scene).toBe(1);
     expect(follower.state.scene).toBe(1);
   });
 
@@ -394,7 +400,7 @@ describe("deferred-command window", () => {
     releaseBlocker();
     await flushMicrotasks();
     expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
-    expect(rig.adapterSession.state.bpm).toBe(133);
+    expect(rig.adapterSession().state.bpm).toBe(133);
   });
 });
 
@@ -482,5 +488,84 @@ describe("unlink", () => {
     conductor.setBpm(180);
     await flushAll();
     expect(useTransportStore.getState().bpm).toBe(100);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Re-link (fresh session per linked period)
+// -----------------------------------------------------------------------------
+
+describe("re-link", () => {
+  it("re-linking solo after link/play/unlink/stop does not auto-start", async () => {
+    const rig = createRig();
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    // Play while linked: the session carries a grid.
+    useTransportStore.setState({ isPlaying: true });
+    await flushAll();
+    expect(rig.adapterSession().state.playing).toBe(true);
+    const playCallsWhileLinked = rig.engine.playCalls.length;
+
+    // Unlink (local playback keeps running), then the user stops locally.
+    rig.adapter.unlink();
+    useTransportStore.setState({ isPlaying: false });
+
+    // Re-link solo: the fresh session must reflect the local stopped
+    // state, not the previous period's playing:true grid - conducting it
+    // must neither restart the engine nor broadcast an ancient grid.
+    rig.adapter.link();
+    await flushAll();
+
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
+    expect(rig.adapterSession().state.playing).toBe(false);
+    expect(rig.adapterSession().state.startEpochMs).toBeNull();
+    expect(rig.engine.playCalls.length).toBe(playCallsWhileLinked);
+  });
+
+  it("re-linking after conducting at a high rev adopts a younger live session", async () => {
+    const rig = createRig();
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
+
+    // Conduct several changes so the first period's rev climbs well above
+    // a fresh session's.
+    useTransportStore.setState({ bpm: 110 });
+    useTransportStore.setState({ bpm: 120 });
+    useTransportStore.setState({ bpm: 130 });
+    await flushAll();
+    const staleSession = rig.adapterSession();
+    expect(staleSession.state.rev).toBeGreaterThanOrEqual(3);
+
+    rig.adapter.unlink();
+
+    // A fresh session forms elsewhere at a low rev.
+    const conductor = rig.createPeer();
+    conductor.setBpm(90);
+    conductor.connect();
+    await flushMicrotasks();
+    expect(conductor.state.rev).toBe(0);
+
+    // Re-linking must adopt the live conductor's state (a stale-high rev
+    // would make the follower deaf to every broadcast).
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapterSession()).not.toBe(staleSession);
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(false);
+    expect(useTransportStore.getState().bpm).toBe(90);
+
+    // Still listening: later conductor changes keep landing.
+    conductor.setBpm(95);
+    await flushAll();
+    expect(useTransportStore.getState().bpm).toBe(95);
+
+    // Handover: winning conductorship must rebroadcast the live state, not
+    // time-travel the session back to the stale first period.
+    conductor.disconnect();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
+    expect(rig.adapterSession().state.bpm).toBe(95);
+    expect(useTransportStore.getState().bpm).toBe(95);
   });
 });

--- a/apps/drumhaus/src/core/session/session-adapter.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.ts
@@ -1,0 +1,369 @@
+/**
+ * The adapter between the Zustand stores / AudioEngine and the shared haus
+ * session (issue #417, epic #414). Mirrors core/audio/bridge: store
+ * subscriptions feed session commands, session changes flow back into the
+ * stores, and an applying-guard keeps inbound state from echoing back out
+ * as intents.
+ *
+ * The session side is @haus/bridge-react's SessionController, which
+ * owns the external-store snapshot and the deferred-command readiness
+ * handling (the connect-window edge where intents can be dropped before a
+ * conductor exists); this adapter owns only what is drumhaus-specific.
+ *
+ * Direction map while linked:
+ * - inbound (session -> app): bpm -> transport store, scene -> pattern
+ *   store variation, playing -> engine start aligned to the shared grid /
+ *   engine stop.
+ * - outbound (app -> session): user bpm changes, play/stop, and variation
+ *   selection become session commands; while this tab conducts with the
+ *   chain enabled, the engine's playback-variation changes drive setScene
+ *   (the conductor's chain is the session's song structure).
+ *
+ * Grid alignment: playback starts at the shared grid's next bar boundary
+ * (during the start lead window that is bar 0's downbeat itself), mapped
+ * onto the live AudioContext with @haus/bridge's epoch clock helpers.
+ * Alignment is deferred one macrotask so a user gesture's own
+ * store-driven engine.play() lands first and the aligned start supersedes
+ * it (the engine's playback intent sequencing guarantees the later call
+ * wins). A tempo rebase while playing is applied as a glide - the protocol
+ * rebases phase-continuously and the transport bpm change preserves phase,
+ * so no restart (and no chain reset) is needed; realignment (a scheduled
+ * restart on the boundary) happens only when adopting a grid this tab is
+ * not already playing on. Same-machine context drift is negligible in v1;
+ * there is no correction loop.
+ */
+
+import {
+  createHausSession,
+  epochNowMs,
+  epochToContextTime,
+  nextBarStartEpochMs,
+  type BridgeAudioContext,
+  type HausSession,
+  type SessionState,
+} from "@haus/bridge";
+import {
+  createSessionController,
+  type SessionController,
+} from "@haus/bridge-react";
+
+import { getAudioEngine } from "@/core/audio/engine";
+import { clampVariationId } from "@/core/audio/engine/pattern-types";
+import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
+import { useTransportStore } from "@/features/transport/store/use-transport-store";
+
+/**
+ * Lead added ahead of "now" when picking the bar boundary to start on, so
+ * the scheduled context time is always comfortably in the future once the
+ * start command reaches the transport.
+ */
+const SCHEDULE_MARGIN_MS = 50;
+
+/**
+ * The engine surface the adapter drives. Structural so tests can inject a
+ * fake; the default is the real AudioEngine facade.
+ */
+interface SessionEngine {
+  play(options?: { atContextTime?: number }): Promise<void>;
+  stop(): void;
+  getLiveAudioContext(): BridgeAudioContext;
+  onPlaybackVariationChange(listener: (variation: number) => void): () => void;
+}
+
+interface SessionAdapterOptions {
+  /** Engine command surface; defaults to the AudioEngine singleton. */
+  engine?: SessionEngine;
+  /** Session factory; defaults to a real BroadcastChannel-backed session. */
+  createSession?: () => HausSession;
+  /** Epoch clock; defaults to epochNowMs. Injectable for tests. */
+  now?: () => number;
+}
+
+interface SessionAdapter {
+  /** Join the shared session (seed local state, then connect). Idempotent. */
+  link(): void;
+  /** Leave the session and restore fully local behavior. Idempotent. */
+  unlink(): void;
+  isLinked(): boolean;
+  /** The shared controller; the LINK control reads it via useSession. */
+  controller: SessionController;
+}
+
+/** The shared musical grid this tab last aligned its playback to. */
+interface SharedGrid {
+  bpm: number;
+  startEpochMs: number;
+}
+
+function stateGrid(state: SessionState): SharedGrid | null {
+  return state.playing && state.startEpochMs !== null
+    ? { bpm: state.bpm, startEpochMs: state.startEpochMs }
+    : null;
+}
+
+function createSessionAdapter(
+  options: SessionAdapterOptions = {},
+): SessionAdapter {
+  const engine = options.engine ?? getAudioEngine();
+  const now = options.now ?? epochNowMs;
+  const session =
+    options.createSession?.() ?? createHausSession({ instrument: "drumhaus" });
+  const controller = createSessionController(session, { now });
+
+  /** Applying-guard: inbound store writes must not echo back as intents. */
+  let applying = false;
+  /** Grid the local transport is (or is being) aligned to; null while the
+   * local engine is not playing on a shared grid. */
+  let appliedGrid: SharedGrid | null = null;
+  /** Latest inbound playback target, coalesced into one deferred sync.
+   * undefined = nothing pending; null = stop. */
+  let pendingGrid: SharedGrid | null | undefined;
+  let pendingSyncTimer: ReturnType<typeof setTimeout> | null = null;
+  let unsubscribers: (() => void)[] = [];
+
+  const linked = () => controller.getSnapshot().linked;
+
+  // --- Playback alignment (session grid -> engine) ---
+
+  function startAlignedToGrid(grid: SharedGrid): void {
+    // During the start lead window the "next bar boundary" is bar 0's
+    // downbeat itself, so fresh starts and mid-playback joins share one
+    // formula. Drumhaus patterns loop one bar, so starting at a bar
+    // boundary with position 0 is exact alignment.
+    const target = nextBarStartEpochMs(
+      {
+        rev: 0,
+        bpm: grid.bpm,
+        playing: true,
+        startEpochMs: grid.startEpochMs,
+        scene: 0,
+      },
+      now() + SCHEDULE_MARGIN_MS,
+    );
+    if (target === null) return; // unreachable: the grid implies playing
+    const atContextTime = epochToContextTime(
+      engine.getLiveAudioContext(),
+      target,
+      now,
+    );
+    void engine.play({ atContextTime }).catch(() => {
+      // The context could not start (suspended with no usable gesture):
+      // stay stopped locally and let a later state or user gesture retry.
+      appliedGrid = null;
+    });
+  }
+
+  function applyPlaybackSync(grid: SharedGrid | null): void {
+    if (!linked()) return; // unlinked while the sync was pending
+
+    if (grid === null) {
+      // Follower stop is immediate. Skipped when already idle so a stop
+      // echo can never cancel an in-flight user play().
+      if (useTransportStore.getState().isPlaying || appliedGrid !== null) {
+        engine.stop();
+      }
+      appliedGrid = null;
+      return;
+    }
+
+    if (appliedGrid !== null && useTransportStore.getState().isPlaying) {
+      const sameGrid =
+        appliedGrid.bpm === grid.bpm &&
+        appliedGrid.startEpochMs === grid.startEpochMs;
+      // A tempo rebase is phase-continuous by protocol design and the
+      // transport bpm was already updated inbound, so the local transport
+      // glides onto the new grid - no restart (and no chain reset).
+      const tempoRebase = appliedGrid.bpm !== grid.bpm;
+      if (sameGrid || tempoRebase) {
+        appliedGrid = grid;
+        return;
+      }
+    }
+
+    appliedGrid = grid;
+    startAlignedToGrid(grid);
+  }
+
+  /**
+   * Defer playback alignment one macrotask, coalescing bursts (latest
+   * wins). The deferral is load-bearing: when the local user pressed play,
+   * togglePlay's own engine.play() is issued synchronously after its store
+   * write; running the aligned play after it makes the aligned start the
+   * newest playback intent, so the immediate unaligned start stands down.
+   */
+  function schedulePlaybackSync(grid: SharedGrid | null): void {
+    pendingGrid = grid;
+    if (pendingSyncTimer !== null) return;
+    pendingSyncTimer = setTimeout(() => {
+      pendingSyncTimer = null;
+      const target = pendingGrid;
+      pendingGrid = undefined;
+      if (target !== undefined) applyPlaybackSync(target);
+    }, 0);
+  }
+
+  // --- Inbound: controller snapshot -> stores ---
+
+  function handleControllerChange(): void {
+    const snapshot = controller.getSnapshot();
+    if (!snapshot.linked) return;
+
+    applying = true;
+    try {
+      const transport = useTransportStore.getState();
+      if (transport.bpm !== snapshot.state.bpm) {
+        // setBpm also pushes engine.setTempo, so a playing transport
+        // glides onto a rebased grid within the same synchronous dispatch.
+        transport.setBpm(snapshot.state.bpm);
+      }
+      const pattern = usePatternStore.getState();
+      if (pattern.variation !== snapshot.state.scene) {
+        // The engine applies variation changes at the next bar on its own;
+        // no extra quantization here.
+        pattern.setVariation(snapshot.state.scene);
+      }
+    } finally {
+      applying = false;
+    }
+
+    schedulePlaybackSync(stateGrid(snapshot.state));
+  }
+
+  // --- Outbound: store changes -> session commands ---
+
+  function handleBpmChange(bpm: number): void {
+    if (applying || !linked()) return;
+    if (controller.getSnapshot().state.bpm === bpm) return;
+    controller.setBpm(bpm);
+  }
+
+  function handleVariationChange(variation: number): void {
+    if (applying || !linked()) return;
+    const scene = clampVariationId(variation);
+    if (controller.getSnapshot().state.scene === scene) return;
+    controller.setScene(scene);
+  }
+
+  function handlePlayingChange(isPlaying: boolean): void {
+    if (applying || !linked()) return;
+    const state = controller.getSnapshot().state;
+    if (isPlaying === state.playing) {
+      // Local play while the session is already playing (e.g. this tab
+      // stayed stopped earlier because its context could not start): the
+      // play gesture is the join - align to the existing grid instead of
+      // posting a no-op intent.
+      if (isPlaying && appliedGrid === null) {
+        schedulePlaybackSync(stateGrid(state));
+      }
+      return;
+    }
+    if (isPlaying) {
+      controller.play();
+    } else {
+      controller.stop();
+    }
+  }
+
+  function handlePlaybackVariationChange(variation: number): void {
+    if (applying || !linked()) return;
+    // The conductor's chain is the session's song structure: bar-boundary
+    // variation changes driven by the chain become scene changes.
+    const snapshot = controller.getSnapshot();
+    if (!snapshot.isConductor) return;
+    if (!usePatternStore.getState().chainEnabled) return;
+    const scene = clampVariationId(variation);
+    if (snapshot.state.scene === scene) return;
+    controller.setScene(scene);
+  }
+
+  // --- Link lifecycle ---
+
+  function link(): void {
+    if (linked()) return;
+    appliedGrid = null;
+
+    // Seed BEFORE connecting: pre-connect commands apply locally without a
+    // rev bump, so if this tab becomes conductor its seeded state
+    // broadcasts; if a session already exists, the conductor's state wins
+    // and the seeds are simply overwritten. Local playback is seeded too:
+    // conducting while playing publishes a fresh grid this tab then aligns
+    // itself to via its own state change.
+    const transport = useTransportStore.getState();
+    controller.setBpm(transport.bpm);
+    controller.setScene(usePatternStore.getState().variation);
+    if (transport.isPlaying) {
+      controller.play();
+    }
+
+    // Session -> app, wired before connect so nothing is missed.
+    unsubscribers.push(controller.subscribe(handleControllerChange));
+
+    controller.connect();
+
+    // App -> session (manual prev-diffing, as in use-engine-bridge).
+    let prevBpm = useTransportStore.getState().bpm;
+    let prevPlaying = useTransportStore.getState().isPlaying;
+    unsubscribers.push(
+      useTransportStore.subscribe((state) => {
+        if (state.bpm !== prevBpm) {
+          prevBpm = state.bpm;
+          handleBpmChange(state.bpm);
+        }
+        if (state.isPlaying !== prevPlaying) {
+          prevPlaying = state.isPlaying;
+          handlePlayingChange(state.isPlaying);
+        }
+      }),
+    );
+    let prevVariation = usePatternStore.getState().variation;
+    unsubscribers.push(
+      usePatternStore.subscribe((state) => {
+        if (state.variation !== prevVariation) {
+          prevVariation = state.variation;
+          handleVariationChange(state.variation);
+        }
+      }),
+    );
+    unsubscribers.push(
+      engine.onPlaybackVariationChange(handlePlaybackVariationChange),
+    );
+  }
+
+  function unlink(): void {
+    if (!linked()) return;
+    if (pendingSyncTimer !== null) {
+      clearTimeout(pendingSyncTimer);
+      pendingSyncTimer = null;
+    }
+    pendingGrid = undefined;
+    unsubscribers.forEach((unsubscribe) => unsubscribe());
+    unsubscribers = [];
+    controller.disconnect();
+    appliedGrid = null;
+    // Fully local from here: playback (if any) keeps running untouched.
+  }
+
+  return {
+    link,
+    unlink,
+    isLinked: linked,
+    controller,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Singleton
+// -----------------------------------------------------------------------------
+
+let sessionAdapter: SessionAdapter | null = null;
+
+/** The app-wide adapter instance driven by use-session-bridge. */
+function getSessionAdapter(): SessionAdapter {
+  if (!sessionAdapter) {
+    sessionAdapter = createSessionAdapter();
+  }
+  return sessionAdapter;
+}
+
+export { createSessionAdapter, getSessionAdapter };
+export type { SessionAdapter, SessionAdapterOptions, SessionEngine };

--- a/apps/drumhaus/src/core/session/session-adapter.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.ts
@@ -73,7 +73,10 @@ interface SessionEngine {
 interface SessionAdapterOptions {
   /** Engine command surface; defaults to the AudioEngine singleton. */
   engine?: SessionEngine;
-  /** Session factory; defaults to a real BroadcastChannel-backed session. */
+  /**
+   * Session factory, invoked once per linked period (every link() wraps a
+   * fresh session); defaults to a real BroadcastChannel-backed session.
+   */
   createSession?: () => HausSession;
   /** Epoch clock; defaults to epochNowMs. Injectable for tests. */
   now?: () => number;
@@ -85,7 +88,11 @@ interface SessionAdapter {
   /** Leave the session and restore fully local behavior. Idempotent. */
   unlink(): void;
   isLinked(): boolean;
-  /** The shared controller; the LINK control reads it via useSession. */
+  /**
+   * The controller the LINK control reads via useSession. A stable facade:
+   * its identity (and subscriptions to it) survive the per-link controller
+   * swaps underneath.
+   */
   controller: SessionController;
 }
 
@@ -106,9 +113,45 @@ function createSessionAdapter(
 ): SessionAdapter {
   const engine = options.engine ?? getAudioEngine();
   const now = options.now ?? epochNowMs;
-  const session =
-    options.createSession?.() ?? createHausSession({ instrument: "drumhaus" });
-  const controller = createSessionController(session, { now });
+  const createSession =
+    options.createSession ??
+    (() => createHausSession({ instrument: "drumhaus" }));
+
+  // Every linked period wraps a FRESH session. The bridge's disconnect()
+  // deliberately never resets state or rev, so reusing one instance across
+  // link cycles would leak the previous period into the next: a stale
+  // playing grid auto-starts playback on re-link, and a stale-high rev
+  // makes a re-linked follower deaf to a younger conductor (and
+  // time-travels the session if it later wins a handover). The controller
+  // is recreated with the session; the facade below keeps a stable
+  // identity for UI subscribers (useSession) across swaps.
+  let controller = createSessionController(createSession(), { now });
+  const facadeListeners = new Set<() => void>();
+  const notifyFacade = () => facadeListeners.forEach((listener) => listener());
+  let forwardUnsubscribe = controller.subscribe(notifyFacade);
+
+  function swapInFreshController(): void {
+    forwardUnsubscribe();
+    controller = createSessionController(createSession(), { now });
+    forwardUnsubscribe = controller.subscribe(notifyFacade);
+    notifyFacade();
+  }
+
+  const facade: SessionController = {
+    getSnapshot: () => controller.getSnapshot(),
+    subscribe(listener) {
+      facadeListeners.add(listener);
+      return () => {
+        facadeListeners.delete(listener);
+      };
+    },
+    connect: () => controller.connect(),
+    disconnect: () => controller.disconnect(),
+    play: () => controller.play(),
+    stop: () => controller.stop(),
+    setBpm: (bpm) => controller.setBpm(bpm),
+    setScene: (scene) => controller.setScene(scene),
+  };
 
   /** Applying-guard: inbound store writes must not echo back as intents. */
   let applying = false;
@@ -280,6 +323,9 @@ function createSessionAdapter(
 
   function link(): void {
     if (linked()) return;
+    // A fresh session (and controller) for this linked period - see the
+    // comment at the top of the factory.
+    swapInFreshController();
     appliedGrid = null;
 
     // Seed BEFORE connecting: pre-connect commands apply locally without a
@@ -347,7 +393,7 @@ function createSessionAdapter(
     link,
     unlink,
     isLinked: linked,
-    controller,
+    controller: facade,
   };
 }
 

--- a/apps/drumhaus/src/core/session/use-session-bridge.ts
+++ b/apps/drumhaus/src/core/session/use-session-bridge.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+import { getSessionAdapter } from "./session-adapter";
+
+/**
+ * The session bridge's lifecycle hook, mounted alongside use-engine-bridge
+ * (DrumhausProvider). Link/unlink themselves are user gestures on the LINK
+ * control; this hook only guarantees the session is left when the page
+ * goes away - pagehide covers close, navigation, and bfcache entry, so
+ * peers drop this tab immediately (the goodbye message) instead of waiting
+ * out the heartbeat timeout, and a tab restored from bfcache is not
+ * silently rejoined (LINK is an explicit per-visit gesture). Conductorship
+ * needs no handling here: the browser releases the Web Lock when the page
+ * goes away.
+ */
+function useSessionBridge(): void {
+  useEffect(() => {
+    const adapter = getSessionAdapter();
+
+    const handlePageHide = () => {
+      adapter.unlink();
+    };
+    window.addEventListener("pagehide", handlePageHide);
+
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      adapter.unlink();
+    };
+  }, []);
+}
+
+export { useSessionBridge };

--- a/apps/drumhaus/src/features/session/components/link-control.tsx
+++ b/apps/drumhaus/src/features/session/components/link-control.tsx
@@ -1,0 +1,47 @@
+import { useSession } from "@haus/bridge-react";
+
+import { getSessionAdapter } from "@/core/session/session-adapter";
+import { cn } from "@/shared/lib/utils";
+
+/**
+ * The floating LINK control: opt this tab into the shared haus session
+ * (#417). Lives on the window edge in the floating-menu family - never on
+ * the hardware chassis - fixed next to the menu button with the same
+ * circular, bordered, backdrop-blurred idiom. Filled while linked, with
+ * the peer count as a bare number and a dot while this tab conducts.
+ *
+ * Reads the shared session snapshot through @haus/bridge-react's headless
+ * hook; the toggle routes through the drumhaus session adapter, which owns
+ * the seed-then-connect handshake. Earmarked for extraction to a shared UI
+ * package once the design tokens are extracted (sprint 2).
+ */
+function LinkControl() {
+  const adapter = getSessionAdapter();
+  const { linked, peers, isConductor } = useSession(adapter.controller);
+
+  return (
+    <button
+      aria-label="LINK"
+      data-linked={linked}
+      data-peers={linked ? peers.length : undefined}
+      data-conductor={linked && isConductor}
+      onClick={() => (linked ? adapter.unlink() : adapter.link())}
+      className={cn(
+        "border-primary focus-ring fixed top-2 left-14 z-50 flex h-10 min-w-10 cursor-pointer items-center justify-center gap-1.5 rounded-full border-2 px-3 backdrop-blur-xl transition-all duration-500",
+        linked
+          ? "bg-primary text-primary-foreground hover:bg-primary/85"
+          : "text-primary hover:bg-accent/20 bg-transparent",
+      )}
+    >
+      <span className="text-xs font-medium tracking-widest">LINK</span>
+      {linked && (
+        <span className="text-xs font-medium tabular-nums">{peers.length}</span>
+      )}
+      {linked && isConductor && (
+        <span aria-hidden="true" className="size-1.5 rounded-full bg-current" />
+      )}
+    </button>
+  );
+}
+
+export { LinkControl };

--- a/apps/drumhaus/src/layout/drumhaus.tsx
+++ b/apps/drumhaus/src/layout/drumhaus.tsx
@@ -1,5 +1,6 @@
 import { InstrumentGrid } from "@/features/instrument/components/instrument-grid";
 import { Sequencer } from "@/features/sequencer/components/sequencer";
+import { LinkControl } from "@/features/session/components/link-control";
 import { useLayoutScale } from "@/shared/hooks/use-layout-scale";
 import { Separator } from "@/shared/ui";
 import { ControlsPanel } from "./controls-panel";
@@ -20,6 +21,7 @@ const Drumhaus = () => {
       }}
     >
       <FloatingMenu />
+      <LinkControl />
       <div
         className="drumhaus-scale-wrapper"
         style={{

--- a/packages/bridge-react/package.json
+++ b/packages/bridge-react/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@haus/bridge-react",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "oxlint src --max-warnings 0",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@haus/bridge": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitest/browser-playwright": "^4.1.10",
+    "oxlint": "^1.71.0",
+    "playwright": "^1.61.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^6",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/bridge-react/src/__tests__/helpers/memory-locks.ts
+++ b/packages/bridge-react/src/__tests__/helpers/memory-locks.ts
@@ -1,0 +1,72 @@
+/**
+ * A deterministic in-memory Web Locks stand-in (mirrors @haus/bridge's own
+ * test helper): FIFO grant order per name, held until the callback's
+ * promise settles, abortable while pending, abort ignored after grant.
+ */
+
+import type { HausLockManager } from "@haus/bridge";
+
+interface Waiter {
+  granted: boolean;
+  aborted: boolean;
+  run: () => void;
+}
+
+function memoryLocks(): HausLockManager {
+  const held = new Set<string>();
+  const queues = new Map<string, Waiter[]>();
+
+  function pump(name: string): void {
+    if (held.has(name)) return;
+    const queue = queues.get(name);
+    while (queue !== undefined && queue.length > 0) {
+      const waiter = queue.shift()!;
+      if (waiter.aborted) continue;
+      waiter.granted = true;
+      held.add(name);
+      queueMicrotask(waiter.run);
+      return;
+    }
+  }
+
+  return {
+    request(name, options, callback) {
+      return new Promise((resolve, reject) => {
+        const waiter: Waiter = {
+          granted: false,
+          aborted: false,
+          run: () => {
+            void (async () => {
+              try {
+                resolve(await callback());
+              } catch (error) {
+                reject(error);
+              } finally {
+                held.delete(name);
+                pump(name);
+              }
+            })();
+          },
+        };
+        options.signal?.addEventListener("abort", () => {
+          if (waiter.granted || waiter.aborted) return;
+          waiter.aborted = true;
+          reject(new DOMException("The request was aborted.", "AbortError"));
+        });
+        const queue = queues.get(name) ?? [];
+        queue.push(waiter);
+        queues.set(name, queue);
+        pump(name);
+      });
+    },
+  };
+}
+
+/** Drain chained microtasks (memory transport delivery, lock grants). */
+async function flushMicrotasks(rounds = 25): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
+export { flushMicrotasks, memoryLocks };

--- a/packages/bridge-react/src/__tests__/session-controller.test.ts
+++ b/packages/bridge-react/src/__tests__/session-controller.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Session controller behavior over deterministic injected seams: memory
+ * transports, an in-memory Web Locks stand-in, and a frozen epoch clock.
+ * The focus is the logic this package owns for every instrument: the
+ * external-store snapshot contract and the deferred-command readiness
+ * handling around the connect window.
+ */
+
+import {
+  createHausSession,
+  DEFAULT_BPM,
+  LOCK_NAME,
+  memoryHub,
+  START_LEAD_MS,
+  type BridgeMessage,
+  type BridgeTransport,
+  type HausLockManager,
+  type HausSession,
+} from "@haus/bridge";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createSessionController,
+  type SessionController,
+} from "../session-controller";
+import { flushMicrotasks, memoryLocks } from "./helpers/memory-locks";
+
+interface Rig {
+  nowMs: { value: number };
+  controller: SessionController;
+  session: HausSession;
+  createPeer(instrument?: string): HausSession;
+  createWire(): BridgeTransport;
+  locks: HausLockManager;
+}
+
+const cleanups: (() => void)[] = [];
+
+function createRig(locks: HausLockManager = memoryLocks()): Rig {
+  const hub = memoryHub();
+  const nowMs = { value: 1_000_000 };
+  const now = () => nowMs.value;
+
+  const session = createHausSession({
+    instrument: "test",
+    transport: hub.createTransport(),
+    locks,
+    now,
+  });
+  const controller = createSessionController(session, { now });
+  cleanups.push(() => controller.disconnect());
+
+  return {
+    nowMs,
+    controller,
+    session,
+    createPeer(instrument = "peer") {
+      const peer = createHausSession({
+        instrument,
+        transport: hub.createTransport(),
+        locks,
+        now,
+      });
+      cleanups.push(() => peer.disconnect());
+      return peer;
+    },
+    createWire: () => hub.createTransport(),
+    locks,
+  };
+}
+
+/** Hold the conductor lock externally; returns the release function. */
+async function blockConductorLock(locks: HausLockManager): Promise<() => void> {
+  let release!: () => void;
+  void locks.request(
+    LOCK_NAME,
+    {},
+    () => new Promise<void>((resolve) => (release = resolve)),
+  );
+  await flushMicrotasks();
+  return release;
+}
+
+afterEach(() => {
+  cleanups.splice(0).forEach((cleanup) => cleanup());
+});
+
+describe("snapshot contract", () => {
+  it("returns a cached snapshot that changes identity only on change", async () => {
+    const rig = createRig();
+    const first = rig.controller.getSnapshot();
+    expect(rig.controller.getSnapshot()).toBe(first);
+
+    rig.controller.connect();
+    await flushMicrotasks();
+    const second = rig.controller.getSnapshot();
+    expect(second).not.toBe(first);
+    expect(second.linked).toBe(true);
+    expect(second.isConductor).toBe(true);
+    expect(rig.controller.getSnapshot()).toBe(second);
+  });
+
+  it("mirrors peers and conductorship", async () => {
+    const rig = createRig();
+    rig.controller.connect();
+    await flushMicrotasks();
+
+    const peer = rig.createPeer();
+    peer.connect();
+    await flushMicrotasks();
+
+    const snapshot = rig.controller.getSnapshot();
+    expect(snapshot.peers).toHaveLength(1);
+    expect(snapshot.peers[0]?.instrument).toBe("peer");
+    expect(snapshot.isConductor).toBe(true);
+  });
+});
+
+describe("pre-connect commands (seed then connect)", () => {
+  it("applies straight to the session without a rev bump", async () => {
+    const rig = createRig();
+    rig.controller.setBpm(128);
+    rig.controller.setScene(2);
+
+    expect(rig.session.state.bpm).toBe(128);
+    expect(rig.session.state.scene).toBe(2);
+    expect(rig.session.state.rev).toBe(0);
+
+    // A lone tab conducts and its seeded state broadcasts to late joiners.
+    rig.controller.connect();
+    await flushMicrotasks();
+    const joiner = rig.createPeer();
+    joiner.connect();
+    await flushMicrotasks();
+    expect(joiner.state.bpm).toBe(128);
+    expect(joiner.state.scene).toBe(2);
+  });
+});
+
+describe("deferred commands in the connect window", () => {
+  it("queues commands and reflects them optimistically until ready", async () => {
+    const locks = memoryLocks();
+    const release = await blockConductorLock(locks);
+    const rig = createRig(locks);
+
+    rig.controller.connect();
+    await flushMicrotasks();
+    expect(rig.controller.getSnapshot().isConductor).toBe(false);
+
+    const intents: BridgeMessage[] = [];
+    const wire = rig.createWire();
+    wire.subscribe((data) => {
+      const message = data as BridgeMessage;
+      if (message.type === "intent") intents.push(message);
+    });
+
+    // No conductor exists: an intent would be dropped, so the command is
+    // deferred - nothing on the wire, but the snapshot answers optimistically.
+    rig.controller.setBpm(133);
+    await flushMicrotasks();
+    expect(intents).toHaveLength(0);
+    expect(rig.controller.getSnapshot().state.bpm).toBe(133);
+    expect(rig.session.state.bpm).toBe(DEFAULT_BPM);
+
+    // Conductorship arrives: the queue replays and the session catches up.
+    release();
+    await flushMicrotasks();
+    expect(rig.controller.getSnapshot().isConductor).toBe(true);
+    expect(rig.session.state.bpm).toBe(133);
+    expect(rig.controller.getSnapshot().state.bpm).toBe(133);
+  });
+
+  it("builds the optimistic grid with the bridge's clock math", async () => {
+    const locks = memoryLocks();
+    await blockConductorLock(locks);
+    const rig = createRig(locks);
+
+    rig.controller.connect();
+    await flushMicrotasks();
+
+    rig.controller.play();
+    const playing = rig.controller.getSnapshot().state;
+    expect(playing.playing).toBe(true);
+    expect(playing.startEpochMs).toBe(rig.nowMs.value + START_LEAD_MS);
+
+    rig.controller.setScene(3);
+    expect(rig.controller.getSnapshot().state.scene).toBe(3);
+
+    rig.controller.stop();
+    const stopped = rig.controller.getSnapshot().state;
+    expect(stopped.playing).toBe(false);
+    expect(stopped.startEpochMs).toBeNull();
+  });
+
+  it("replays through an existing conductor when readiness arrives via its state", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.setBpm(90);
+    conductor.connect();
+    await flushMicrotasks();
+
+    // Connect and command in the same synchronous window, before the
+    // conductor's first state broadcast lands.
+    rig.controller.connect();
+    rig.controller.setScene(2);
+    await flushMicrotasks();
+
+    // The replayed command round-tripped as an intent.
+    expect(conductor.state.scene).toBe(2);
+    expect(rig.controller.getSnapshot().state.scene).toBe(2);
+    // And the conductor's state won everything it owned.
+    expect(rig.controller.getSnapshot().state.bpm).toBe(90);
+    expect(rig.controller.getSnapshot().isConductor).toBe(false);
+  });
+
+  it("drops deferred commands on disconnect", async () => {
+    const locks = memoryLocks();
+    const release = await blockConductorLock(locks);
+    const rig = createRig(locks);
+
+    rig.controller.connect();
+    await flushMicrotasks();
+    rig.controller.setBpm(150);
+    rig.controller.disconnect();
+    expect(rig.controller.getSnapshot().linked).toBe(false);
+    expect(rig.controller.getSnapshot().state.bpm).toBe(DEFAULT_BPM);
+
+    release();
+    await flushMicrotasks();
+    expect(rig.session.state.bpm).toBe(DEFAULT_BPM);
+  });
+
+  it("opens the command path on a visible peer even when states are identical", async () => {
+    const rig = createRig();
+    // A conductor whose state exactly equals ours: its reply broadcast is
+    // swallowed by the bridge's no-change guard, so no state event ever
+    // fires - the peer signal must open the command path instead.
+    const conductor = rig.createPeer();
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.controller.connect();
+    rig.controller.setScene(2);
+    await flushMicrotasks();
+
+    expect(conductor.state.scene).toBe(2);
+    expect(rig.controller.getSnapshot().state.scene).toBe(2);
+  });
+
+  it("does not open the command path from pre-connect state changes", async () => {
+    const locks = memoryLocks();
+    await blockConductorLock(locks);
+    const rig = createRig(locks);
+
+    // Seeding fires state changes, but only a conductor (or its broadcast)
+    // may open the command path - otherwise post-connect commands would be
+    // posted into the void.
+    rig.controller.setBpm(128);
+    rig.controller.connect();
+    await flushMicrotasks();
+
+    const intents: BridgeMessage[] = [];
+    const wire = rig.createWire();
+    wire.subscribe((data) => {
+      const message = data as BridgeMessage;
+      if (message.type === "intent") intents.push(message);
+    });
+
+    rig.controller.setBpm(133);
+    await flushMicrotasks();
+    expect(intents).toHaveLength(0);
+    expect(rig.controller.getSnapshot().state.bpm).toBe(133);
+  });
+});
+
+describe("ready sessions", () => {
+  it("sends commands straight to the session once ready", async () => {
+    const rig = createRig();
+    rig.controller.connect();
+    await flushMicrotasks();
+
+    rig.controller.setBpm(140);
+    expect(rig.session.state.bpm).toBe(140);
+    expect(rig.session.state.rev).toBe(1);
+
+    rig.controller.play();
+    expect(rig.session.state.playing).toBe(true);
+    expect(rig.session.state.startEpochMs).toBe(
+      rig.nowMs.value + START_LEAD_MS,
+    );
+  });
+});

--- a/packages/bridge-react/src/__tests__/use-session.browser.test.tsx
+++ b/packages/bridge-react/src/__tests__/use-session.browser.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * The hook against a real DOM: snapshot values render, session events
+ * re-render through useSyncExternalStore, and commands are wired.
+ */
+
+import { StrictMode } from "react";
+import { createHausSession, memoryHub, type HausSession } from "@haus/bridge";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSessionController } from "../session-controller";
+import { useSession } from "../use-session";
+import { memoryLocks } from "./helpers/memory-locks";
+
+interface Harness {
+  session: HausSession;
+  peer: HausSession;
+  container: HTMLElement;
+  root: Root;
+}
+
+const harnesses: Harness[] = [];
+
+function renderHarness(): Harness {
+  const hub = memoryHub();
+  const locks = memoryLocks();
+  const session = createHausSession({
+    instrument: "test",
+    transport: hub.createTransport(),
+    locks,
+  });
+  const peer = createHausSession({
+    instrument: "peer",
+    transport: hub.createTransport(),
+    locks,
+  });
+  const controller = createSessionController(session);
+
+  function Probe() {
+    const { state, peers, isConductor, linked, connect, setBpm } =
+      useSession(controller);
+    return (
+      <div>
+        <output data-testid="bpm">{state.bpm}</output>
+        <output data-testid="peers">{peers.length}</output>
+        <output data-testid="conductor">{String(isConductor)}</output>
+        <output data-testid="linked">{String(linked)}</output>
+        <button data-testid="connect" onClick={connect} />
+        <button data-testid="bump" onClick={() => setBpm(150)} />
+      </div>
+    );
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  root.render(
+    <StrictMode>
+      <Probe />
+    </StrictMode>,
+  );
+
+  const harness = { session, peer, container, root };
+  harnesses.push(harness);
+  return harness;
+}
+
+function read(container: HTMLElement, testId: string): string {
+  return (
+    container.querySelector(`[data-testid="${testId}"]`)?.textContent ?? ""
+  );
+}
+
+afterEach(() => {
+  for (const harness of harnesses.splice(0)) {
+    harness.root.unmount();
+    harness.container.remove();
+    harness.session.disconnect();
+    harness.peer.disconnect();
+  }
+});
+
+describe("useSession", () => {
+  it("renders the snapshot and re-renders on session and command events", async () => {
+    const { session, peer, container } = renderHarness();
+
+    await vi.waitFor(() => {
+      expect(read(container, "bpm")).toBe("120");
+      expect(read(container, "linked")).toBe("false");
+    });
+
+    container
+      .querySelector<HTMLButtonElement>('[data-testid="connect"]')!
+      .click();
+    await vi.waitFor(() => {
+      expect(read(container, "linked")).toBe("true");
+      expect(read(container, "conductor")).toBe("true");
+    });
+
+    peer.connect();
+    await vi.waitFor(() => {
+      expect(read(container, "peers")).toBe("1");
+    });
+
+    container.querySelector<HTMLButtonElement>('[data-testid="bump"]')!.click();
+    await vi.waitFor(() => {
+      expect(read(container, "bpm")).toBe("150");
+      expect(session.state.bpm).toBe(150);
+    });
+  });
+});

--- a/packages/bridge-react/src/index.ts
+++ b/packages/bridge-react/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @haus/bridge-react - the shared React-facing glue over @haus/bridge.
+ * Headless only: a session controller (external-store contract + the
+ * deferred-command readiness handling) and the useSession hook.
+ */
+
+export { createSessionController } from "./session-controller";
+export type {
+  SessionController,
+  SessionSnapshot,
+  SessionControllerOptions,
+} from "./session-controller";
+export { useSession } from "./use-session";
+export type { SessionCommands, SessionView } from "./use-session";

--- a/packages/bridge-react/src/session-controller.ts
+++ b/packages/bridge-react/src/session-controller.ts
@@ -1,0 +1,212 @@
+/**
+ * The framework-free core behind useSession: wraps one HausSession in
+ * an external-store shape (cached snapshot + single change signal, the
+ * useSyncExternalStore contract) and owns the deferred-command readiness
+ * handling every instrument would otherwise reimplement.
+ *
+ * The readiness edge (bridge README, "Handover semantics"): between
+ * connect() and the first evidence of a conductor - conductorship
+ * ourselves, a state message, or a visible peer (see onPeersChange below)
+ * - there is no conductor known to apply intents, so a command posted in
+ * that window would be dropped. Until one of those fires, commands issued
+ * while connected are deferred: queued for the session and applied to a local
+ * optimistic state - built from the bridge's own exported clock math - so
+ * the UI responds immediately. The window is page-load sized (a solo tab
+ * wins conductorship almost instantly). If readiness arrives via another
+ * conductor's state, the snapshot may snap to the conductor's view for a
+ * broadcast beat before the replayed commands land; consistency wins.
+ * (Semantics mirrored from the pulse reference implementation.)
+ *
+ * Commands issued while NOT connected pass straight through: the bridge
+ * applies pre-connect commands locally without a rev bump, which is
+ * exactly the seed-then-connect idiom (seed local tempo/scene, then
+ * connect; a lone tab's seeded state broadcasts when it conducts, an
+ * existing conductor's state wins otherwise).
+ */
+
+import {
+  epochNowMs,
+  rebaseTempo,
+  START_LEAD_MS,
+  type HausPeer,
+  type HausSession,
+  type SceneId,
+  type SessionState,
+} from "@haus/bridge";
+
+/** One immutable view of the session, stable between change signals. */
+interface SessionSnapshot {
+  /** Session state; optimistic while commands are deferred. */
+  state: SessionState;
+  /** Other currently-known peers (self excluded). */
+  peers: HausPeer[];
+  /** Whether this tab currently conducts the session. */
+  isConductor: boolean;
+  /** Whether this controller is currently connected to the session. */
+  linked: boolean;
+}
+
+interface SessionController {
+  /** Cached snapshot; a new object exactly when something changed. */
+  getSnapshot(): SessionSnapshot;
+  /** Single change signal for state, peers, conductorship, and linked. */
+  subscribe(listener: () => void): () => void;
+  /** Join the shared session. Idempotent. */
+  connect(): void;
+  /** Leave the session, dropping any still-deferred commands. Idempotent. */
+  disconnect(): void;
+  play(): void;
+  stop(): void;
+  setBpm(bpm: number): void;
+  setScene(scene: SceneId): void;
+}
+
+interface SessionControllerOptions {
+  /** Epoch clock for optimistic grid math; defaults to epochNowMs. */
+  now?: () => number;
+}
+
+function createSessionController(
+  session: HausSession,
+  options: SessionControllerOptions = {},
+): SessionController {
+  const now = options.now ?? epochNowMs;
+
+  let linked = false;
+  /** True once a conductor exists: us, or one whose state we have seen. */
+  let ready = false;
+  /** Commands queued while connected but not ready, replayed in order. */
+  const deferred: (() => void)[] = [];
+  /** Local view of deferred commands; null once the session speaks. */
+  let optimistic: SessionState | null = null;
+
+  let peers: HausPeer[] = [];
+  let isConductor = false;
+
+  const listeners = new Set<() => void>();
+  let snapshot: SessionSnapshot = {
+    state: session.state,
+    peers,
+    isConductor,
+    linked,
+  };
+
+  function emit(): void {
+    snapshot = {
+      state: optimistic ?? session.state,
+      peers,
+      isConductor,
+      linked,
+    };
+    for (const listener of listeners) listener();
+  }
+
+  function becomeReady(): void {
+    if (ready) return;
+    ready = true;
+    optimistic = null;
+    for (const send of deferred.splice(0)) send();
+  }
+
+  session.onStateChange(() => {
+    // A state broadcast means a conductor spoke; intents will be applied.
+    // Pre-connect local applications (seeding) do NOT open the command
+    // path - the readiness window only exists while connected.
+    if (linked) becomeReady();
+    emit();
+  });
+  session.onConductorChange((conductor) => {
+    isConductor = conductor;
+    if (conductor && linked) becomeReady();
+    emit();
+  });
+  session.onPeersChange((nextPeers) => {
+    peers = nextPeers;
+    // Peers also open the command path: a conductor whose state happens to
+    // equal ours broadcasts it in reply to our hello, but the bridge's
+    // no-change guard fires no state event for it - only this peer signal
+    // arrives. In production the conductor lock is always held by some
+    // connected peer, so a visible peer implies an appliable session; the
+    // residual race (a peer seen mid conductor-handover) degrades to the
+    // protocol's accepted handover intent loss.
+    if (linked && nextPeers.length > 0) becomeReady();
+    emit();
+  });
+
+  /**
+   * Route one command: straight to the session when not connected (local
+   * pre-connect application, no rev bump) or once ready; queued with an
+   * optimistic local application while the connect window is open.
+   */
+  function command(
+    applyOptimistic: (state: SessionState, atEpochMs: number) => SessionState,
+    send: () => void,
+  ): void {
+    if (!linked || ready) {
+      send();
+      return;
+    }
+    deferred.push(send);
+    optimistic = applyOptimistic(optimistic ?? session.state, now());
+    emit();
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    connect() {
+      if (linked) return;
+      linked = true;
+      ready = false;
+      session.connect();
+      emit();
+    },
+    disconnect() {
+      if (!linked) return;
+      session.disconnect();
+      linked = false;
+      ready = false;
+      deferred.length = 0;
+      optimistic = null;
+      emit();
+    },
+    play: () =>
+      command(
+        (state, atEpochMs) =>
+          state.playing
+            ? state
+            : {
+                ...state,
+                playing: true,
+                startEpochMs: atEpochMs + START_LEAD_MS,
+              },
+        () => session.play(),
+      ),
+    stop: () =>
+      command(
+        (state) =>
+          state.playing
+            ? { ...state, playing: false, startEpochMs: null }
+            : state,
+        () => session.stop(),
+      ),
+    setBpm: (bpm) =>
+      command(
+        (state, atEpochMs) => rebaseTempo(state, bpm, atEpochMs),
+        () => session.setBpm(bpm),
+      ),
+    setScene: (scene) =>
+      command(
+        (state) => ({ ...state, scene }),
+        () => session.setScene(scene),
+      ),
+  };
+}
+
+export { createSessionController };
+export type { SessionController, SessionSnapshot, SessionControllerOptions };

--- a/packages/bridge-react/src/use-session.ts
+++ b/packages/bridge-react/src/use-session.ts
@@ -1,0 +1,50 @@
+/**
+ * The headless React hook over a SessionController: one
+ * useSyncExternalStore subscription exposing the session snapshot
+ * ({ state, peers, isConductor, linked }) plus the session commands
+ * ({ connect, disconnect, play, stop, setBpm, setScene }).
+ *
+ * Headless by design - no styling, no instrument specifics. Instruments
+ * render their own affordances on top; the controller (and with it the
+ * deferred-command readiness handling) is shared for free.
+ */
+
+import { useMemo, useSyncExternalStore } from "react";
+import type { SceneId } from "@haus/bridge";
+
+import type { SessionController, SessionSnapshot } from "./session-controller";
+
+interface SessionCommands {
+  connect(): void;
+  disconnect(): void;
+  play(): void;
+  stop(): void;
+  setBpm(bpm: number): void;
+  setScene(scene: SceneId): void;
+}
+
+type SessionView = SessionSnapshot & SessionCommands;
+
+function useSession(controller: SessionController): SessionView {
+  const snapshot = useSyncExternalStore(
+    controller.subscribe,
+    controller.getSnapshot,
+    controller.getSnapshot,
+  );
+
+  return useMemo(
+    () => ({
+      ...snapshot,
+      connect: controller.connect,
+      disconnect: controller.disconnect,
+      play: controller.play,
+      stop: controller.stop,
+      setBpm: controller.setBpm,
+      setScene: controller.setScene,
+    }),
+    [snapshot, controller],
+  );
+}
+
+export { useSession };
+export type { SessionCommands, SessionView };

--- a/packages/bridge-react/tsconfig.json
+++ b/packages/bridge-react/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/bridge-react/vitest.config.ts
+++ b/packages/bridge-react/vitest.config.ts
@@ -1,0 +1,29 @@
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: "unit",
+          environment: "node",
+          include: ["src/**/*.test.ts"],
+          exclude: ["src/**/*.browser.test.ts", "src/**/*.browser.test.tsx"],
+        },
+      },
+      {
+        test: {
+          name: "browser",
+          include: ["src/**/*.browser.test.ts", "src/**/*.browser.test.tsx"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
       '@fontsource-variable/albert-sans':
         specifier: ^5.2.8
         version: 5.2.8
+      '@haus/bridge':
+        specifier: workspace:*
+        version: link:../../packages/bridge
+      '@haus/bridge-react':
+        specifier: workspace:*
+        version: link:../../packages/bridge-react
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.80.0(react@19.2.7))
@@ -238,6 +244,40 @@ importers:
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
+      typescript:
+        specifier: ^6
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.3)(@vitest/browser-playwright@4.1.10)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/bridge-react:
+    dependencies:
+      '@haus/bridge':
+        specifier: workspace:*
+        version: link:../bridge
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.61.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.71.0
+      playwright:
+        specifier: ^1.61.1
+        version: 1.61.1
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ^6
         version: 6.0.3


### PR DESCRIPTION
Part of #414. Closes #417.

Drumhaus can now join the shared haus session. A new opt-in LINK control connects the tab over @haus/bridge; while linked, tempo, transport, and scene stay in sync with every other linked instrument on the origin. Unlinked tabs are byte-for-byte the app that shipped yesterday.

## Behavior

- LINK is default OFF. Toggling on seeds the session with the local bpm and selected variation before connect (pre-connect commands apply locally without a rev bump), then connects: a lone tab conducts and its state becomes the session's; joining an existing session adopts the conductor's state (bpm may jump - correct).
- Inbound: session bpm -> transport store (the transport glides through tempo rebases, phase-continuous), scene -> variation selection (the engine already applies variation changes at the next bar; no extra quantization), playing -> grid-aligned engine start / immediate stop.
- Outbound: user bpm changes, play/stop, and variation pads become session commands, guarded against echo loops; while this tab conducts with the variation chain enabled, the engine's bar-boundary variation changes drive setScene - the conductor's chain is the session's song structure.
- Grid alignment starts playback at the shared grid's next bar boundary (bar 0's downbeat during the start lead), mapped onto the live AudioContext with the bridge's epoch clock helpers. Drumhaus patterns loop one bar, so a boundary start at position 0 is exact alignment. No drift-correction loop; a suspended context that cannot start stays stopped gracefully and joins on the next user gesture.
- Toggling off disconnects and restores fully local behavior; pagehide disconnects too, so peers drop the tab immediately.

## @haus/bridge-react (new package)

The React-facing session glue is a shared package so future instruments inherit it instead of reimplementing it:

- `createSessionController(session)` - a framework-free external-store wrapper (cached snapshot of `{ state, peers, isConductor, linked }`, single change signal, commands `{ connect, disconnect, play, stop, setBpm, setScene }`).
- `useSession(controller)` - the headless hook over it via useSyncExternalStore.
- The controller owns the deferred-command readiness window (commands posted between connect() and the first evidence of a conductor would be dropped): they queue and apply to an optimistic local state built from the bridge's exported clock math, then replay on readiness - semantics mirrored from the pulse reference implementation.
- One readiness signal was added beyond pulse's: a visible peer also opens the command path. A conductor whose state happens to equal the joiner's replies to the hello, but the bridge's no-change guard fires no state event for it - without the peer signal, deferred commands strand forever whenever two tabs join at identical defaults (found by the two-drumhaus-tabs e2e; pulse mostly masks it because its default bpm differs from drumhaus presets).
- Headless only, no styling, no drumhaus imports; brand-free identifiers throughout (the brand appears only in the package name). Existing @haus/bridge exports are consumed as-is.

## Engine surface change (minimal)

- `play(options?: { atContextTime?: number })` - threads a scheduled start time to the transport. `startTransport(atContextTime)` stops the transport at that instant first, which cancels any pending scheduled start and resets position, so the downbeat lands exactly there whether the transport was running or not; a later play/stop intent still supersedes via the existing intentSeq machinery (the adapter leans on this to outrace togglePlay's immediate start).
- `getLiveAudioContext()` - read-only access to the live context through the retained live transport and Tone's public `Context.rawContext`; tone-internals.ts keeps its private-API monopoly. Note: Tone's default context is a standardized-audio-context wrapper without getOutputTimestamp, so the bridge's documented currentTime fallback anchors the epoch mapping (uniform across same-machine tabs).

## UI

One floating LINK control on the window edge, in the floating-menu family (same circular bordered backdrop-blur idiom, fixed next to the menu button). Bare LINK label; linked state fills the pill and shows the peer count as a number plus a dot while conducting. Nothing was added to the hardware chassis: an ImageMagick pixel diff of the full instrument (`.drumhaus-scale-wrapper` screenshot, before vs after) is exactly 0 differing pixels - the floating control is the only visual addition. Earmarked for extraction to a shared UI package when the design tokens are extracted (sprint 2).

## Tests

- packages/bridge-react: 11 (node controller suite covering seed passthrough, queue/optimistic/replay, identical-state readiness, disconnect semantics, snapshot caching; browser hook test through real react-dom).
- apps/drumhaus: 12 new adapter browser tests over memoryHub + injected locks + fake engine (seed-then-connect conduct vs adopt, echo-loop guard, scene <-> variation both directions, chain-conductor setScene, deferred window end to end, downbeat-aligned play, rebase-glide, unlink, and both re-link regressions); full app suite 865 passed, 4 skipped (pre-existing).
- e2e: new link.spec.ts with two pages in one context - tempo both directions, play/stop across tabs (playhead asserted on both), variation pad sync, conductor handover on page close with state surviving, linked/unlinked isolation, and a re-link scenario (link, play, unlink, stop, re-link - nothing auto-starts). Full drumhaus e2e: 34 passed.
- The skipped family spec (e2e/family/drumhaus-pulse.spec.ts) was run locally with the skip removed and passes as written against this LINK control - no selector changes needed; it stays skipped per plan.
- pnpm format:check, pnpm lint, pnpm -r test, pnpm build all green; lockfile regenerated.

## Review fix: fresh session per linked period

Review found that reusing one HausSession across link cycles leaked the previous period into the next, because the bridge's disconnect() deliberately never resets state or rev:

- a stale playing grid auto-started playback (and broadcast playing:true on an ancient grid) when re-linking solo after link -> play -> unlink -> stop;
- a stale-high rev made a re-linked follower deaf to a younger conductor's broadcasts, and time-traveled the session if the tab later won a handover.

Fixed in the adapter: every link() now creates a fresh session and controller, torn down fully on unlink; a stable controller facade keeps useSession subscribers (the LINK control) alive across the swap. packages/bridge is untouched; seeding semantics are unchanged (a fresh session makes a stop-seed unnecessary). Regression tests: "re-linking solo after link/play/unlink/stop does not auto-start" and "re-linking after conducting at a high rev adopts a younger live session" (adapter browser suite), plus the e2e re-link scenario above.

## Deviations from the brief

- Realign on tempo rebase: the brief listed "tempo rebase while playing" as a realign trigger, but the protocol's rebase is phase-continuous by design (README: "followers glide to the new rate without a jump") and the store's setBpm already retunes the live transport in the same dispatch, so the adapter glides instead of restarting - restarting on every bpm nudge would reset the conductor's chain position audibly for zero alignment gain. Realignment still happens for any grid this tab is not already playing on (fresh start, join, new startEpochMs at fixed bpm).
- The originally-planned drumhaus zustand session store was dropped: the controller snapshot is the single source for linked/peers/isConductor, and the LINK control consumes it through useSession directly.
