### PR TITLE
fix cross-app start misalignment (#425)

### DIFF
--- a/apps/drumhaus/src/core/audio/engine/tone-internals.ts
+++ b/apps/drumhaus/src/core/audio/engine/tone-internals.ts
@@ -28,6 +28,16 @@ interface ToneSamplerInternal {
 }
 
 /**
+ * Tone's live Context.rawContext is a standardized-audio-context wrapper
+ * (tone's pinned dependency), which keeps the browser AudioContext it
+ * wraps in _nativeAudioContext (its base class uses _nativeContext).
+ */
+interface StandardizedAudioContextInternal {
+  _nativeAudioContext?: unknown;
+  _nativeContext?: unknown;
+}
+
+/**
  * Safely access internal envelope signal for cancellation.
  * Returns undefined if the internal structure doesn't match expectations.
  */
@@ -49,4 +59,37 @@ function getSamplerActiveSources(
   return internal._activeSources;
 }
 
-export { getEnvelopeInternalSignal, getSamplerActiveSources };
+/**
+ * Safely reach the NATIVE AudioContext beneath Tone's rawContext.
+ *
+ * The standardized-audio-context wrapper does not implement
+ * getOutputTimestamp, so an epoch<->context clock mapping anchored on it
+ * falls back to currentTime and cannot compensate for output latency -
+ * grid-aligned playback then lands late at the speaker by exactly that
+ * latency (issue #425). The native context underneath carries the real
+ * getOutputTimestamp; scheduling times are interchangeable because the
+ * wrapper's currentTime IS the native context's clock.
+ *
+ * Returns undefined when the internal structure doesn't match
+ * expectations, so callers can fall back to the wrapper (losing only the
+ * latency compensation, not correctness of the clock).
+ */
+function getNativeAudioContext(
+  context: BaseAudioContext,
+): AudioContext | undefined {
+  const internal = context as unknown as StandardizedAudioContextInternal;
+  const candidate = internal._nativeAudioContext ?? internal._nativeContext;
+  if (
+    candidate instanceof AudioContext &&
+    typeof candidate.getOutputTimestamp === "function"
+  ) {
+    return candidate;
+  }
+  return undefined;
+}
+
+export {
+  getEnvelopeInternalSignal,
+  getNativeAudioContext,
+  getSamplerActiveSources,
+};

--- a/apps/drumhaus/src/core/audio/engine/transport/transport.ts
+++ b/apps/drumhaus/src/core/audio/engine/transport/transport.ts
@@ -1,6 +1,7 @@
 import { getTransport, Ticks } from "tone/build/esm/index";
 
 import { SEQUENCE_SUBDIVISION, STEP_COUNT } from "../constants";
+import { getNativeAudioContext } from "../tone-internals";
 
 /**
  * The LIVE transport, captured once at module evaluation.
@@ -44,17 +45,21 @@ function startTransport(atContextTime?: number): void {
 /**
  * The LIVE context's underlying AudioContext, reached through the retained
  * live transport (so a call landing mid-offline-render can never hand out
- * the offline context) and Tone's public Context.rawContext surface - no
- * private internals involved (tone-internals.ts keeps its monopoly).
+ * the offline context).
  *
  * Used by the session adapter to map the shared epoch clock onto the audio
- * clock for grid-aligned starts. Note: Tone's default context is a
- * standardized-audio-context wrapper without getOutputTimestamp, so epoch
- * mapping consumers fall back to currentTime anchoring (a few ms, uniform
- * across same-machine tabs - see @haus/bridge clock.ts).
+ * clock for grid-aligned starts. Tone's public Context.rawContext is a
+ * standardized-audio-context wrapper WITHOUT getOutputTimestamp, and an
+ * epoch mapping anchored on its currentTime lands audio late at the
+ * speaker by the context's whole output latency (tens of ms - issue #425).
+ * So this hands out the NATIVE context beneath the wrapper (same clock,
+ * real getOutputTimestamp; via tone-internals.ts, which keeps its monopoly
+ * on internals), falling back to the wrapper if the internals ever change
+ * shape - degrading to uncompensated anchoring, never breaking the clock.
  */
 function getLiveRawContext(): BaseAudioContext {
-  return liveTransport.context.rawContext;
+  const rawContext = liveTransport.context.rawContext;
+  return getNativeAudioContext(rawContext) ?? rawContext;
 }
 
 /**

--- a/apps/drumhaus/src/core/session/link-state.ts
+++ b/apps/drumhaus/src/core/session/link-state.ts
@@ -1,0 +1,27 @@
+/**
+ * Whether this tab is currently linked to the shared haus session.
+ *
+ * A leaf module that imports nothing, so feature stores can consult the
+ * linked state without importing the session adapter (which imports the
+ * stores back - a cycle). Written only by the adapter's link()/unlink();
+ * everything else is read-only.
+ *
+ * The consumer that motivates this: while linked, the transport store's
+ * togglePlay must NOT start the engine immediately - the session adapter
+ * owns starting playback, aligned to the shared grid's downbeat. An
+ * immediate start would audibly misfire ahead of the downbeat and then be
+ * restarted onto the grid (the double-fire stutter of issue #425).
+ */
+
+let sessionLinked = false;
+
+/** Adapter-only mutator; see module doc. */
+function setSessionLinked(linked: boolean): void {
+  sessionLinked = linked;
+}
+
+function isSessionLinked(): boolean {
+  return sessionLinked;
+}
+
+export { isSessionLinked, setSessionLinked };

--- a/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
@@ -25,6 +25,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import { isSessionLinked } from "./link-state";
 import {
   createSessionAdapter,
   type SessionAdapter,
@@ -488,6 +489,19 @@ describe("unlink", () => {
     conductor.setBpm(180);
     await flushAll();
     expect(useTransportStore.getState().bpm).toBe(100);
+  });
+
+  it("publishes the linked flag for the transport store (#425)", () => {
+    const rig = createRig();
+    expect(isSessionLinked()).toBe(false);
+
+    // While linked, togglePlay consults this flag and leaves starting the
+    // engine to the adapter's grid-aligned path.
+    rig.adapter.link();
+    expect(isSessionLinked()).toBe(true);
+
+    rig.adapter.unlink();
+    expect(isSessionLinked()).toBe(false);
   });
 });
 

