### PR TITLE
feat(pulse): adopt the shared design packages

### DIFF
--- a/apps/pulse/index.html
+++ b/apps/pulse/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#0e0e11" />
+    <meta name="theme-color" content="#e8e3dd" />
     <link rel="icon" href="data:," />
     <title>pulse</title>
     <meta

--- a/apps/pulse/package.json
+++ b/apps/pulse/package.json
@@ -12,14 +12,18 @@
   "dependencies": {
     "@haus/bridge": "workspace:*",
     "@haus/bridge-react": "workspace:*",
+    "@haus/tokens": "workspace:*",
+    "@haus/ui": "workspace:*",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "oxlint": "^1.71.0",
+    "tailwindcss": "^4.3.1",
     "typescript": "^6",
     "vite": "^8.0.16"
   }

--- a/apps/pulse/src/app.tsx
+++ b/apps/pulse/src/app.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import type { SceneId } from "@haus/bridge";
 import { useSession, type SessionController } from "@haus/bridge-react";
+import { Button, cn } from "@haus/ui";
 
 import { createMetronome, type Metronome } from "./metronome";
 
@@ -45,58 +46,80 @@ function App({ controller }: AppProps) {
   const bpm = Math.round(state.bpm);
 
   return (
-    <main className="app">
-      <h1 className="wordmark">pulse</h1>
+    <main className="app flex h-full flex-col items-center justify-between px-8 py-12">
+      <h1 className="wordmark font-pixel text-primary indent-[0.5em] text-xl tracking-[0.5em]">
+        pulse
+      </h1>
 
-      <div className="controls">
-        <button
+      <div className="controls neu-medium-raised surface flex flex-col items-center gap-10 rounded-xl border p-10">
+        <Button
           type="button"
-          className="transport"
+          variant="hardware"
+          size="lg"
+          className={cn(
+            "transport w-36 indent-[0.3em] tracking-[0.3em]",
+            state.playing && "border-primary text-primary border-2",
+          )}
           data-playing={state.playing}
           onClick={() => (state.playing ? stop() : play())}
         >
           {state.playing ? "stop" : "play"}
-        </button>
+        </Button>
 
-        <div className="tempo">
-          <button
+        <div className="tempo flex items-center gap-6">
+          <Button
             type="button"
+            variant="hardware"
+            size="icon-lg"
             aria-label="tempo down"
             onClick={() => setBpm(bpm - 1)}
           >
             -
-          </button>
-          <output className="bpm" aria-label="tempo">
+          </Button>
+          <output
+            className="bpm bg-screen text-screen-foreground shadow-inset font-pixel min-w-28 rounded-xl px-4 py-2 text-center text-4xl tabular-nums"
+            aria-label="tempo"
+          >
             {bpm}
           </output>
-          <button
+          <Button
             type="button"
+            variant="hardware"
+            size="icon-lg"
             aria-label="tempo up"
             onClick={() => setBpm(bpm + 1)}
           >
             +
-          </button>
+          </Button>
         </div>
 
-        <div className="scenes" role="group" aria-label="scene">
+        <div className="scenes flex gap-3" role="group" aria-label="scene">
           {SCENES.map((scene) => (
-            <button
+            <Button
               key={scene}
               type="button"
+              variant="hardware"
+              size="icon-lg"
               aria-label={`scene ${scene}`}
               aria-pressed={state.scene === scene}
+              className={cn(
+                state.scene === scene && "border-primary text-primary border-2",
+              )}
               onClick={() => setScene(scene)}
             >
               {scene}
-            </button>
+            </Button>
           ))}
         </div>
       </div>
 
-      <footer className="status">
+      <footer className="status text-foreground-muted flex items-center gap-4 text-sm tracking-widest">
         <span className="peers">peers {peerCount}</span>
         <span
-          className="conductor"
+          className={cn(
+            "conductor size-2 rounded-full border",
+            isConductor && "bg-primary border-primary",
+          )}
           data-conductor={isConductor}
           title="conductor"
         />

--- a/apps/pulse/src/main.tsx
+++ b/apps/pulse/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
+import "@haus/tokens/fonts.css";
+
 import { App } from "./app";
 import { createPulseSession } from "./session";
 

--- a/apps/pulse/src/styles.css
+++ b/apps/pulse/src/styles.css
@@ -1,141 +1,43 @@
-/* Pulse wears plain CSS until sprint 2 extracts the shared design packages.
-   Dark, monospace, generous negative space; one accent for anything lit. */
+/* Pulse wears the family design language: @haus/tokens supplies the theme
+   and neumorphic utilities, @haus/ui the components. Only layout glue that
+   has no token or utility equivalent lives here. */
+
+/* ==================== Core ==================== */
+@import "tailwindcss";
+
+/* ==================== Theme & Configuration ==================== */
+@import "@haus/tokens/theme.css";
+
+/* ==================== Utilities ==================== */
+@import "@haus/tokens/utilities.css";
+
+/* ==================== Content Scanning ==================== */
+/* Workspace packages live outside this app's Vite root, so Tailwind's
+   automatic content detection never scans them. Register their component
+   source explicitly or every utility class used only inside the package
+   would be dropped from the built CSS. */
+@source "../../../packages/ui/src";
+
+/* ==================== Base Elements ==================== */
 
 :root {
-  color-scheme: dark;
-  --bg: #0e0e11;
-  --ink: #e6e4dd;
-  --dim: #58575f;
-  --accent: #f5c04e;
-}
-
-* {
-  box-sizing: border-box;
+  color-scheme: light;
 }
 
 html,
 body,
 #root {
   height: 100%;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
 }
 
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--ink);
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 14px;
-  -webkit-font-smoothing: antialiased;
+/* Default border color (Tailwind preflight defaults to currentColor) */
+*:not([class*="border-"]) {
+  border-color: var(--color-border);
 }
 
