### PR TITLE
close out #414: de-brand sweep, pulse on bridge-react, cross-app e2e live, LINK dark on prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,20 @@ jobs:
       - name: Build project
         run: pnpm build
 
+      - name: Verify default build ships without LINK
+        # LINK ships dark: a build without VITE_ENABLE_LINK must exclude the
+        # session code path entirely (the wire key only exists inside it).
+        run: |
+          if grep -rq "haus:conductor" apps/drumhaus/dist/assets; then
+            echo "LINK code path leaked into a default (flag-off) build"
+            exit 1
+          fi
+
       - name: Lightshow cold-load smoke check
         run: pnpm smoke:lightshow
+
+      - name: Rebuild drumhaus with LINK for E2E
+        run: VITE_ENABLE_LINK=true pnpm --filter drumhaus build
 
       - name: Run E2E tests
         run: pnpm test:e2e

--- a/apps/drumhaus/playwright.config.ts
+++ b/apps/drumhaus/playwright.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI ? preview : `pnpm build && ${preview}`,
+    // The suite covers LINK (link.spec), which ships dark: the local build
+    // here needs the flag; in CI the workflow rebuilds with it before this
+    // suite runs.
+    env: { VITE_ENABLE_LINK: "true" },
     port,
     reuseExistingServer: false,
     timeout: 180_000,

--- a/apps/drumhaus/playwright.config.ts
+++ b/apps/drumhaus/playwright.config.ts
@@ -3,14 +3,19 @@ import { defineConfig, devices } from "@playwright/test";
 /**
  * UI-driving end-to-end suite (issue #271).
  *
- * Runs against a production build served by `vite preview` on port 4444 for
- * CI fidelity. In CI the build step has already produced `dist/`, so the web
+ * Runs against a production build served by `vite preview` (port 4444;
+ * PORT overrides so parallel checkouts can pick a free one) for CI
+ * fidelity. In CI the build step has already produced `dist/`, so the web
  * server only needs to serve it; locally the suite rebuilds first so it
  * always exercises the current source.
  *
  * Kept fully separate from vitest: vitest only picks up `.test.ts` files
  * under `src`, and this runner only picks up `.spec.ts` files under `e2e`.
  */