--- a/apps/drumhaus/src/core/session/session-adapter.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.ts
@@ -22,10 +22,13 @@
  * Grid alignment: playback starts at the shared grid's next bar boundary
  * (during the start lead window that is bar 0's downbeat itself), mapped
  * onto the live AudioContext with @haus/bridge's epoch clock helpers.
- * Alignment is deferred one macrotask so a user gesture's own
- * store-driven engine.play() lands first and the aligned start supersedes
- * it (the engine's playback intent sequencing guarantees the later call
- * wins). A tempo rebase while playing is applied as a glide - the protocol
+ * While linked this adapter is the ONLY engine starter: togglePlay
+ * suppresses its immediate engine.play() (see link-state.ts), because an
+ * unaligned start would sound ahead of the shared downbeat and then be
+ * restarted onto it - the double-fire stutter of issue #425. Alignment is
+ * still deferred one macrotask, coalescing state bursts (latest wins) and
+ * keeping engine commands out of store-notification stacks. A tempo
+ * rebase while playing is applied as a glide - the protocol
  * rebases phase-continuously and the transport bpm change preserves phase,
  * so no restart (and no chain reset) is needed; realignment (a scheduled
  * restart on the boundary) happens only when adopting a grid this tab is
@@ -51,6 +54,7 @@ import { getAudioEngine } from "@/core/audio/engine";
 import { clampVariationId } from "@/core/audio/engine/pattern-types";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import { setSessionLinked } from "./link-state";
 
 /**
  * Lead added ahead of "now" when picking the bar boundary to start on, so
@@ -229,10 +233,10 @@ function createSessionAdapter(
 
   /**
    * Defer playback alignment one macrotask, coalescing bursts (latest
-   * wins). The deferral is load-bearing: when the local user pressed play,
-   * togglePlay's own engine.play() is issued synchronously after its store
-   * write; running the aligned play after it makes the aligned start the
-   * newest playback intent, so the immediate unaligned start stands down.
+   * wins). togglePlay never starts the engine while linked (#425 - see
+   * link-state.ts), so nothing here races a user start; the deferral
+   * keeps engine commands out of synchronous store-notification stacks
+   * and collapses rapid state changes into one aligned start.
    */
   function schedulePlaybackSync(grid: SharedGrid | null): void {
     pendingGrid = grid;
@@ -327,6 +331,9 @@ function createSessionAdapter(
     // comment at the top of the factory.
     swapInFreshController();
     appliedGrid = null;
+    // Published for the transport store: while linked, togglePlay leaves
+    // starting the engine to this adapter's grid-aligned path (#425).
+    setSessionLinked(true);
 
     // Seed BEFORE connecting: pre-connect commands apply locally without a
     // rev bump, so if this tab becomes conductor its seeded state
@@ -386,6 +393,7 @@ function createSessionAdapter(
     unsubscribers = [];
     controller.disconnect();
     appliedGrid = null;
+    setSessionLinked(false);
     // Fully local from here: playback (if any) keeps running untouched.
   }
 

--- a/apps/drumhaus/src/features/transport/store/use-transport-store.test.ts
+++ b/apps/drumhaus/src/features/transport/store/use-transport-store.test.ts
@@ -8,7 +8,17 @@
  * separately by the browser tests.
  */
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { setSessionLinked } from "@/core/session/link-state";
 
 const engineMock = vi.hoisted(() => ({
   play: vi.fn<() => Promise<void>>(() => Promise.resolve()),
@@ -31,6 +41,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   engineMock.play.mockImplementation(() => Promise.resolve());
   useTransportStore.setState({ isPlaying: false });
+});
+
+afterEach(() => {
+  setSessionLinked(false);
 });
 
 describe("togglePlay", () => {
@@ -79,5 +93,22 @@ describe("togglePlay", () => {
     expect(engineMock.play).toHaveBeenCalledTimes(1);
     expect(engineMock.setTempo).not.toHaveBeenCalled();
     expect(engineMock.setSwing).not.toHaveBeenCalled();
+  });
+
+  it("while linked, leaves starting the engine to the session adapter (#425)", async () => {
+    setSessionLinked(true);
+
+    // Play: the store flips optimistically (the adapter sees the flip via
+    // its subscription and schedules the grid-aligned start), but the
+    // immediate engine start is suppressed - it would sound ahead of the
+    // shared downbeat and then be restarted onto it.
+    await useTransportStore.getState().togglePlay();
+    expect(useTransportStore.getState().isPlaying).toBe(true);
+    expect(engineMock.play).not.toHaveBeenCalled();
+
+    // Stop stays immediate while linked.
+    await useTransportStore.getState().togglePlay();
+    expect(useTransportStore.getState().isPlaying).toBe(false);
+    expect(engineMock.stop).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/drumhaus/src/features/transport/store/use-transport-store.ts
+++ b/apps/drumhaus/src/features/transport/store/use-transport-store.ts
@@ -3,6 +3,7 @@ import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { getAudioEngine } from "@/core/audio/engine";
+import { isSessionLinked } from "@/core/session/link-state";
 
 // No persist middleware: bpm/swing persist inside the session document
 // (features/preset/session), restored by bootstrapSession() before React
@@ -45,6 +46,17 @@ const useTransportStore = create<TransportState>()(
 
         if (!shouldPlay) {
           engine.stop();
+          return;
+        }
+
+        // While linked, the session adapter owns starting the engine: the
+        // store flip above just reached it (synchronous subscription), and
+        // it starts playback aligned to the shared grid's downbeat. An
+        // immediate start here would sound ahead of that downbeat and then
+        // be restarted onto it - the double-fire stutter of issue #425.
+        // The UI is already optimistic via the flip; engine playback-state
+        // events reconcile it if the aligned start cannot run.
+        if (isSessionLinked()) {
           return;
         }
 

--- a/e2e/family/cross-app-timing.spec.ts
+++ b/e2e/family/cross-app-timing.spec.ts
@@ -1,0 +1,301 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+/**
+ * Cross-app playback ALIGNMENT (issue #425): drumhaus and pulse must place
+ * their beat onsets on the same shared-grid instants, not merely both be
+ * "playing". This spec is the automated ear.
+ *
+ * How it measures: an init script in every page patches
+ * OscillatorNode.start / AudioBufferSourceNode.start to record each
+ * scheduled onset, mapped to shared epoch time with the node's own
+ * context's getOutputTimestamp anchor - the same mapping
+ * packages/bridge/src/clock.ts uses (contextTimeToEpochMs), so the numbers
+ * are speaker-time, comparable across pages. The session's grid
+ * (startEpochMs, bpm) is captured off the BroadcastChannel state
+ * broadcasts. Pulse's metronome clicks give the reference beat grid;
+ * drumhaus is measured against it.
+ *
+ * Asserted for both start-from-drumhaus and start-from-pulse:
+ * - at least MIN_ALIGNED_BEATS consecutive beats where the two apps'
+ *   onsets agree within TOLERANCE_MS, and
+ * - no drumhaus double-fire: no scheduled hit audibly ahead of the shared
+ *   downbeat (the "misfire then restart" stutter of #425).
+ */
+
+/** Cross-app onset agreement tolerance. Musically tight, not sample-locked. */
+const TOLERANCE_MS = 10;
+
+/** Minimum consecutive aligned beats each scenario must produce. */
+const MIN_ALIGNED_BEATS = 8;
+
+/** Beats measured: 8 asserted plus margin for scheduling to settle. */
+const PLAY_MS = 6_000;
+
+interface CapturedOnset {
+  kind: "osc" | "buffer";
+  /** start()'s `when` argument; null when called with no argument. */
+  rawWhen: number | null;
+  /** Resolved schedule time on the node's own context (seconds). */
+  contextWhen: number;
+  /** The context's currentTime at the start() call (seconds). */
+  currentTime: number;
+  /** contextWhen mapped to shared epoch ms via getOutputTimestamp. */
+  epochMs: number;
+}
+
+interface CapturedState {
+  state: { playing: boolean; bpm: number; startEpochMs: number | null };
+}
+
+declare global {
+  interface Window {
+    __onsets: CapturedOnset[];
+    __sessionStates: CapturedState[];
+  }
+}
+
+/**
+ * Injected before any app code: records every scheduled source start with
+ * an epoch mapping anchored by that context's getOutputTimestamp (falling
+ * back to currentTime exactly like the bridge clock), and spies session
+ * state broadcasts off the haus BroadcastChannel.
+ */
+const ONSET_CAPTURE_INIT = `(() => {
+  const onsets = [];
+  window.__onsets = onsets;
+  const anchorOf = (ctx) => {
+    const ts = ctx.getOutputTimestamp ? ctx.getOutputTimestamp() : null;
+    if (
+      ts &&
+      typeof ts.contextTime === "number" &&
+      typeof ts.performanceTime === "number" &&
+      (ts.contextTime !== 0 || ts.performanceTime !== 0)
+    ) {
+      return { c: ts.contextTime, e: performance.timeOrigin + ts.performanceTime };
+    }
+    return { c: ctx.currentTime, e: performance.timeOrigin + performance.now() };
+  };
+  const patch = (Ctor, kind) => {
+    const orig = Ctor.prototype.start;
+    Ctor.prototype.start = function (when, ...rest) {
+      try {
+        const ctx = this.context;
+        const contextWhen = Math.max(when ?? 0, ctx.currentTime);
+        const a = anchorOf(ctx);
+        onsets.push({
+          kind,
+          rawWhen: when === undefined ? null : when,
+          contextWhen,
+          currentTime: ctx.currentTime,
+          epochMs: a.e + (contextWhen - a.c) * 1000,
+        });
+      } catch {}
+      return orig.call(this, when, ...rest);
+    };
+  };
+  patch(OscillatorNode, "osc");
+  patch(AudioBufferSourceNode, "buffer");
+
+  window.__sessionStates = [];
+  const OrigBC = window.BroadcastChannel;
+  const record = (state) => {
+    window.__sessionStates.push({ state });
+  };
+  window.BroadcastChannel = function (name) {
+    const bc = new OrigBC(name);
+    if (name === "haus-session") {
+      const spy = new OrigBC(name);
+      spy.onmessage = (ev) => {
+        const d = ev.data;
+        if (d && d.type === "state") record(d.state);
+      };
+      const origPost = bc.postMessage.bind(bc);
+      bc.postMessage = (msg) => {
+        if (msg && msg.type === "state") record(msg.state);
+        return origPost(msg);
+      };
+    }
+    return bc;
+  };
+  window.BroadcastChannel.prototype = OrigBC.prototype;
+})();`;
+
+// --- page drivers (selectors mirror drumhaus-pulse.spec.ts) ---
+
+async function openDrumhaus(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto("/");
+  for (let i = 0; i < 8; i++) {
+    await expect(
+      page.locator(`[data-instrument-index="${i}"] button`).first(),
+    ).toBeEnabled({ timeout: 20_000 });
+  }
+  await expect(page.locator('[data-light-node="done"]').first()).toBeAttached({
+    timeout: 15_000,
+  });
+  return page;
+}
+
+async function openPulse(context: BrowserContext): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto("/pulse/");
+  await expect(page.getByRole("heading", { name: "pulse" })).toBeVisible();
+  // Any pointerdown creates pulse's AudioContext; without it the metronome
+  // cannot sound when playback starts from the other app.
+  await page.locator("h1").click();
+  return page;
+}
+
+async function enableLink(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "LINK", exact: true }).click();
+  await expect(
+    page.getByRole("button", { name: "LINK", exact: true }),
+  ).toHaveAttribute("data-linked", "true");
+}
+
+/**
+ * Program hits on every beat (steps 0, 4, 8, 12) of the selected voice so
+ * drumhaus produces a transient on each quarter note, comparable to
+ * pulse's metronome clicks.
+ */
+async function programBeats(page: Page): Promise<void> {
+  for (const index of [0, 4, 8, 12]) {
+    const step = page.locator(`button[data-step-index="${index}"]`);
+    await step.click();
+    await expect(step).toHaveAttribute("data-active", "true");
+  }
+}
+
+// --- measurement ---
+
+interface PageCapture {
+  onsets: CapturedOnset[];
+  states: CapturedState[];
+}
+
+function capture(page: Page): Promise<PageCapture> {
+  return page.evaluate(() => ({
+    onsets: window.__onsets,
+    states: window.__sessionStates,
+  }));
+}
+
+/**
+ * Onsets genuinely scheduled ahead on a running context: filters the
+ * context-unlock blips (start() with no argument) and library
+ * feature-detection calls (start(0) on fresh offline contexts).
+ */
+function scheduledOnsets(onsets: CapturedOnset[]): CapturedOnset[] {
+  return onsets.filter(
+    (onset) =>
+      onset.rawWhen !== null && onset.contextWhen > onset.currentTime + 0.02,
+  );
+}
+
+/** The grid both apps agreed to play on (last playing state broadcast). */
+function sessionGrid(...captures: PageCapture[]): {
+  startEpochMs: number;
+  beatMs: number;
+} {
+  const playing = captures
+    .flatMap((c) => c.states)
+    .filter((s) => s.state.playing && s.state.startEpochMs !== null);
+  expect(playing.length).toBeGreaterThan(0);
+  const grid = playing[playing.length - 1].state;
+  return { startEpochMs: grid.startEpochMs!, beatMs: 60_000 / grid.bpm };
+}
+
+/**
+ * Assert cross-app agreement: for each pulse click (the reference beat
+ * grid), the nearest scheduled drumhaus onset must land within
+ * TOLERANCE_MS, for at least MIN_ALIGNED_BEATS consecutive beats.
+ */
+function expectAligned(drumhaus: PageCapture, pulse: PageCapture): void {
+  const { startEpochMs, beatMs } = sessionGrid(drumhaus, pulse);
+  const clicks = scheduledOnsets(pulse.onsets).filter((o) => o.kind === "osc");
+  const hits = scheduledOnsets(drumhaus.onsets).filter(
+    (o) => o.kind === "buffer",
+  );
+  expect(clicks.length).toBeGreaterThanOrEqual(MIN_ALIGNED_BEATS);
+  expect(hits.length).toBeGreaterThanOrEqual(MIN_ALIGNED_BEATS);
+
+  // Offset per beat index, where a beat is aligned when the nearest
+  // drumhaus onset to the pulse click is within tolerance.
+  const alignedBeats = new Set<number>();
+  const offsets: string[] = [];
+  for (const click of clicks) {
+    const beat = Math.round((click.epochMs - startEpochMs) / beatMs);
+    let nearest = Infinity;
+    for (const hit of hits) {
+      const delta = hit.epochMs - click.epochMs;
+      if (Math.abs(delta) < Math.abs(nearest)) nearest = delta;
+    }
+    offsets.push(`beat ${beat}: ${nearest.toFixed(2)}ms`);
+    if (Math.abs(nearest) <= TOLERANCE_MS) alignedBeats.add(beat);
+  }
+
+  let longestRun = 0;
+  let run = 0;
+  const maxBeat = Math.max(...alignedBeats, 0);
+  for (let beat = 0; beat <= maxBeat; beat++) {
+    run = alignedBeats.has(beat) ? run + 1 : 0;
+    longestRun = Math.max(longestRun, run);
+  }
+
+  expect
+    .soft(longestRun, `per-beat offsets:\n${offsets.join("\n")}`)
+    .toBeGreaterThanOrEqual(MIN_ALIGNED_BEATS);
+
+  // No double-fire: nothing from drumhaus may sound audibly ahead of the
+  // shared downbeat (the immediate unaligned start's misfire).
+  const misfires = hits.filter(
+    (hit) =>
+      hit.epochMs < startEpochMs - TOLERANCE_MS &&
+      hit.epochMs > startEpochMs - beatMs,
+  );
+  expect(
+    misfires.map((hit) => `${(hit.epochMs - startEpochMs).toFixed(2)}ms`),
+  ).toEqual([]);
+}
+
+// --- scenarios ---
+
+test.describe("cross-app beat alignment", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.addInitScript(ONSET_CAPTURE_INIT);
+  });
+
+  test("starting from drumhaus, both apps sound the same beats", async ({
+    context,
+  }) => {
+    const drumhaus = await openDrumhaus(context);
+    await programBeats(drumhaus);
+    const pulse = await openPulse(context);
+    await enableLink(drumhaus);
+
+    await drumhaus.getByRole("button", { name: "Play", exact: true }).click();
+    await expect(
+      drumhaus.getByRole("button", { name: "Pause", exact: true }),
+    ).toBeVisible();
+    await drumhaus.waitForTimeout(PLAY_MS);
+
+    expectAligned(await capture(drumhaus), await capture(pulse));
+  });
+
+  test("starting from pulse, both apps sound the same beats", async ({
+    context,
+  }) => {
+    const drumhaus = await openDrumhaus(context);
+    await programBeats(drumhaus);
+    const pulse = await openPulse(context);
+    await enableLink(drumhaus);
+
+    await pulse.getByRole("button", { name: "play", exact: true }).click();
+    await expect(
+      drumhaus.getByRole("button", { name: "Pause", exact: true }),
+    ).toBeVisible();
+    await pulse.waitForTimeout(PLAY_MS);
+
+    expectAligned(await capture(drumhaus), await capture(pulse));
+  });
+});


### PR DESCRIPTION
Fixes #425.

## Measured numbers (before)

Built the family server and drove the real flows headlessly, patching `OscillatorNode.start` / `AudioBufferSourceNode.start` in both pages via Playwright init scripts and mapping every scheduled onset to shared epoch time with each context's own `getOutputTimestamp` anchor (the same math as `packages/bridge/src/clock.ts` `contextTimeToEpochMs`). Pulse's clicks land exactly on the session grid; drumhaus was measured against them, per beat:

| scenario | drumhaus vs pulse (median, n=20) | spread |
| --- | --- | --- |
| start from drumhaus | +30.46ms | 30.32..30.54 |
| start from pulse | +28.24ms | 28.14..28.26 |
| drumhaus joins playing session | +31.82ms | 31.80..31.91 |

Start-from-drumhaus additionally showed the stutter Max heard: step 0's sample fired at -64ms (the immediate unaligned start) and again at +30ms (the aligned restart) - two hits ~95ms apart.

## Root cause

Two independent defects:

1. Output-latency blindness (the constant ~30ms, all flows). `startAlignedToGrid` maps `startEpochMs` onto the context returned by `engine.getLiveAudioContext()`, which was Tone's `Context.rawContext` - a standardized-audio-context wrapper that does not implement `getOutputTimestamp` at all (verified in the pinned standardized-audio-context 25.3.77 source). The bridge clock therefore took its documented `currentTime` fallback, which cannot compensate for output latency, so drumhaus's downbeat left the speaker late by exactly the context's output latency (~30ms in headless Chromium; device-dependent tens of ms live). Pulse anchors on its native context's real `getOutputTimestamp`, so it lands on the instant. Verified against pinned tone 15.5.25 source that `transport.start(t)` takes raw context seconds and places position 0's audio exactly at `t` - the measurement shows no lookAhead/time-domain term, only the anchor delta.

2. Double-fire stutter (start-from-drumhaus). `togglePlay` starts the engine immediately; the adapter's deferred aligned start then stop/restarts the transport on the shared downbeat. The immediate start is not "superseded" silently - it *sounds* first (step 0 up to 200ms early), then step 0 fires again on the grid.

## Fix

- `tone-internals.ts` (the quarantine for internals) gains `getNativeAudioContext`, reaching the native `AudioContext` beneath the standardized-audio-context wrapper; `getLiveRawContext` now hands that out (same clock - the wrapper's `currentTime` IS the native one - plus a real `getOutputTimestamp`), falling back to the wrapper if the internals ever change shape. The bridge clock then takes its preferred output-timestamp branch, exactly like pulse.
- While linked, `togglePlay` leaves starting the engine to the session adapter's grid-aligned path (new `core/session/link-state.ts` leaf flag, written only by `link()`/`unlink()`; a leaf module because the adapter imports the stores back). The UI still flips optimistically; unlinked playback keeps today's instant start. Stop remains immediate everywhere.

Pulse's scheduling was the correct reference and is untouched.

## Regression guard

`e2e/family/cross-app-timing.spec.ts` - the automated ear. Both start directions: capture scheduled onsets in both pages with the init-script technique above, filter unlock blips and library feature-detection calls, and assert (a) at least 8 consecutive beats where the two apps' onsets agree within 10ms, and (b) no drumhaus hit audibly ahead of the shared downbeat (the misfire).

- Against unfixed main (rebased tip, LINK-enabled build): both tests fail - constant +27.2ms / +28.7ms per-beat offsets on every beat, plus a `-67.68ms` misfire in the from-drumhaus flow.
- With the fix: both pass; measured per-beat offsets collapse to median +0.04ms / +0.04ms / +0.05ms (join) with spread under 0.2ms.

## Measured numbers (after)

| scenario | drumhaus vs pulse (median, n=20) |
| --- | --- |
| start from drumhaus | +0.04ms |
| start from pulse | +0.04ms |
| drumhaus joins playing session | +0.05ms |

No pre-downbeat misfire in any flow; the join scenario starts cleanly on the next bar boundary.

## Verification

- `pnpm format:check`, `pnpm lint` - clean
- `pnpm -r test` - 867 passed drumhaus (+ bridge/bridge-react/pulse suites), including new unit coverage: togglePlay suppression while linked, link-state flag lifecycle
- `pnpm build` - clean
- `pnpm --filter drumhaus test:e2e` - 34 passed (link.spec included)
- `pnpm test:e2e:family` - 8 passed; full family suite run 5x with `--retries 0`: 8/8 passed every run
