### PR TITLE
feat(bridge): expose which anchor branch a context mapping uses

### DIFF
--- a/apps/drumhaus/src/core/session/session-adapter.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.ts
@@ -37,11 +37,13 @@
  */
 
 import {
+  contextClockAnchor,
   createSession as createBridgeSession,
   epochNowMs,
   epochToContextTime,
   nextBarStartEpochMs,
   type BridgeAudioContext,
+  type ClockAnchorKind,
   type Session,
   type SessionState,
 } from "@haus/bridge";
@@ -112,11 +114,24 @@ function stateGrid(state: SessionState): SharedGrid | null {
     : null;
 }
 
+/** Window slot for the anchor-kind diagnostic; read by the family e2e. */
+interface ClockAnchorDiagnostics {
+  __clockAnchorKind?: () => ClockAnchorKind;
+}
+
 function createSessionAdapter(
   options: SessionAdapterOptions = {},
 ): SessionAdapter {
   const engine = options.engine ?? getAudioEngine();
   const now = options.now ?? epochNowMs;
+
+  // Non-UI diagnostic hook: which branch anchors the epoch<->context mapping
+  // for the SAME live context this adapter schedules aligned starts on. The
+  // family e2e asserts the speaker-aligned "outputTimestamp" branch here -
+  // the currentTime fallback silently loses output-latency compensation
+  // (issues #425/#429).
+  (window as unknown as ClockAnchorDiagnostics).__clockAnchorKind = () =>
+    contextClockAnchor(engine.getLiveAudioContext()).kind;
   const createSession =
     options.createSession ??
     (() => createBridgeSession({ instrument: "drumhaus" }));

--- a/apps/pulse/src/metronome.ts
+++ b/apps/pulse/src/metronome.ts
@@ -16,8 +16,10 @@
 import {
   beatMs,
   BEATS_PER_BAR,
+  contextClockAnchor,
   epochNowMs,
   epochToContextTime,
+  type ClockAnchorKind,
   type SessionState,
 } from "@haus/bridge";
 
@@ -46,7 +48,19 @@ interface Click {
   gain: GainNode;
 }
 
+/** Window slot for the anchor-kind diagnostic; read by the family e2e. */
+interface ClockAnchorDiagnostics {
+  __clockAnchorKind?: () => ClockAnchorKind;
+}
+
 function createMetronome(ctx: AudioContext): Metronome {
+  // Non-UI diagnostic hook: which branch anchors the epoch<->context mapping
+  // for the SAME context the clicks are scheduled on. The family e2e asserts
+  // the speaker-aligned "outputTimestamp" branch here - the currentTime
+  // fallback silently loses output-latency compensation (issues #425/#429).
+  (window as unknown as ClockAnchorDiagnostics).__clockAnchorKind = () =>
+    contextClockAnchor(ctx).kind;
+
   /** The grid currently being scheduled; null while stopped. */
   let grid: { startEpochMs: number; bpm: number } | null = null;
   /** Next absolute session beat index (counted from bar 0 beat 0). */

--- a/e2e/family/cross-app-timing.spec.ts
+++ b/e2e/family/cross-app-timing.spec.ts
@@ -17,9 +17,13 @@ import { expect, test, type BrowserContext, type Page } from "@playwright/test";
  *
  * Asserted for both start-from-drumhaus and start-from-pulse:
  * - at least MIN_ALIGNED_BEATS consecutive beats where the two apps'
- *   onsets agree within TOLERANCE_MS, and
+ *   onsets agree within TOLERANCE_MS,
  * - no drumhaus double-fire: no scheduled hit audibly ahead of the shared
- *   downbeat (the "misfire then restart" stutter of #425).
+ *   downbeat (the "misfire then restart" stutter of #425), and
+ * - both apps' epoch mappings anchored on the speaker-aligned
+ *   outputTimestamp branch, via each app's __clockAnchorKind diagnostic
+ *   (#429): the currentTime fallback silently loses output-latency
+ *   compensation.
  */
 
 /** Cross-app onset agreement tolerance. Musically tight, not sample-locked. */
@@ -51,6 +55,8 @@ declare global {
   interface Window {
     __onsets: CapturedOnset[];
     __sessionStates: CapturedState[];
+    /** App-registered diagnostic: which branch anchors its epoch mapping. */
+    __clockAnchorKind?: () => "outputTimestamp" | "currentTime";
   }
 }
 
@@ -258,6 +264,24 @@ function expectAligned(drumhaus: PageCapture, pulse: PageCapture): void {
   ).toEqual([]);
 }
 
+/**
+ * Assert each app's epoch mapping runs on the speaker-aligned
+ * outputTimestamp branch. The currentTime fallback silently drops
+ * output-latency compensation - the constant ~30ms error of #425 - so a
+ * regression here (e.g. the mapping fed a context without a usable
+ * getOutputTimestamp again) must fail loudly even if both apps happen to
+ * still align with each other. Queried after playback, when every context
+ * has produced output and the fallback would only mean degradation.
+ */
+async function expectSpeakerAnchored(...pages: Page[]): Promise<void> {
+  for (const page of pages) {
+    const kind = await page.evaluate(
+      () => window.__clockAnchorKind?.() ?? "missing",
+    );
+    expect(kind).toBe("outputTimestamp");
+  }
+}
+
 // --- scenarios ---
 
 test.describe("cross-app beat alignment", () => {
@@ -280,6 +304,7 @@ test.describe("cross-app beat alignment", () => {
     await drumhaus.waitForTimeout(PLAY_MS);
 
     expectAligned(await capture(drumhaus), await capture(pulse));
+    await expectSpeakerAnchored(drumhaus, pulse);
   });
 
   test("starting from pulse, both apps sound the same beats", async ({
@@ -297,5 +322,6 @@ test.describe("cross-app beat alignment", () => {
     await pulse.waitForTimeout(PLAY_MS);
 
     expectAligned(await capture(drumhaus), await capture(pulse));
+    await expectSpeakerAnchored(drumhaus, pulse);
   });
 });

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -109,6 +109,8 @@ The mapping anchors on `ctx.getOutputTimestamp()`, which pairs a context time wi
 Fallback: when `getOutputTimestamp` is unavailable (older WebKit) or returns zeros (a context that has not produced output yet, e.g. suspended), the anchor is `ctx.currentTime` sampled against the epoch clock directly.
 The fallback ignores output latency but stays within a few milliseconds, consistent with the library's contract below.
 
+The anchor itself is observable via `contextClockAnchor(ctx)`, whose `kind` (`"outputTimestamp"` or `"currentTime"`) names the branch taken - so instruments and tests can detect a mapping that silently degraded onto the fallback instead of discovering it by ear.
+
 ## Roles and election
 
 Conductor election uses the Web Locks API: every connected peer requests the `haus:conductor` lock and holds it for the session instance's lifetime once granted.

--- a/packages/bridge/src/__tests__/clock.test.ts
+++ b/packages/bridge/src/__tests__/clock.test.ts
@@ -12,6 +12,7 @@ import {
   beatMs,
   beatsAt,
   clampBpm,
+  contextClockAnchor,
   contextTimeToEpochMs,
   epochNowMs,
   epochToContextTime,
@@ -165,6 +166,41 @@ describe("AudioContext clock mapping", () => {
     };
     const epochNow = () => 10_000;
     expect(epochToContextTime(ctx, 10_500, epochNow)).toBeCloseTo(1.5, 9);
+  });
+
+  it("reports the outputTimestamp kind when the timestamp anchors", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 99,
+      getOutputTimestamp: () => ({ contextTime: 1.5, performanceTime: 2500 }),
+    };
+    const anchor = contextClockAnchor(ctx);
+    expect(anchor.kind).toBe("outputTimestamp");
+    expect(anchor.contextTimeS).toBe(1.5);
+    expect(anchor.epochMs).toBe(performance.timeOrigin + 2500);
+  });
+
+  it("reports the currentTime kind when getOutputTimestamp is unavailable", () => {
+    const ctx: BridgeAudioContext = { currentTime: 3 };
+    const anchor = contextClockAnchor(ctx, () => 50_000);
+    expect(anchor.kind).toBe("currentTime");
+    expect(anchor.contextTimeS).toBe(3);
+    expect(anchor.epochMs).toBe(50_000);
+  });
+
+  it("reports the currentTime kind on the zeros fallback (no output yet)", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 0.25,
+      getOutputTimestamp: () => ({ contextTime: 0, performanceTime: 0 }),
+    };
+    expect(contextClockAnchor(ctx, () => 10_000).kind).toBe("currentTime");
+  });
+
+  it("reports the currentTime kind on the empty-timestamp fallback", () => {
+    const ctx: BridgeAudioContext = {
+      currentTime: 1,
+      getOutputTimestamp: () => ({}),
+    };
+    expect(contextClockAnchor(ctx, () => 10_000).kind).toBe("currentTime");
   });
 
   it("round-trips epoch to context time and back", () => {

--- a/packages/bridge/src/clock.ts
+++ b/packages/bridge/src/clock.ts
@@ -104,9 +104,19 @@ interface BridgeAudioContext {
   };
 }
 
+/**
+ * Which clock source produced an anchor: "outputTimestamp" is the preferred
+ * speaker-aligned branch (output latency compensated); "currentTime" is the
+ * documented fallback, which loses output-latency compensation (audio lands
+ * late at the speaker by the context's whole output latency).
+ */
+type ClockAnchorKind = "outputTimestamp" | "currentTime";
+
 interface ClockAnchor {
   contextTimeS: number;
   epochMs: number;
+  /** The branch that produced this (contextTime, epoch) pair. */
+  kind: ClockAnchorKind;
 }
 
 /**
@@ -122,6 +132,11 @@ interface ClockAnchor {
  * directly. The fallback ignores output latency but keeps the mapping honest
  * to within a few milliseconds, consistent with the library's
  * musically-tight-not-sample-locked contract.
+ *
+ * The returned kind names the branch taken, so instruments and tests can
+ * observe a mapping that silently degraded onto the fallback (issue #429) -
+ * the ~30ms constant error of #425 was invisible precisely because nothing
+ * reported which branch anchored the mapping.
  */
 function contextClockAnchor(
   ctx: BridgeAudioContext,
@@ -137,9 +152,14 @@ function contextClockAnchor(
     return {
       contextTimeS: ts.contextTime,
       epochMs: performance.timeOrigin + ts.performanceTime,
+      kind: "outputTimestamp",
     };
   }
-  return { contextTimeS: ctx.currentTime, epochMs: epochNow() };
+  return {
+    contextTimeS: ctx.currentTime,
+    epochMs: epochNow(),
+    kind: "currentTime",
+  };
 }
 
 /**
@@ -172,10 +192,11 @@ export {
   beatsAt,
   BEATS_PER_BAR,
   clampBpm,
+  contextClockAnchor,
   contextTimeToEpochMs,
   epochNowMs,
   epochToContextTime,
   nextBarStartEpochMs,
   rebaseTempo,
 };
-export type { BridgeAudioContext };
+export type { BridgeAudioContext, ClockAnchor, ClockAnchorKind };

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -11,13 +11,14 @@ export {
   beatsAt,
   BEATS_PER_BAR,
   clampBpm,
+  contextClockAnchor,
   contextTimeToEpochMs,
   epochNowMs,
   epochToContextTime,
   nextBarStartEpochMs,
   rebaseTempo,
 } from "./clock";
-export type { BridgeAudioContext } from "./clock";
+export type { BridgeAudioContext, ClockAnchor, ClockAnchorKind } from "./clock";
 export { createConductorElection } from "./election";
 export type {
   ConductorElection,


### PR DESCRIPTION
Closes #429

## What

In #425 the failure was silent: drumhaus's context (a standardized-audio-context wrapper without getOutputTimestamp) dropped the epoch mapping onto the currentTime fallback, losing output-latency compensation with nothing reporting it. This makes that failure mode observable.

- packages/bridge/src/clock.ts: the anchor returned by contextClockAnchor gains a kind - "outputTimestamp" (speaker-aligned, latency compensated) or "currentTime" (documented fallback, compensation lost). contextClockAnchor and the ClockAnchor/ClockAnchorKind types are now exported. The mapping math (epochToContextTime / contextTimeToEpochMs) is byte-for-byte unchanged.
- README: one paragraph documenting the observable anchor.

## Truth-bearing diagnostics + e2e guard

The e2e assertion is only worth having if the kind reflects the context each app actually maps with, so each app registers a tiny non-UI window hook bound to exactly that context:

- drumhaus (session-adapter): __clockAnchorKind samples engine.getLiveAudioContext() - the native context reached through tone-internals' getNativeAudioContext unwrap, the same reference startAlignedToGrid maps with. If the unwrap ever breaks (Tone internals change shape), the mapping degrades to the wrapper and this reports "currentTime".
- pulse (metronome): same hook bound to the metronome's own AudioContext.

e2e/family/cross-app-timing.spec.ts now asserts, after playback in both scenarios, that both pages report "outputTimestamp" (a missing hook fails as "missing", so the assertion cannot pass vacuously). This catches the #425 regression class even when both apps still align with each other because they share the same uncompensated error.

No UI changes anywhere - surfacing degraded sync to users is a separate product decision.

## Tests

- Unit: contextClockAnchor kind for both branches, plus the zeros and empty-timestamp fallbacks (packages/bridge clock.test.ts).
- e2e: speaker-anchored assertion added to both cross-app-timing scenarios.

## Gates (all green)

- pnpm format:check, pnpm lint, pnpm test (64 bridge tests; 805 drumhaus tests)
- pnpm --filter drumhaus build (with and without VITE_ENABLE_LINK=true)
- pnpm --filter pulse build
- PORT=4447 pnpm test:e2e:family - 8/8 passed (4446 was held by a long-running family server; the config's PORT override handled it)