+/** Server port; PORT overrides so parallel checkouts can pick a free one. */
+const port = Number(process.env.PORT ?? 4444);
+const preview = `pnpm exec vite preview --port ${port} --strictPort`;
+
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "**/*.spec.ts",
@@ -31,7 +36,7 @@ export default defineConfig({
   timeout: 60_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: "http://localhost:4444",
+    baseURL: `http://localhost:${port}`,
     trace: "retain-on-failure",
   },
   projects: [
@@ -41,8 +46,8 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? "pnpm preview" : "pnpm build && pnpm preview",
-    port: 4444,
+    command: process.env.CI ? preview : `pnpm build && ${preview}`,
+    port,
     reuseExistingServer: false,
     timeout: 180_000,
   },

--- a/apps/drumhaus/src/app/vite-env.d.ts
+++ b/apps/drumhaus/src/app/vite-env.d.ts
@@ -4,6 +4,8 @@
 declare const __APP_VERSION__: string;
 declare const __BUILD_TIME__: string;
 declare const __NODE_VERSION__: string;
+// LINK feature flag: on in dev, opt-in per build via VITE_ENABLE_LINK
+declare const __ENABLE_LINK__: boolean;
 
 // Side-effect imports for non-standard packages
 // e.g. main is a CSS file (no .ts/.js.d.ts entry)

--- a/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
@@ -13,13 +13,13 @@
  */
 
 import {
-  createHausSession,
+  createSession as createBridgeSession,
   memoryHub,
   START_LEAD_MS,
   type BridgeMessage,
   type BridgeTransport,
-  type HausLockManager,
-  type HausSession,
+  type LockManager,
+  type Session,
 } from "@haus/bridge";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -46,7 +46,7 @@ interface LockWaiter {
  * FIFO grant order, held until the callback's promise settles, abortable
  * while pending.
  */
-function memoryLocks(): HausLockManager {
+function memoryLocks(): LockManager {
   const held = new Set<string>();
   const queues = new Map<string, LockWaiter[]>();
 
@@ -148,18 +148,18 @@ interface Rig {
   nowMs: { value: number };
   engine: FakeEngine;
   /** The session instance the adapter currently wraps (fresh per link). */
-  adapterSession: () => HausSession;
+  adapterSession: () => Session;
   adapter: SessionAdapter;
   /** A raw peer session on the same hub/locks (auto-tracked for cleanup). */
-  createPeer(instrument?: string): HausSession;
+  createPeer(instrument?: string): Session;
   /** A bare wire on the hub, for observing raw protocol traffic. */
   createWire(): BridgeTransport;
-  locks: HausLockManager;
+  locks: LockManager;
 }
 
 const cleanups: (() => void)[] = [];
 
-function createRig(locks: HausLockManager = memoryLocks()): Rig {
+function createRig(locks: LockManager = memoryLocks()): Rig {
   const hub = memoryHub();
   const nowMs = { value: 1_000_000 };
   const now = () => nowMs.value;
@@ -167,12 +167,12 @@ function createRig(locks: HausLockManager = memoryLocks()): Rig {
 
   // The adapter creates a FRESH session per link(); track them so tests can
   // address the current one.
-  const sessions: HausSession[] = [];
+  const sessions: Session[] = [];
   const adapter = createSessionAdapter({
     engine,
     now,
     createSession: () => {
-      const session = createHausSession({
+      const session = createBridgeSession({
         instrument: "drumhaus",
         transport: hub.createTransport(),
         locks,
@@ -190,7 +190,7 @@ function createRig(locks: HausLockManager = memoryLocks()): Rig {
     adapter,
     adapterSession: () => sessions[sessions.length - 1],
     createPeer(instrument = "peer") {
-      const peer = createHausSession({
+      const peer = createBridgeSession({
         instrument,
         transport: hub.createTransport(),
         locks,

--- a/apps/drumhaus/src/core/session/session-adapter.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.ts
@@ -1,5 +1,5 @@
 /**
- * The adapter between the Zustand stores / AudioEngine and the shared haus
+ * The adapter between the Zustand stores / AudioEngine and the shared
  * session (issue #417, epic #414). Mirrors core/audio/bridge: store
  * subscriptions feed session commands, session changes flow back into the
  * stores, and an applying-guard keeps inbound state from echoing back out
@@ -34,12 +34,12 @@
  */
 
 import {
-  createHausSession,
+  createSession as createBridgeSession,
   epochNowMs,
   epochToContextTime,
   nextBarStartEpochMs,
   type BridgeAudioContext,
-  type HausSession,
+  type Session,
   type SessionState,
 } from "@haus/bridge";
 import {
@@ -77,7 +77,7 @@ interface SessionAdapterOptions {
    * Session factory, invoked once per linked period (every link() wraps a
    * fresh session); defaults to a real BroadcastChannel-backed session.
    */
-  createSession?: () => HausSession;
+  createSession?: () => Session;
   /** Epoch clock; defaults to epochNowMs. Injectable for tests. */
   now?: () => number;
 }
@@ -115,7 +115,7 @@ function createSessionAdapter(
   const now = options.now ?? epochNowMs;
   const createSession =
     options.createSession ??
-    (() => createHausSession({ instrument: "drumhaus" }));
+    (() => createBridgeSession({ instrument: "drumhaus" }));
 
   // Every linked period wraps a FRESH session. The bridge's disconnect()
   // deliberately never resets state or rev, so reusing one instance across

--- a/apps/drumhaus/src/core/session/use-session-bridge.ts
+++ b/apps/drumhaus/src/core/session/use-session-bridge.ts
@@ -15,6 +15,10 @@ import { getSessionAdapter } from "./session-adapter";
  */
 function useSessionBridge(): void {
   useEffect(() => {
+    // LINK ships dark: with the build-time flag off this hook is a no-op
+    // and no session objects are ever created (the whole session graph
+    // dead-code-eliminates out of the bundle).
+    if (!__ENABLE_LINK__) return;
     const adapter = getSessionAdapter();
 
     const handlePageHide = () => {

--- a/apps/drumhaus/src/features/session/components/link-control.tsx
+++ b/apps/drumhaus/src/features/session/components/link-control.tsx
@@ -4,7 +4,7 @@ import { getSessionAdapter } from "@/core/session/session-adapter";
 import { cn } from "@/shared/lib/utils";
 
 /**
- * The floating LINK control: opt this tab into the shared haus session
+ * The floating LINK control: opt this tab into the shared session
  * (#417). Lives on the window edge in the floating-menu family - never on
  * the hardware chassis - fixed next to the menu button with the same
  * circular, bordered, backdrop-blurred idiom. Filled while linked, with

--- a/apps/drumhaus/src/layout/drumhaus.tsx
+++ b/apps/drumhaus/src/layout/drumhaus.tsx
@@ -21,7 +21,8 @@ const Drumhaus = () => {
       }}
     >
       <FloatingMenu />
-      <LinkControl />
+      {/* LINK ships dark: build-time flag, so off means fully absent. */}
+      {__ENABLE_LINK__ && <LinkControl />}
       <div
         className="drumhaus-scale-wrapper"
         style={{

--- a/apps/drumhaus/vite.config.ts
+++ b/apps/drumhaus/vite.config.ts
@@ -18,8 +18,20 @@ const getGitHash = () => {
 const appVersion = getGitHash();
 const nodeVersion = process.version;
 
+/**
+ * LINK (the shared cross-instrument session) ships dark for now: on in dev,
+ * on when VITE_ENABLE_LINK is explicitly truthy at build time (CI and the
+ * e2e suites), off otherwise. Production builds set nothing, so deployed
+ * builds exclude the feature entirely; enabling it later is a build-config
+ * env var, not a code change. Build-time constant so the off path
+ * dead-code-eliminates.
+ */
+const enableLink = (command: "build" | "serve") =>
+  command === "serve" ||
+  ["1", "true"].includes(process.env.VITE_ENABLE_LINK ?? "");
+
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [
     react(),
     babel({
@@ -32,6 +44,7 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify(appVersion),
     __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
     __NODE_VERSION__: JSON.stringify(nodeVersion),
+    __ENABLE_LINK__: JSON.stringify(enableLink(command)),
   },
   resolve: {
     tsconfigPaths: true,
@@ -43,4 +56,4 @@ export default defineConfig({
   build: {
     outDir: "dist",
   },
-});
+}));

--- a/apps/pulse/index.html
+++ b/apps/pulse/index.html
@@ -8,7 +8,7 @@
     <title>pulse</title>
     <meta
       name="description"
-      content="A tiny metronome for the haus family, and the reference implementation of @haus/bridge session sync."
+      content="A tiny metronome for the instrument family, and the reference implementation of @haus/bridge session sync."
     />
   </head>
   <body>

--- a/apps/pulse/package.json
+++ b/apps/pulse/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@haus/bridge": "workspace:*",
+    "@haus/bridge-react": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/apps/pulse/src/app.tsx
+++ b/apps/pulse/src/app.tsx
@@ -1,30 +1,26 @@
-import { useEffect, useSyncExternalStore } from "react";
+import { useEffect } from "react";
 import type { SceneId } from "@haus/bridge";
+import { useSession, type SessionController } from "@haus/bridge-react";
 
 import { createMetronome, type Metronome } from "./metronome";
-import type { PulseSession } from "./session";
 
 const SCENES: SceneId[] = [0, 1, 2, 3];
 
 type AppProps = {
-  session: PulseSession;
+  controller: SessionController;
 };
 
-function App({ session }: AppProps) {
-  const state = useSyncExternalStore(session.subscribe, session.getState);
-  const peerCount = useSyncExternalStore(
-    session.subscribe,
-    session.getPeerCount,
-  );
-  const isConductor = useSyncExternalStore(
-    session.subscribe,
-    session.getIsConductor,
-  );
+function App({ controller }: AppProps) {
+  const { state, peers, isConductor, play, stop, setBpm, setScene } =
+    useSession(controller);
+  const peerCount = peers.length + 1;
 
   // The session is connected from load, but the AudioContext (autoplay
   // policy) exists only after a user gesture. Any pointerdown qualifies -
   // pressing play covers a fresh start, and any click at all covers joining
-  // a session that is already mid-playback.
+  // a session that is already mid-playback. The metronome follows the
+  // controller directly (not the render cycle): audio scheduling has no
+  // reason to wait for React.
   useEffect(() => {
     let ctx: AudioContext | null = null;
     let metronome: Metronome | null = null;
@@ -32,11 +28,11 @@ function App({ session }: AppProps) {
       ctx = new AudioContext();
       void ctx.resume();
       metronome = createMetronome(ctx);
-      metronome.update(session.getState());
+      metronome.update(controller.getSnapshot().state);
     }
     window.addEventListener("pointerdown", startAudio, { once: true });
-    const unsubscribe = session.subscribe(() => {
-      metronome?.update(session.getState());
+    const unsubscribe = controller.subscribe(() => {
+      metronome?.update(controller.getSnapshot().state);
     });
     return () => {
       window.removeEventListener("pointerdown", startAudio);
@@ -44,7 +40,7 @@ function App({ session }: AppProps) {
       metronome?.dispose();
       void ctx?.close();
     };
-  }, [session]);
+  }, [controller]);
 
   const bpm = Math.round(state.bpm);
 
@@ -57,7 +53,7 @@ function App({ session }: AppProps) {
           type="button"
           className="transport"
           data-playing={state.playing}
-          onClick={() => (state.playing ? session.stop() : session.play())}
+          onClick={() => (state.playing ? stop() : play())}
         >
           {state.playing ? "stop" : "play"}
         </button>
@@ -66,7 +62,7 @@ function App({ session }: AppProps) {
           <button
             type="button"
             aria-label="tempo down"
-            onClick={() => session.setBpm(bpm - 1)}
+            onClick={() => setBpm(bpm - 1)}
           >
             -
           </button>
@@ -76,7 +72,7 @@ function App({ session }: AppProps) {
           <button
             type="button"
             aria-label="tempo up"
-            onClick={() => session.setBpm(bpm + 1)}
+            onClick={() => setBpm(bpm + 1)}
           >
             +
           </button>
@@ -89,7 +85,7 @@ function App({ session }: AppProps) {
               type="button"
               aria-label={`scene ${scene}`}
               aria-pressed={state.scene === scene}
-              onClick={() => session.setScene(scene)}
+              onClick={() => setScene(scene)}
             >
               {scene}
             </button>

--- a/apps/pulse/src/main.tsx
+++ b/apps/pulse/src/main.tsx
@@ -6,19 +6,19 @@ import { createPulseSession } from "./session";
 
 import "./styles.css";
 
-// One session for the app's lifetime, connected on load: pulse is always
+// One controller for the app's lifetime, connected on load: pulse is always
 // linked - that is its purpose. Audio waits for a user gesture (see app.tsx);
 // the session does not.
-const session = createPulseSession();
-session.connect();
+const controller = createPulseSession();
+controller.connect();
 
 // A clean goodbye lets peers drop this tab immediately instead of waiting
 // out the heartbeat timeout; pageshow rejoins after a bfcache restore.
-window.addEventListener("pagehide", () => session.disconnect());
-window.addEventListener("pageshow", () => session.connect());
+window.addEventListener("pagehide", () => controller.disconnect());
+window.addEventListener("pageshow", () => controller.connect());
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App session={session} />
+    <App controller={controller} />
   </StrictMode>,
 );

--- a/apps/pulse/src/session.ts
+++ b/apps/pulse/src/session.ts
@@ -2,7 +2,7 @@
  * Pulse's session hookup: how an instrument integrates @haus/bridge.
  *
  * Pulse is always linked - that is its purpose - so this wraps one
- * createHausSession instance in exactly the surface the UI needs: a snapshot
+ * createSession instance in exactly the surface the UI needs: a snapshot
  * getter per value plus a single change signal (the useSyncExternalStore
  * contract), and the four session commands.
  *
@@ -18,7 +18,7 @@
  */
 
 import {
-  createHausSession,
+  createSession,
   epochNowMs,
   rebaseTempo,
   START_LEAD_MS,
@@ -46,7 +46,7 @@ interface PulseSession {
 }
 
 function createPulseSession(): PulseSession {
-  const session = createHausSession({ instrument: "pulse" });
+  const session = createSession({ instrument: "pulse" });
 
   /** True once a conductor exists: us, or one whose state we have seen. */
   let ready = false;

--- a/apps/pulse/src/session.ts
+++ b/apps/pulse/src/session.ts
@@ -1,154 +1,23 @@
 /**
- * Pulse's session hookup: how an instrument integrates @haus/bridge.
+ * Pulse's session hookup - the reference integration of @haus/bridge: one
+ * session wrapped in @haus/bridge-react's controller. The controller owns
+ * everything an instrument would otherwise reimplement - the external-store
+ * snapshot contract and the deferred-command readiness handling around the
+ * connect window - so the instrument's own code reduces to this factory.
  *
- * Pulse is always linked - that is its purpose - so this wraps one
- * createSession instance in exactly the surface the UI needs: a snapshot
- * getter per value plus a single change signal (the useSyncExternalStore
- * contract), and the four session commands.
- *
- * One bridge edge is handled here. Between connect() and either
- * onConductorChange(true) or the first onStateChange there is no conductor
- * to apply intents, so a command posted in that window would be dropped
- * (README, "Handover semantics"). Until one of those fires, user commands
- * are deferred: queued for the session and applied to a local optimistic
- * state so the UI and metronome respond immediately - the same treatment the
- * bridge gives commands issued before connect(). The window is page-load
- * sized (a solo tab wins conductorship almost instantly), and the optimistic
- * reducer below mirrors the bridge's own, built from its exported clock math.
+ * Pulse is always linked - that is its purpose - so main.tsx connects the
+ * controller on load and across pagehide/pageshow; the UI reads it through
+ * useSession (app.tsx).
  */
 
+import { createSession } from "@haus/bridge";
 import {
-  createSession,
-  epochNowMs,
-  rebaseTempo,
-  START_LEAD_MS,
-  type SceneId,
-  type SessionState,
-} from "@haus/bridge";
+  createSessionController,
+  type SessionController,
+} from "@haus/bridge-react";
 
-interface PulseSession {
-  /** Join the shared session. Idempotent. */
-  connect(): void;
-  /** Leave the session (posts a goodbye so peers drop us immediately). */
-  disconnect(): void;
-  /** Current session state; optimistic while commands are deferred. */
-  getState(): SessionState;
-  /** Session size: this tab plus every known peer. */
-  getPeerCount(): number;
-  /** Whether this tab currently conducts the session. */
-  getIsConductor(): boolean;
-  /** Single change signal for state, peer count, and conductorship. */
-  subscribe(listener: () => void): () => void;
-  play(): void;
-  stop(): void;
-  setBpm(bpm: number): void;
-  setScene(scene: SceneId): void;
-}
-
-function createPulseSession(): PulseSession {
-  const session = createSession({ instrument: "pulse" });
-
-  /** True once a conductor exists: us, or one whose state we have seen. */
-  let ready = false;
-  /** Commands queued while not ready, replayed in order on readiness. */
-  const deferred: (() => void)[] = [];
-  /** Local view of deferred commands; null once the session is authoritative. */
-  let optimistic: SessionState | null = null;
-
-  let peerCount = 1;
-  let isConductor = false;
-  const listeners = new Set<() => void>();
-
-  function notify(): void {
-    for (const fn of listeners) fn();
-  }
-
-  function becomeReady(): void {
-    if (ready) return;
-    ready = true;
-    optimistic = null;
-    for (const send of deferred.splice(0)) send();
-  }
-
-  session.onStateChange(() => {
-    // A state broadcast means a conductor spoke; intents will be applied.
-    becomeReady();
-    notify();
-  });
-  session.onConductorChange((conductor) => {
-    isConductor = conductor;
-    if (conductor) becomeReady();
-    notify();
-  });
-  session.onPeersChange((peers) => {
-    peerCount = peers.length + 1;
-    notify();
-  });
-
-  /**
-   * Route one command: straight to the session once ready, otherwise queue
-   * it and apply the equivalent change to the optimistic state. If readiness
-   * arrives via another conductor's state, the replayed intents round-trip
-   * through it, so the optimistic view may snap to the conductor's for a
-   * broadcast beat before the commands land - consistency wins.
-   */
-  function command(
-    apply: (state: SessionState, atEpochMs: number) => SessionState,
-    send: () => void,
-  ): void {
-    if (ready) {
-      send();
-      return;
-    }
-    deferred.push(send);
-    optimistic = apply(optimistic ?? session.state, epochNowMs());
-    notify();
-  }
-
-  return {
-    connect: () => session.connect(),
-    disconnect: () => session.disconnect(),
-    getState: () => optimistic ?? session.state,
-    getPeerCount: () => peerCount,
-    getIsConductor: () => isConductor,
-    subscribe(listener) {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
-    play: () =>
-      command(
-        (state, atEpochMs) =>
-          state.playing
-            ? state
-            : {
-                ...state,
-                playing: true,
-                startEpochMs: atEpochMs + START_LEAD_MS,
-              },
-        () => session.play(),
-      ),
-    stop: () =>
-      command(
-        (state) =>
-          state.playing
-            ? { ...state, playing: false, startEpochMs: null }
-            : state,
-        () => session.stop(),
-      ),
-    setBpm: (bpm) =>
-      command(
-        (state, atEpochMs) => rebaseTempo(state, bpm, atEpochMs),
-        () => session.setBpm(bpm),
-      ),
-    setScene: (scene) =>
-      command(
-        (state) => ({ ...state, scene }),
-        () => session.setScene(scene),
-      ),
-  };
+function createPulseSession(): SessionController {
+  return createSessionController(createSession({ instrument: "pulse" }));
 }
 
 export { createPulseSession };
-export type { PulseSession };

--- a/e2e/family/drumhaus-pulse.spec.ts
+++ b/e2e/family/drumhaus-pulse.spec.ts
@@ -2,29 +2,75 @@ import { expect, test, type BrowserContext, type Page } from "@playwright/test";
 
 /**
  * Cross-app session sync: drumhaus at / and pulse at /pulse/ in one browser
- * context, jamming over @haus/bridge.
- *
- * SKIPPED until the drumhaus session adapter and its LINK control (issue
- * #417) land on main - that work is in a parallel PR. The body below is
- * written against #417's planned flow (drumhaus joins the session when LINK
- * is toggled on; session bpm <-> transport store, play/stop <-> engine,
- * scene -> variation) so the spec can be enabled by removing the .skip the
- * moment both PRs have merged. Selector details may need a touch-up against
- * the real LINK control.
+ * context, jamming over @haus/bridge. Pulse joins the session on load;
+ * drumhaus opts in through its floating LINK control (issue #417). All
+ * assertions are on UI state - what an end user sees in each app.
  */
+
+// --- drumhaus ---
 
 async function openDrumhaus(context: BrowserContext): Promise<Page> {
   const page = await context.newPage();
   await page.goto("/");
-  // Ready when the default kit's sample channels are loaded (mirrors
-  // apps/drumhaus/e2e/helpers.ts).
+  // Ready when the default kit's sample channels are loaded and the intro
+  // lightshow has finished (mirrors apps/drumhaus/e2e/helpers.ts).
   for (let i = 0; i < 8; i++) {
     await expect(
       page.locator(`[data-instrument-index="${i}"] button`).first(),
     ).toBeEnabled({ timeout: 20_000 });
   }
+  await expect(page.locator('[data-light-node="done"]').first()).toBeAttached({
+    timeout: 15_000,
+  });
   return page;
 }
+
+const linkControl = (page: Page) =>
+  page.getByRole("button", { name: "LINK", exact: true });
+
+/** Opt a drumhaus page into the session and wait until it reports linked. */
+async function enableLink(page: Page): Promise<void> {
+  await linkControl(page).click();
+  await expect(linkControl(page)).toHaveAttribute("data-linked", "true");
+}
+
+/**
+ * The tempo screen's bpm readout: click-to-edit via keyboard. Scoped to the
+ * screen value field: the hardware tempo knob is also a slider named "bpm".
+ */
+const screenBpm = (page: Page) =>
+  page.locator('[data-slot="value-field"][aria-label="bpm"]');
+
+async function setBpmViaScreen(page: Page, bpm: number): Promise<void> {
+  const bpmControl = screenBpm(page);
+  await bpmControl.press("Enter");
+  const input = bpmControl.locator("input");
+  await input.fill(String(bpm));
+  await input.press("Enter");
+  await expect(bpmControl).toContainText(String(bpm));
+}
+
+/** A variation pad (A-D) in the pattern module. */
+const variationPad = (page: Page, label: "A" | "B" | "C" | "D") =>
+  page.getByRole("button", { name: label, exact: true });
+
+/**
+ * Index of the sequencer step indicator (playhead) that is currently lit,
+ * or -1 when the transport is idle. Only advances once the audio clock
+ * runs, so it asserts real playback rather than button state.
+ */
+function litIndicatorIndex(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const indicators = document.querySelectorAll(
+      '[data-light-group="sequencer-indicator"]',
+    );
+    return Array.from(indicators).findIndex((el) =>
+      el.classList.contains("bg-primary"),
+    );
+  });
+}
+
+// --- pulse ---
 
 async function openPulse(context: BrowserContext): Promise<Page> {
   const page = await context.newPage();
@@ -33,42 +79,112 @@ async function openPulse(context: BrowserContext): Promise<Page> {
   return page;
 }
 
+const pulsePlay = (page: Page) =>
+  page.getByRole("button", { name: "play", exact: true });
+const pulseStop = (page: Page) =>
+  page.getByRole("button", { name: "stop", exact: true });
+const pulseBpm = (page: Page) => page.getByLabel("tempo", { exact: true });
+const pulseScene = (page: Page, scene: number) =>
+  page.getByRole("button", { name: `scene ${scene}`, exact: true });
+const pulseConductorDot = (page: Page) => page.locator(".conductor");
+
 test.describe("drumhaus <-> pulse session sync", () => {
-  test.skip("tempo, transport, and scene sync both directions once drumhaus is linked", async ({
+  test("tempo, transport, and scene sync both directions once drumhaus is linked", async ({
     context,
   }) => {
     const drumhaus = await openDrumhaus(context);
     const pulse = await openPulse(context);
 
-    // Drumhaus opts into the session (#417's LINK control); pulse is
-    // always linked.
-    await drumhaus.getByRole("button", { name: /link/i }).click();
+    // Pulse joined on load and, alone in the session, conducts it at the
+    // protocol default 120. Drumhaus opts in and adopts the conductor's
+    // state (its local default is 100).
+    await enableLink(drumhaus);
     await expect(pulse.getByText("peers 2")).toBeVisible();
+    await expect(linkControl(drumhaus)).toHaveAttribute("data-peers", "1");
+    await expect(pulseConductorDot(pulse)).toHaveAttribute(
+      "data-conductor",
+      "true",
+    );
+    await expect(linkControl(drumhaus)).toHaveAttribute(
+      "data-conductor",
+      "false",
+    );
+    await expect(screenBpm(drumhaus)).toContainText("120");
 
-    // pulse -> drumhaus: play from pulse starts the drumhaus transport.
-    await pulse.getByRole("button", { name: "play", exact: true }).click();
+    // pulse -> drumhaus: play from pulse starts the drumhaus transport for
+    // real (the playhead only advances once the audio clock does).
+    await pulsePlay(pulse).click();
     await expect(
       drumhaus.getByRole("button", { name: "Pause", exact: true }),
     ).toBeVisible();
+    await expect
+      .poll(() => litIndicatorIndex(drumhaus), { timeout: 15_000 })
+      .toBeGreaterThanOrEqual(0);
 
     // drumhaus -> pulse: stopping from drumhaus stops pulse.
     await drumhaus.getByRole("button", { name: "Pause", exact: true }).click();
-    await expect(
-      pulse.getByRole("button", { name: "play", exact: true }),
-    ).toBeVisible();
+    await expect(pulsePlay(pulse)).toBeVisible();
+    await expect.poll(() => litIndicatorIndex(drumhaus)).toBe(-1);
 
-    // pulse -> drumhaus: a tempo nudge from pulse reaches drumhaus's bpm
-    // control, and both readouts agree.
+    // pulse -> drumhaus: a tempo nudge from pulse reaches drumhaus's screen
+    // readout, and both agree.
     await pulse.getByLabel("tempo up").click();
-    await expect(pulse.getByLabel("tempo", { exact: true })).toHaveText("121");
-    await expect(drumhaus.getByText("121")).toBeVisible();
+    await expect(pulseBpm(pulse)).toHaveText("121");
+    await expect(screenBpm(drumhaus)).toContainText("121");
 
-    // scene both directions: pulse scene 1 selects drumhaus variation B
-    // while linked, and a drumhaus variation change lights pulse's
-    // indicator (#417 maps scene <-> variation).
-    await pulse.getByRole("button", { name: "scene 1", exact: true }).click();
-    await expect(
-      pulse.getByRole("button", { name: "scene 1", exact: true }),
-    ).toHaveAttribute("aria-pressed", "true");
+    // drumhaus -> pulse: a bpm edit on the drumhaus screen reaches pulse
+    // (an intent round-trip through the pulse conductor).
+    await setBpmViaScreen(drumhaus, 96);
+    await expect(pulseBpm(pulse)).toHaveText("96");
+
+    // pulse -> drumhaus: scene 1 selects variation B while linked.
+    await pulseScene(pulse, 1).click();
+    await expect(pulseScene(pulse, 1)).toHaveAttribute("aria-pressed", "true");
+    await expect(variationPad(drumhaus, "B")).toHaveClass(/border-primary/);
+
+    // drumhaus -> pulse: variation D lights pulse's scene 3.
+    await variationPad(drumhaus, "D").click();
+    await expect(variationPad(drumhaus, "D")).toHaveClass(/border-primary/);
+    await expect(pulseScene(pulse, 3)).toHaveAttribute("aria-pressed", "true");
+    await expect(pulseScene(pulse, 1)).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("conductorship hands off from drumhaus to pulse with state intact", async ({
+    context,
+  }) => {
+    // Drumhaus links while alone, so it conducts; pulse joins as follower.
+    const drumhaus = await openDrumhaus(context);
+    await enableLink(drumhaus);
+    await expect(linkControl(drumhaus)).toHaveAttribute(
+      "data-conductor",
+      "true",
+    );
+
+    const pulse = await openPulse(context);
+    await expect(linkControl(drumhaus)).toHaveAttribute("data-peers", "1");
+    await expect(pulseConductorDot(pulse)).toHaveAttribute(
+      "data-conductor",
+      "false",
+    );
+
+    // The drumhaus conductor's seeded state (its local default bpm 100)
+    // is the session state; put a distinctive tempo in place.
+    await expect(pulseBpm(pulse)).toHaveText("100");
+    await setBpmViaScreen(drumhaus, 132);
+    await expect(pulseBpm(pulse)).toHaveText("132");
+
+    // Closing drumhaus releases the conductor lock; pulse takes over with
+    // the state intact and the departed peer dropped.
+    await drumhaus.close();
+    await expect(pulseConductorDot(pulse)).toHaveAttribute(
+      "data-conductor",
+      "true",
+    );
+    await expect(pulseBpm(pulse)).toHaveText("132");
+    await expect(pulse.getByText("peers 1")).toBeVisible();
+
+    // The surviving conductor still applies commands.
+    await pulse.getByLabel("tempo up").click();
+    await expect(pulseBpm(pulse)).toHaveText("133");
   });
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,6 +13,9 @@ import { defineConfig, devices } from "@playwright/test";
  * `pnpm test:e2e:family` at the repo root builds drumhaus and pulse first,
  * then runs this suite against the static server.
  */
+/** Server port; PORT overrides so parallel checkouts can pick a free one. */
+const port = Number(process.env.PORT ?? 4446);
+
 export default defineConfig({
   testDir: "./family",
   testMatch: "**/*.spec.ts",
@@ -26,7 +29,7 @@ export default defineConfig({
   timeout: 60_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: "http://localhost:4446",
+    baseURL: `http://localhost:${port}`,
     trace: "retain-on-failure",
   },
   projects: [
@@ -37,7 +40,7 @@ export default defineConfig({
   ],
   webServer: {
     command: "node ../scripts/family-server.mjs",
-    port: 4446,
+    port,
     reuseExistingServer: false,
     timeout: 30_000,
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "test:e2e": "pnpm -r test:e2e",
-    "test:e2e:family": "pnpm --filter drumhaus build && pnpm --filter pulse build && playwright test --config e2e/playwright.config.ts",
+    "test:e2e:family": "VITE_ENABLE_LINK=true pnpm --filter drumhaus build && pnpm --filter pulse build && playwright test --config e2e/playwright.config.ts",
     "lint": "pnpm -r lint",
     "format": "prettier . --write",
     "format:check": "prettier . --check",

--- a/packages/bridge-react/src/__tests__/helpers/memory-locks.ts
+++ b/packages/bridge-react/src/__tests__/helpers/memory-locks.ts
@@ -4,7 +4,7 @@
  * promise settles, abortable while pending, abort ignored after grant.
  */
 
-import type { HausLockManager } from "@haus/bridge";
+import type { LockManager } from "@haus/bridge";
 
 interface Waiter {
   granted: boolean;
@@ -12,7 +12,7 @@ interface Waiter {
   run: () => void;
 }
 
-function memoryLocks(): HausLockManager {
+function memoryLocks(): LockManager {
   const held = new Set<string>();
   const queues = new Map<string, Waiter[]>();
 

--- a/packages/bridge-react/src/__tests__/session-controller.test.ts
+++ b/packages/bridge-react/src/__tests__/session-controller.test.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-  createHausSession,
+  createSession,
   DEFAULT_BPM,
   LOCK_NAME,
   memoryHub,
   START_LEAD_MS,
   type BridgeMessage,
   type BridgeTransport,
-  type HausLockManager,
-  type HausSession,
+  type LockManager,
+  type Session,
 } from "@haus/bridge";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -28,20 +28,20 @@ import { flushMicrotasks, memoryLocks } from "./helpers/memory-locks";
 interface Rig {
   nowMs: { value: number };
   controller: SessionController;
-  session: HausSession;
-  createPeer(instrument?: string): HausSession;
+  session: Session;
+  createPeer(instrument?: string): Session;
   createWire(): BridgeTransport;
-  locks: HausLockManager;
+  locks: LockManager;
 }
 
 const cleanups: (() => void)[] = [];
 
-function createRig(locks: HausLockManager = memoryLocks()): Rig {
+function createRig(locks: LockManager = memoryLocks()): Rig {
   const hub = memoryHub();
   const nowMs = { value: 1_000_000 };
   const now = () => nowMs.value;
 
-  const session = createHausSession({
+  const session = createSession({
     instrument: "test",
     transport: hub.createTransport(),
     locks,
@@ -55,7 +55,7 @@ function createRig(locks: HausLockManager = memoryLocks()): Rig {
     controller,
     session,
     createPeer(instrument = "peer") {
-      const peer = createHausSession({
+      const peer = createSession({
         instrument,
         transport: hub.createTransport(),
         locks,
@@ -70,7 +70,7 @@ function createRig(locks: HausLockManager = memoryLocks()): Rig {
 }
 
 /** Hold the conductor lock externally; returns the release function. */
-async function blockConductorLock(locks: HausLockManager): Promise<() => void> {
+async function blockConductorLock(locks: LockManager): Promise<() => void> {
   let release!: () => void;
   void locks.request(
     LOCK_NAME,

--- a/packages/bridge-react/src/__tests__/use-session.browser.test.tsx
+++ b/packages/bridge-react/src/__tests__/use-session.browser.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import { StrictMode } from "react";
-import { createHausSession, memoryHub, type HausSession } from "@haus/bridge";
+import { createSession, memoryHub, type Session } from "@haus/bridge";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -13,8 +13,8 @@ import { useSession } from "../use-session";
 import { memoryLocks } from "./helpers/memory-locks";
 
 interface Harness {
-  session: HausSession;
-  peer: HausSession;
+  session: Session;
+  peer: Session;
   container: HTMLElement;
   root: Root;
 }
@@ -24,12 +24,12 @@ const harnesses: Harness[] = [];
 function renderHarness(): Harness {
   const hub = memoryHub();
   const locks = memoryLocks();
-  const session = createHausSession({
+  const session = createSession({
     instrument: "test",
     transport: hub.createTransport(),
     locks,
   });
-  const peer = createHausSession({
+  const peer = createSession({
     instrument: "peer",
     transport: hub.createTransport(),
     locks,

--- a/packages/bridge-react/src/session-controller.ts
+++ b/packages/bridge-react/src/session-controller.ts
@@ -1,5 +1,5 @@
 /**
- * The framework-free core behind useSession: wraps one HausSession in
+ * The framework-free core behind useSession: wraps one Session in
  * an external-store shape (cached snapshot + single change signal, the
  * useSyncExternalStore contract) and owns the deferred-command readiness
  * handling every instrument would otherwise reimplement.
@@ -28,9 +28,9 @@ import {
   epochNowMs,
   rebaseTempo,
   START_LEAD_MS,
-  type HausPeer,
-  type HausSession,
+  type Peer,
   type SceneId,
+  type Session,
   type SessionState,
 } from "@haus/bridge";
 
@@ -39,7 +39,7 @@ interface SessionSnapshot {
   /** Session state; optimistic while commands are deferred. */
   state: SessionState;
   /** Other currently-known peers (self excluded). */
-  peers: HausPeer[];
+  peers: Peer[];
   /** Whether this tab currently conducts the session. */
   isConductor: boolean;
   /** Whether this controller is currently connected to the session. */
@@ -67,7 +67,7 @@ interface SessionControllerOptions {
 }
 
 function createSessionController(
-  session: HausSession,
+  session: Session,
   options: SessionControllerOptions = {},
 ): SessionController {
   const now = options.now ?? epochNowMs;
@@ -80,7 +80,7 @@ function createSessionController(
   /** Local view of deferred commands; null once the session speaks. */
   let optimistic: SessionState | null = null;
 
-  let peers: HausPeer[] = [];
+  let peers: Peer[] = [];
   let isConductor = false;
 
   const listeners = new Set<() => void>();

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -1,6 +1,6 @@
 # @haus/bridge
 
-Serverless cross-instrument session sync for the haus family.
+Serverless cross-instrument session sync for the instrument family.
 A framework-free, zero-runtime-dependency TypeScript library that lets multiple browser instruments open on the same origin share a musical session: tempo, transport, and scene.
 This README is the protocol's document of record (protocol v1).
 
@@ -11,9 +11,9 @@ One tab, elected via the Web Locks API, is the conductor and owns the session st
 The session's musical grid is fully determined by `(startEpochMs, bpm)`: no position or phase messages exist, every tab derives the grid deterministically from the shared epoch clock and self-corrects locally.
 
 ```ts
-import { createHausSession, epochToContextTime } from "@haus/bridge";
+import { createSession, epochToContextTime } from "@haus/bridge";
 
-const session = createHausSession({ instrument: "drumhaus" });
+const session = createSession({ instrument: "drumhaus" });
 session.connect();
 
 session.onStateChange((state) => {
@@ -167,9 +167,9 @@ These are design decisions, not omissions:
 | `clock.ts`     | pure grid math, tempo rebase, epoch and AudioContext time mapping              |
 | `transport.ts` | the `BridgeTransport` seam: `broadcastChannelTransport`, `memoryHub` for tests |
 | `election.ts`  | conductor election over Web Locks                                              |
-| `session.ts`   | `createHausSession`, the facade wiring all of the above together               |
+| `session.ts`   | `createSession`, the facade wiring all of the above together                   |
 
-`createHausSession({ instrument, label?, transport?, now?, locks? })` accepts injectable transport, clock, and locks, so the whole session is deterministic under test; the defaults are the real `BroadcastChannel`, `epochNowMs`, and `navigator.locks`.
+`createSession({ instrument, label?, transport?, now?, locks? })` accepts injectable transport, clock, and locks, so the whole session is deterministic under test; the defaults are the real `BroadcastChannel`, `epochNowMs`, and `navigator.locks`.
 
 ## Testing
 

--- a/packages/bridge/src/__tests__/helpers/memory-locks.ts
+++ b/packages/bridge/src/__tests__/helpers/memory-locks.ts
@@ -5,7 +5,7 @@
  * relies on.
  */
 
-import type { HausLockManager } from "../../election";
+import type { LockManager } from "../../election";
 
 interface Waiter {
   granted: boolean;
@@ -13,7 +13,7 @@ interface Waiter {
   run: () => void;
 }
 
-function memoryLocks(): HausLockManager {
+function memoryLocks(): LockManager {
   const held = new Set<string>();
   const queues = new Map<string, Waiter[]>();
 

--- a/packages/bridge/src/__tests__/session.browser.test.ts
+++ b/packages/bridge/src/__tests__/session.browser.test.ts
@@ -1,5 +1,5 @@
 /**
- * Real-browser integration: multiple createHausSession instances in one page
+ * Real-browser integration: multiple createSession instances in one page
  * over a real BroadcastChannel and real Web Locks. BroadcastChannel delivers
  * between channel instances in the same context and Web Locks queue within
  * one context exactly as across tabs, so this exercises the production code
@@ -10,8 +10,8 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { beatMs, beatsAt, epochNowMs } from "../clock";
-import type { HausLockManager } from "../election";
-import { createHausSession, type HausSession } from "../session";
+import type { LockManager } from "../election";
+import { createSession, type Session } from "../session";
 import { broadcastChannelTransport } from "../transport";
 import type { SessionState } from "../types";
 
@@ -22,18 +22,18 @@ afterEach(() => {
 });
 
 /** Scope the real Web Locks to this test so suites cannot interfere. */
-function scopedLocks(scope: string): HausLockManager {
+function scopedLocks(scope: string): LockManager {
   return {
     request: (name, options, callback) =>
       navigator.locks.request(`${scope}:${name}`, options, callback),
   };
 }
 
-function createScope(): (instrument: string, label?: string) => HausSession {
-  const scope = `haus-bridge-test-${crypto.randomUUID()}`;
+function createScope(): (instrument: string, label?: string) => Session {
+  const scope = `bridge-test-${crypto.randomUUID()}`;
   return (instrument, label) => {
     const transport = broadcastChannelTransport(`${scope}:channel`);
-    const session = createHausSession({
+    const session = createSession({
       instrument,
       ...(label !== undefined ? { label } : {}),
       transport,
@@ -69,11 +69,11 @@ function until(
   });
 }
 
-describe("haus session in a real browser", () => {
+describe("session in a real browser", () => {
   it("converges two sessions over a real BroadcastChannel", async () => {
     const create = createScope();
     const a = create("drumhaus", "left");
-    const b = create("basshaus", "right");
+    const b = create("bass", "right");
     a.connect();
     await until(() => a.isConductor, "first session conducting");
     b.connect();
@@ -88,7 +88,7 @@ describe("haus session in a real browser", () => {
       "peer discovery",
     );
     expect(a.peers[0]).toMatchObject({
-      instrument: "basshaus",
+      instrument: "bass",
       label: "right",
     });
     expect(b.peers[0]).toMatchObject({ instrument: "drumhaus", label: "left" });
@@ -97,7 +97,7 @@ describe("haus session in a real browser", () => {
   it("elects via real Web Locks and hands off on disconnect with state intact", async () => {
     const create = createScope();
     const a = create("drumhaus");
-    const b = create("basshaus");
+    const b = create("bass");
     a.connect();
     await until(() => a.isConductor, "first session conducting");
     b.connect();
@@ -121,7 +121,7 @@ describe("haus session in a real browser", () => {
     a.setBpm(150);
     a.setScene(3);
 
-    const c = create("synthhaus");
+    const c = create("synth");
     c.connect();
     await until(() => c.state.bpm === 150, "late joiner adopting state");
     expect(c.state).toEqual(a.state);
@@ -130,7 +130,7 @@ describe("haus session in a real browser", () => {
   it("round-trips a follower's setBpm intent through the conductor", async () => {
     const create = createScope();
     const a = create("drumhaus");
-    const b = create("basshaus");
+    const b = create("bass");
     a.connect();
     await until(() => a.isConductor, "conductor ready");
     b.connect();
@@ -148,7 +148,7 @@ describe("haus session in a real browser", () => {
   it("keeps the derived grid continuous across peers through a mid-play rebase", async () => {
     const create = createScope();
     const a = create("drumhaus");
-    const b = create("basshaus");
+    const b = create("bass");
     a.connect();
     await until(() => a.isConductor, "conductor ready");
     b.connect();

--- a/packages/bridge/src/__tests__/session.test.ts
+++ b/packages/bridge/src/__tests__/session.test.ts
@@ -7,18 +7,22 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createHausSession, reduceIntent, type HausSession } from "../session";
+import {
+  createSession as createBridgeSession,
+  reduceIntent,
+  type Session,
+} from "../session";
 import { memoryHub, type BridgeTransport } from "../transport";
 import { START_LEAD_MS, type SessionState } from "../types";
 import { flushMicrotasks, memoryLocks } from "./helpers/memory-locks";
 
 interface Rig {
   nowMs: { value: number };
-  createSession(instrument: string, label?: string): HausSession;
+  createSession(instrument: string, label?: string): Session;
   createWire(): BridgeTransport;
 }
 
-const sessions: HausSession[] = [];
+const sessions: Session[] = [];
 
 /** One shared hub + lock manager + fake clock per test. */
 function createRig(): Rig {
@@ -28,7 +32,7 @@ function createRig(): Rig {
   return {
     nowMs,
     createSession(instrument, label) {
-      const session = createHausSession({
+      const session = createBridgeSession({
         instrument,
         ...(label !== undefined ? { label } : {}),
         transport: hub.createTransport(),
@@ -174,9 +178,9 @@ describe("standalone (never connected)", () => {
 });
 
 describe("conductor and follower", () => {
-  async function connectPair(rig: Rig): Promise<[HausSession, HausSession]> {
+  async function connectPair(rig: Rig): Promise<[Session, Session]> {
     const a = rig.createSession("drumhaus", "a");
-    const b = rig.createSession("basshaus", "b");
+    const b = rig.createSession("bass", "b");
     a.connect();
     await flushMicrotasks();
     b.connect();
@@ -214,7 +218,7 @@ describe("conductor and follower", () => {
     a.setBpm(150);
     a.setScene(3);
 
-    const c = rig.createSession("synthhaus");
+    const c = rig.createSession("synth");
     c.connect();
     await flushMicrotasks();
     expect(c.state).toEqual(a.state);
@@ -240,7 +244,7 @@ describe("conductor and follower", () => {
   it("tracks peers symmetrically and honors goodbye", async () => {
     const rig = createRig();
     const [a, b] = await connectPair(rig);
-    expect(a.peers.map((p) => p.instrument)).toEqual(["basshaus"]);
+    expect(a.peers.map((p) => p.instrument)).toEqual(["bass"]);
     expect(b.peers.map((p) => p.instrument)).toEqual(["drumhaus"]);
 
     b.disconnect();
@@ -314,7 +318,7 @@ describe("peer timeout bookkeeping", () => {
         v: 1,
         type: "hello",
         from: peerId,
-        peer: { id: peerId, instrument: "basshaus" },
+        peer: { id: peerId, instrument: "bass" },
       });
     };
     const heartbeat = (peerId: string) => {
@@ -322,7 +326,7 @@ describe("peer timeout bookkeeping", () => {
         v: 1,
         type: "heartbeat",
         from: peerId,
-        peer: { id: peerId, instrument: "basshaus" },
+        peer: { id: peerId, instrument: "bass" },
       });
     };
 

--- a/packages/bridge/src/election.ts
+++ b/packages/bridge/src/election.ts
@@ -21,7 +21,7 @@ import { LOCK_NAME } from "./types";
  * The subset of navigator.locks the election needs; injectable for
  * deterministic tests and for lock-name scoping.
  */
-interface HausLockManager {
+interface LockManager {
   request(
     name: string,
     options: { signal?: AbortSignal },
@@ -35,7 +35,7 @@ interface ConductorElectionOptions {
   /** Lock name; defaults to LOCK_NAME. */
   name?: string;
   /** Lock manager; defaults to navigator.locks (with the fallback above). */
-  locks?: HausLockManager;
+  locks?: LockManager;
 }
 
 interface ConductorElection {
@@ -49,7 +49,7 @@ interface ConductorElection {
 }
 
 /** Immediate-grant stand-in for environments without Web Locks. */
-function soloLocks(): HausLockManager {
+function soloLocks(): LockManager {
   return {
     async request(_name, _options, callback) {
       return await callback();
@@ -57,7 +57,7 @@ function soloLocks(): HausLockManager {
   };
 }
 
-function defaultLocks(): HausLockManager {
+function defaultLocks(): LockManager {
   const locks = globalThis.navigator?.locks;
   return locks ?? soloLocks();
 }
@@ -102,4 +102,4 @@ function createConductorElection(
 }
 
 export { createConductorElection };
-export type { ConductorElection, ConductorElectionOptions, HausLockManager };
+export type { ConductorElection, ConductorElectionOptions, LockManager };

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,6 +1,7 @@
 /**
- * @haus/bridge - serverless cross-instrument session sync for the haus
- * family. See README.md for the protocol specification (document of record).
+ * @haus/bridge - serverless cross-instrument session sync for the
+ * instrument family. See README.md for the protocol specification
+ * (document of record).
  */
 
 export {
@@ -21,10 +22,10 @@ export { createConductorElection } from "./election";
 export type {
   ConductorElection,
   ConductorElectionOptions,
-  HausLockManager,
+  LockManager,
 } from "./election";
-export { createHausSession } from "./session";
-export type { CreateHausSessionOptions, HausSession } from "./session";
+export { createSession } from "./session";
+export type { CreateSessionOptions, Session } from "./session";
 export { broadcastChannelTransport, memoryHub } from "./transport";
 export type { BridgeTransport, MemoryHub } from "./transport";
 export {
@@ -41,7 +42,7 @@ export {
 } from "./types";
 export type {
   BridgeMessage,
-  HausPeer,
+  Peer,
   SceneId,
   SessionIntent,
   SessionState,

--- a/packages/bridge/src/session.ts
+++ b/packages/bridge/src/session.ts
@@ -16,7 +16,7 @@ import { epochNowMs, rebaseTempo } from "./clock";
 import {
   createConductorElection,
   type ConductorElection,
-  type HausLockManager,
+  type LockManager,
 } from "./election";
 import { broadcastChannelTransport, type BridgeTransport } from "./transport";
 import {
@@ -27,13 +27,13 @@ import {
   PEER_TIMEOUT_MS,
   PROTOCOL_VERSION,
   START_LEAD_MS,
-  type HausPeer,
+  type Peer,
   type SceneId,
   type SessionIntent,
   type SessionState,
 } from "./types";
 
-interface CreateHausSessionOptions {
+interface CreateSessionOptions {
   /** Instrument name announced to peers, e.g. "drumhaus". */
   instrument: string;
   /** Optional human-facing label to distinguish multiple instances. */
@@ -43,14 +43,14 @@ interface CreateHausSessionOptions {
   /** Epoch clock; defaults to epochNowMs. */
   now?: () => number;
   /** Lock manager for conductor election; defaults to navigator.locks. */
-  locks?: HausLockManager;
+  locks?: LockManager;
 }
 
-interface HausSession {
+interface Session {
   /** Current session state (immutable snapshot; never mutated in place). */
   readonly state: SessionState;
   /** Other currently-known peers (self excluded). */
-  readonly peers: HausPeer[];
+  readonly peers: Peer[];
   /** Whether this instance currently holds conductorship. */
   readonly isConductor: boolean;
   /** Join the shared session. Idempotent. */
@@ -66,7 +66,7 @@ interface HausSession {
   /** Request a scene change (0-3). */
   setScene(scene: SceneId): void;
   onStateChange(fn: (state: SessionState) => void): () => void;
-  onPeersChange(fn: (peers: HausPeer[]) => void): () => void;
+  onPeersChange(fn: (peers: Peer[]) => void): () => void;
   onConductorChange(fn: (isConductor: boolean) => void): () => void;
 }
 
@@ -107,8 +107,8 @@ function reduceIntent(
 type OutgoingBody =
   | { type: "intent"; intent: SessionIntent }
   | { type: "state"; state: SessionState }
-  | { type: "hello"; peer: HausPeer }
-  | { type: "heartbeat"; peer: HausPeer }
+  | { type: "hello"; peer: Peer }
+  | { type: "heartbeat"; peer: Peer }
   | { type: "goodbye" };
 
 function statesEqual(a: SessionState, b: SessionState): boolean {
@@ -121,10 +121,10 @@ function statesEqual(a: SessionState, b: SessionState): boolean {
   );
 }
 
-function createHausSession(options: CreateHausSessionOptions): HausSession {
+function createSession(options: CreateSessionOptions): Session {
   const now = options.now ?? epochNowMs;
   const id = crypto.randomUUID();
-  const self: HausPeer = {
+  const self: Peer = {
     id,
     instrument: options.instrument,
     ...(options.label !== undefined ? { label: options.label } : {}),
@@ -138,9 +138,9 @@ function createHausSession(options: CreateHausSessionOptions): HausSession {
     scene: 0,
   };
 
-  const peerEntries = new Map<string, { peer: HausPeer; lastSeenMs: number }>();
+  const peerEntries = new Map<string, { peer: Peer; lastSeenMs: number }>();
   const stateListeners = new Set<(state: SessionState) => void>();
-  const peersListeners = new Set<(peers: HausPeer[]) => void>();
+  const peersListeners = new Set<(peers: Peer[]) => void>();
   const conductorListeners = new Set<(isConductor: boolean) => void>();
 
   let connected = false;
@@ -161,7 +161,7 @@ function createHausSession(options: CreateHausSessionOptions): HausSession {
     };
   }
 
-  function peersSnapshot(): HausPeer[] {
+  function peersSnapshot(): Peer[] {
     return [...peerEntries.values()].map((entry) => entry.peer);
   }
 
@@ -206,7 +206,7 @@ function createHausSession(options: CreateHausSessionOptions): HausSession {
     if (conductor) broadcastState();
   }
 
-  function upsertPeer(peer: HausPeer): void {
+  function upsertPeer(peer: Peer): void {
     const existing = peerEntries.get(peer.id);
     peerEntries.set(peer.id, { peer, lastSeenMs: now() });
     if (
@@ -332,5 +332,5 @@ function createHausSession(options: CreateHausSessionOptions): HausSession {
   };
 }
 
-export { createHausSession, reduceIntent };
-export type { CreateHausSessionOptions, HausSession };
+export { createSession, reduceIntent };
+export type { CreateSessionOptions, Session };

--- a/packages/bridge/src/types.ts
+++ b/packages/bridge/src/types.ts
@@ -44,7 +44,7 @@ const DEFAULT_BPM = 120;
 type SceneId = 0 | 1 | 2 | 3;
 
 /** Identity of one session participant (one instrument in one tab). */
-interface HausPeer {
+interface Peer {
   /** Random per-session-instance id (crypto.randomUUID). */
   id: string;
   /** Instrument name, e.g. "drumhaus". */
@@ -103,13 +103,13 @@ interface StateMessage extends EnvelopeBase {
 /** Any peer: announce joining; triggers heartbeat and state replies. */
 interface HelloMessage extends EnvelopeBase {
   type: "hello";
-  peer: HausPeer;
+  peer: Peer;
 }
 
 /** Any peer: periodic liveness, carrying the peer descriptor. */
 interface HeartbeatMessage extends EnvelopeBase {
   type: "heartbeat";
-  peer: HausPeer;
+  peer: Peer;
 }
 
 /** Any peer: leaving cleanly. */
@@ -136,7 +136,7 @@ function isSceneId(value: unknown): value is SceneId {
   return value === 0 || value === 1 || value === 2 || value === 3;
 }
 
-function isHausPeer(value: unknown): value is HausPeer {
+function isPeer(value: unknown): value is Peer {
   if (!isRecord(value)) return false;
   if (typeof value.id !== "string" || value.id.length === 0) return false;
   if (typeof value.instrument !== "string") return false;
@@ -192,7 +192,7 @@ function parseBridgeMessage(data: unknown): BridgeMessage | null {
   switch (data.type) {
     case "hello":
     case "heartbeat":
-      if (!isHausPeer(data.peer) || data.peer.id !== data.from) return null;
+      if (!isPeer(data.peer) || data.peer.id !== data.from) return null;
       return data as unknown as HelloMessage | HeartbeatMessage;
     case "goodbye":
       return data as unknown as GoodbyeMessage;
@@ -223,7 +223,7 @@ export {
 export type {
   BridgeMessage,
   GoodbyeMessage,
-  HausPeer,
+  Peer,
   HeartbeatMessage,
   HelloMessage,
   IntentMessage,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@haus/bridge':
         specifier: workspace:*
         version: link:../../packages/bridge
+      '@haus/bridge-react':
+        specifier: workspace:*
+        version: link:../../packages/bridge-react
       react:
         specifier: ^19.2.7
         version: 19.2.7


### PR DESCRIPTION
Closes #422. Part of #414 - the closing PR of the epic.

## Commits

### 1. de-brand sweep (#422)

The brand codename now lives only in the @haus/* package scope and the two frozen wire-key defaults (`CHANNEL_NAME "haus-session"`, `LOCK_NAME "haus:conductor"`). Renames: `createHausSession -> createSession`, `HausSession -> Session`, `HausPeer -> Peer`, `HausLockManager -> LockManager`, `CreateHausSessionOptions -> CreateSessionOptions` (and internal `isHausPeer -> isPeer`), with all consumers following (pulse, the drumhaus session adapter, bridge-react, all test rigs). Where a local `createSession` already existed (drumhaus adapter and two test rigs), the bridge factory is imported as `createBridgeSession` instead of keeping the prefix. Live docs prose (bridge README, module comments, pulse's index.html) now says "the instrument family"; test instrument names dropped the -haus suffix. No wire-format or behavior changes.

### 2. pulse adopts @haus/bridge-react

Pulse's hand-rolled deferred-command readiness pattern is deleted in favor of `createSessionController`, which also fixes the known stranding bug (a joiner whose state equals the conductor's never got an `onStateChange`, so readiness never opened; the shared controller's third readiness signal - a visible peer - covers it). `session.ts` is now the recommended integration in 23 lines: `createSession` wrapped in `createSessionController`, one factory. The UI reads it through `useSession`; the metronome keeps following the controller imperatively; pagehide/pageshow handling is unchanged. `@haus/bridge-react: workspace:*` added to pulse.

### 3. cross-app e2e live

`e2e/family/drumhaus-pulse.spec.ts` is un-skipped and rewritten against the real UIs: drumhaus at `/` linked via the floating LINK control, pulse at `/pulse/`; tempo, transport (with a real playhead poll on drumhaus), and scene sync asserted in both directions; conductor handoff from drumhaus to pulse with state intact. Both playwright configs (family and drumhaus) now respect a `PORT` override so parallel checkouts can run side by side.

### 4. LINK ships dark on production

`__ENABLE_LINK__` build-time constant in the app's existing `define` idiom: ON in dev (`vite serve`), ON when `VITE_ENABLE_LINK` is explicitly truthy at build time, OFF otherwise. Flag off: the LINK control does not render and the session bridge hook is a no-op - no session objects are created and the whole session graph (adapter, controller, @haus/bridge) dead-code-eliminates out of the bundle, verified by grepping the default dist for the wire key `haus:conductor` (now a CI step). The drumhaus e2e webServer, a new CI rebuild step, and the family script all build with the flag on. To enable LINK on drumha.us later: set `VITE_ENABLE_LINK=true` in the Cloudflare build config - no code change.

## Grep audit

`grep -ri haus` across `packages/` and `apps/` (excluding node_modules/dist) now hits only:

- `@haus/*` package names and imports, and prose references to those package names
- the two frozen wire keys, `haus-session` and `haus:conductor` (types.ts and the README protocol tables)
- `drumhaus` - the product name, including its `drumhaus-session*` localStorage keys
- English words that merely contain the letters: `exhausted`, `exhaustive-deps`, and "Bauhaus design" in the webmanifest
- drumhaus factory preset names and their fixtures/docs ("Welcome to the Haus", "A Drum Called Haus", "Purple Haus", "Super Dream Haus") and the "in haus" preset-select group label - product creative content, not live family identifiers; renaming them would be a user-visible behavior (and golden-data) change, so they are deliberately out of #422's scope

## Test results

All from repo root, on the final tree:

- `pnpm install --frozen-lockfile`, `pnpm format:check`, `pnpm lint` - clean
- `pnpm -r test` - bridge 60, bridge-react 11, drumhaus 865 passed (4 skipped)
- `pnpm build` - all four projects; default drumhaus dist verified to exclude the LINK code path (wire-key grep empty)
- `pnpm --filter drumhaus test:e2e` - 34 passed (includes the 6 link.spec tests against a flag-on production build)
- `pnpm test:e2e:family` - 6 passed; flake check: 13 total runs across the branch (6 pre-flag, 7 post-flag), the dedicated flake runs with `--retries=0` - 0 failures, 0 retries

Note: local e2e verification ran with `PORT` overrides (4447/4450) because this checkout shares the machine with another worktree holding 4444/4446; that is what the new PORT override in both playwright configs is for.