-.app {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
-  padding: 3rem 2rem;
-}
-
-.wordmark {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 400;
-  letter-spacing: 0.5em;
-  text-indent: 0.5em; /* recenters the tracked-out glyphs */
-  color: var(--ink);
-}
-
-.controls {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3rem;
-}
-
-button {
-  font: inherit;
-  color: var(--ink);
-  background: none;
-  border: 1px solid var(--dim);
-  border-radius: 2px;
-  padding: 0.5rem 1rem;
+button:not(:disabled) {
   cursor: pointer;
-}
-
-button:hover {
-  border-color: var(--ink);
-}
-
-button:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.transport {
-  width: 9rem;
-  padding: 1.25rem 0;
-  letter-spacing: 0.3em;
-  text-indent: 0.3em;
-}
-
-.transport[data-playing="true"] {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
-.tempo {
-  display: flex;
-  align-items: center;
-  gap: 1.5rem;
-}
-
-.tempo button {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-}
-
-.bpm {
-  min-width: 6rem;
-  text-align: center;
-  font-size: 3rem;
-  font-variant-numeric: tabular-nums;
-}
-
-.scenes {
-  display: flex;
-  gap: 0.75rem;
-}
-
-.scenes button {
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0;
-  color: var(--dim);
-}
-
-.scenes button[aria-pressed="true"] {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
-.status {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  color: var(--dim);
-  letter-spacing: 0.1em;
-}
-
-.conductor {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  border: 1px solid var(--dim);
-}
-
-.conductor[data-conductor="true"] {
-  background: var(--accent);
-  border-color: var(--accent);
 }

--- a/apps/pulse/src/styles.css
+++ b/apps/pulse/src/styles.css
@@ -41,3 +41,20 @@ body,
 button:not(:disabled) {
   cursor: pointer;
 }
+
+/* ==================== Focus Indicators ==================== */
+
+/* All focusable elements get consistent focus ring (the @haus/ui Button
+   base carries outline-none; this restores visible keyboard focus, same
+   as drumhaus's base rule) */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[role="tab"]:focus-visible,
+[role="slider"]:focus-visible {
+  outline: 2px solid var(--color-ring);
+  outline-offset: 0px;
+}

--- a/apps/pulse/vite.config.ts
+++ b/apps/pulse/vite.config.ts
@@ -1,3 +1,4 @@
+import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
@@ -6,7 +7,7 @@ import { defineConfig } from "vite";
 // built on - are same-origin only.
 export default defineConfig({
   base: "/pulse/",
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   server: {
     port: 4445,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,12 @@ importers:
       '@haus/bridge-react':
         specifier: workspace:*
         version: link:../../packages/bridge-react
+      '@haus/tokens':
+        specifier: workspace:*
+        version: link:../../packages/tokens
+      '@haus/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -178,6 +184,9 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.1
+        version: 4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -190,6 +199,9 @@ importers:
       oxlint:
         specifier: ^1.71.0
         version: 1.71.0
+      tailwindcss:
+        specifier: ^4.3.1
+        version: 4.3.1
       typescript:
         specifier: ^6
         version: 6.0.3


### PR DESCRIPTION
## What changed

Pulse drops its placeholder plain CSS (the file itself said it wears plain CSS until sprint 2 extracts the shared design packages) and adopts @haus/tokens and @haus/ui. It now comes out of the box looking like a sibling of drumhaus: warm light background, neumorphic raised chassis panel, hardware buttons, an inset screen-style bpm readout in the pixel font, and the primary orange for the wordmark, active states, and the conductor dot.

- Tailwind v4 wired the way drumhaus does it: tailwindcss + @tailwindcss/vite, a CSS entry importing tailwindcss, @haus/tokens/theme.css, and @haus/tokens/utilities.css, plus an @source directive for packages/ui/src so @haus/ui component classes are emitted. Fonts come in via @haus/tokens/fonts.css at the app entry. tw-animate-css is omitted: pulse only uses Button (and cn) from @haus/ui, which use no animation classes.
- All controls are the hardware Button variant; the rest is token utilities. styles.css is reduced to the Tailwind entry plus a few base rules with no utility equivalent (root sizing, default border color, cursor).
- index.html theme-color updated from the dark placeholder to the shared background.
- Scope: apps/pulse and the lockfile only. Zero changes under apps/drumhaus or packages/.

## Faithful re-skin

This is a re-skin, not a redesign: the exact structure and interaction model are unchanged (wordmark, play/stop transport, minus/bpm/plus, 4 scene buttons, peers count + conductor dot), with bare labels and no added copy. Further art direction on the instrument is Max's.

## Selector contracts preserved

Everything the family e2e suite relies on is intact: the h1 "pulse" heading, play/stop button names, tempo up/down aria-labels, the output[aria-label="tempo"] readout with the bpm as its exact text, scene buttons with aria-pressed, the .conductor dot with data-conductor, and the peers text.

## Verification

- pnpm format:check, pnpm lint, pnpm test: all green
- pulse build, drumhaus build, and VITE_ENABLE_LINK=true drumhaus build: all green
- Family e2e suite (test:e2e:family): 8/8 passed
- Before/after screenshots at 900x700 captured locally (/tmp/haus-sprint2-visual/pulse-before.png and pulse-after.png)