### PR TITLE
fix(session): smooth adapter round-trips for drags, stops, and late starts

### DIFF
--- a/apps/drumhaus/src/core/session/bpm-gesture.ts
+++ b/apps/drumhaus/src/core/session/bpm-gesture.ts
@@ -1,0 +1,46 @@
+/**
+ * Whether a local continuous bpm gesture (a knob drag or an open value
+ * edit) is in progress.
+ *
+ * A leaf module like link-state.ts, so the transport controls can report
+ * their param-control gesture brackets without importing the session
+ * adapter (and without pulling the session graph into builds that compile
+ * LINK out). The transport UI writes; the session adapter reads.
+ *
+ * The consumer that motivates this: while a follower drags the bpm knob,
+ * every conductor state broadcast carries the last-ACKED tempo, so
+ * applying it inbound would snap the store back per broadcast until the
+ * final intent lands - the drag-fights-acks jitter of issue #424. The
+ * adapter suppresses inbound bpm while a gesture is open and observes the
+ * gesture end to reconcile.
+ */
+
+let depth = 0;
+const endListeners = new Set<() => void>();
+
+/** Bracket open. Callers must pair every begin with exactly one end. */
+function beginBpmGesture(): void {
+  depth += 1;
+}
+
+function endBpmGesture(): void {
+  if (depth === 0) return;
+  depth -= 1;
+  if (depth === 0) {
+    endListeners.forEach((listener) => listener());
+  }
+}
+
+function isBpmGestureActive(): boolean {
+  return depth > 0;
+}
+
+/** Observe the last open gesture ending; returns an unsubscriber. */
+function onBpmGestureEnd(listener: () => void): () => void {
+  endListeners.add(listener);
+  return () => {
+    endListeners.delete(listener);
+  };
+}
+
+export { beginBpmGesture, endBpmGesture, isBpmGestureActive, onBpmGestureEnd };

--- a/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.browser.test.ts
@@ -14,7 +14,9 @@
 
 import {
   createSession as createBridgeSession,
+  LOCK_NAME,
   memoryHub,
+  PROTOCOL_VERSION,
   START_LEAD_MS,
   type BridgeMessage,
   type BridgeTransport,
@@ -25,6 +27,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import {
+  beginBpmGesture,
+  endBpmGesture,
+  isBpmGestureActive,
+} from "./bpm-gesture";
 import { isSessionLinked } from "./link-state";
 import {
   createSessionAdapter,
@@ -115,6 +122,12 @@ interface FakeEngine extends SessionEngine {
   playCalls: ({ atContextTime?: number } | undefined)[];
   stopCalls: number;
   contextTime: number;
+  /**
+   * When true, play() returns a promise the test settles by hand via
+   * pendingPlays - for exercising late start rejections (#424).
+   */
+  manualPlay: boolean;
+  pendingPlays: { resolve: () => void; reject: (reason?: unknown) => void }[];
   emitVariation(variation: number): void;
 }
 
@@ -124,9 +137,14 @@ function createFakeEngine(): FakeEngine {
     playCalls: [],
     stopCalls: 0,
     contextTime: 5,
+    manualPlay: false,
+    pendingPlays: [],
     play(options) {
       engine.playCalls.push(options);
-      return Promise.resolve();
+      if (!engine.manualPlay) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        engine.pendingPlays.push({ resolve, reject });
+      });
     },
     stop() {
       engine.stopCalls += 1;
@@ -208,6 +226,8 @@ function createRig(locks: LockManager = memoryLocks()): Rig {
 beforeEach(() => {
   useTransportStore.setState({ bpm: 100, isPlaying: false });
   usePatternStore.setState({ variation: 0, chainEnabled: false });
+  // A test that failed mid-gesture must not leak an open bracket.
+  while (isBpmGestureActive()) endBpmGesture();
 });
 
 afterEach(() => {
@@ -581,5 +601,258 @@ describe("re-link", () => {
     expect(rig.adapter.controller.getSnapshot().isConductor).toBe(true);
     expect(rig.adapterSession().state.bpm).toBe(95);
     expect(useTransportStore.getState().bpm).toBe(95);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Session adapter follow-ups (#424)
+// -----------------------------------------------------------------------------
+
+describe("follower bpm drag (#424)", () => {
+  it("inbound acks do not snap the store back during a local drag", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    // Same tempo as the local store so linking itself changes nothing.
+    conductor.setBpm(100);
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(false);
+
+    // Record every store bpm write, as the knob would observe them.
+    const bpmWrites: number[] = [];
+    const unsubscribe = useTransportStore.subscribe((state, prev) => {
+      if (state.bpm !== prev.bpm) bpmWrites.push(state.bpm);
+    });
+
+    // A continuous drag (bracketed by the knob's gesture handlers): two
+    // moves land before the first intent's ack returns. Each conductor
+    // state broadcast would snap the store back to the last-acked value
+    // until the final intent lands.
+    beginBpmGesture();
+    useTransportStore.getState().setBpm(120);
+    useTransportStore.getState().setBpm(125);
+    await flushAll();
+    endBpmGesture();
+    await flushAll();
+
+    unsubscribe();
+    // No snap-back: the local drag values are the only store writes.
+    expect(bpmWrites).toEqual([120, 125]);
+    expect(useTransportStore.getState().bpm).toBe(125);
+    // And the session converged on the drag's final value.
+    expect(conductor.state.bpm).toBe(125);
+  });
+
+  it("a suppressed foreign bpm is adopted when a gesture that posted nothing ends", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.setBpm(100);
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    // A grab that never moves: the gesture opens, a foreign bpm change
+    // arrives, and no outbound intent is ever posted.
+    beginBpmGesture();
+    conductor.setBpm(140);
+    await flushAll();
+    expect(useTransportStore.getState().bpm).toBe(100);
+
+    // Gesture end reconciles from the session.
+    endBpmGesture();
+    expect(useTransportStore.getState().bpm).toBe(140);
+    // And without echoing an intent back (the conductor stays at 140).
+    await flushAll();
+    expect(conductor.state.bpm).toBe(140);
+  });
+
+  it("inbound bpm applies normally once the gesture is over", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.setBpm(100);
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+
+    beginBpmGesture();
+    endBpmGesture();
+
+    conductor.setBpm(90);
+    await flushAll();
+    expect(useTransportStore.getState().bpm).toBe(90);
+  });
+});
+
+describe("stop-echo window (#424)", () => {
+  /** Post a conductor state broadcast onto the wire by hand. */
+  function postState(
+    wire: BridgeTransport,
+    state: {
+      rev: number;
+      bpm: number;
+      playing: boolean;
+      startEpochMs: number | null;
+      scene: 0 | 1 | 2 | 3;
+    },
+  ): void {
+    wire.post({
+      v: PROTOCOL_VERSION,
+      from: "fake-conductor",
+      type: "state",
+      state,
+    });
+  }
+
+  it("an interleaved stopped-state broadcast does not stop the engine while a local play intent is in flight", async () => {
+    // Hold the conductor lock externally so the adapter stays a follower
+    // whose intents the test answers by hand - the only way to hold the
+    // round-trip open across the adapter's deferred playback sync.
+    const locks = memoryLocks();
+    void locks.request(LOCK_NAME, {}, () => new Promise<void>(() => {}));
+    await flushMicrotasks();
+
+    const rig = createRig(locks);
+    const wire = rig.createWire();
+    const intents: BridgeMessage[] = [];
+    wire.subscribe((data) => {
+      const message = data as BridgeMessage;
+      if (message.type === "intent") intents.push(message);
+    });
+
+    rig.adapter.link();
+    await flushMicrotasks();
+    expect(rig.adapter.controller.getSnapshot().isConductor).toBe(false);
+
+    // The fake conductor speaks: a stopped session at rev 1.
+    postState(wire, {
+      rev: 1,
+      bpm: 100,
+      playing: false,
+      startEpochMs: null,
+      scene: 0,
+    });
+    await flushAll();
+
+    // The user taps play: togglePlay flips isPlaying synchronously and the
+    // adapter posts a play intent (the engine start waits for the grid).
+    useTransportStore.setState({ isPlaying: true });
+    await flushMicrotasks();
+    expect(
+      intents.some(
+        (message) =>
+          message.type === "intent" && message.intent.kind === "play",
+      ),
+    ).toBe(true);
+
+    // An unrelated stopped-state broadcast interleaves before the play
+    // intent's ack (e.g. a bpm change applied just ahead of it).
+    postState(wire, {
+      rev: 2,
+      bpm: 100,
+      playing: false,
+      startEpochMs: null,
+      scene: 0,
+    });
+    await flushAll();
+
+    // The echo must not stop the engine mid round-trip.
+    expect(rig.engine.stopCalls).toBe(0);
+
+    // The ack lands: playback starts aligned to the shared grid.
+    postState(wire, {
+      rev: 3,
+      bpm: 100,
+      playing: true,
+      startEpochMs: rig.nowMs.value + START_LEAD_MS,
+      scene: 0,
+    });
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(1);
+
+    // A genuine stop afterwards still stops the engine.
+    postState(wire, {
+      rev: 4,
+      bpm: 100,
+      playing: false,
+      startEpochMs: null,
+      scene: 0,
+    });
+    await flushAll();
+    expect(rig.engine.stopCalls).toBe(1);
+  });
+});
+
+describe("late start rejection (#424)", () => {
+  it("a rejection from a superseded grid does not force a redundant realign restart", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.setBpm(100);
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+    rig.engine.manualPlay = true;
+
+    // Grid A: the start is issued but its promise stays pending (a
+    // suspended context deciding whether it can start).
+    conductor.play();
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(1);
+    const gridAStart = rig.engine.pendingPlays[0];
+
+    conductor.stop();
+    await flushAll();
+    expect(rig.engine.stopCalls).toBe(1);
+
+    // Grid B at a different origin; this start succeeds.
+    rig.nowMs.value += 10_000;
+    conductor.play();
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(2);
+    rig.engine.pendingPlays[1].resolve();
+    // The engine reports the start; the bridge mirror would set this.
+    useTransportStore.setState({ isPlaying: true });
+    await flushAll();
+
+    // Grid A's start finally rejects - long after grid B took over.
+    gridAStart.reject(new Error("context could not start"));
+    await flushAll();
+
+    // A state broadcast carrying the same grid B (a scene change) must not
+    // trigger a realign restart of playback that is already on grid B.
+    conductor.setScene(1);
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(2);
+  });
+
+  it("a rejection of the live start attempt still clears the grid so a rebroadcast retries", async () => {
+    const rig = createRig();
+    const conductor = rig.createPeer();
+    conductor.setBpm(100);
+    conductor.connect();
+    await flushMicrotasks();
+
+    rig.adapter.link();
+    await flushMicrotasks();
+    rig.engine.manualPlay = true;
+
+    conductor.play();
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(1);
+    rig.engine.pendingPlays[0].reject(new Error("context could not start"));
+    await flushAll();
+
+    // The next broadcast of the same grid retries the aligned start.
+    conductor.setScene(1);
+    await flushAll();
+    expect(rig.engine.playCalls).toHaveLength(2);
   });
 });

--- a/apps/drumhaus/src/core/session/session-adapter.ts
+++ b/apps/drumhaus/src/core/session/session-adapter.ts
@@ -34,6 +34,12 @@
  * restart on the boundary) happens only when adopting a grid this tab is
  * not already playing on. Same-machine context drift is negligible in v1;
  * there is no correction loop.
+ *
+ * Round-trip smoothing (#424): inbound bpm is held while a local bpm
+ * gesture is open (bpm-gesture.ts) so conductor acks cannot fight an
+ * active drag, and the follower stop path is gated while a local play
+ * intent is in flight so a stopped-state broadcast interleaved into the
+ * round-trip cannot stop-then-restart the engine.
  */
 
 import {
@@ -54,6 +60,7 @@ import { getAudioEngine } from "@/core/audio/engine";
 import { clampVariationId } from "@/core/audio/engine/pattern-types";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
+import { isBpmGestureActive, onBpmGestureEnd } from "./bpm-gesture";
 import { setSessionLinked } from "./link-state";
 
 /**
@@ -162,6 +169,18 @@ function createSessionAdapter(
   /** Grid the local transport is (or is being) aligned to; null while the
    * local engine is not playing on a shared grid. */
   let appliedGrid: SharedGrid | null = null;
+  /** Monotonic id of the latest aligned start issued; a superseded start's
+   * late rejection must not clear the grid a newer start applied (#424). */
+  let startAttempt = 0;
+  /** True while a locally-posted play intent awaits its ack (an inbound
+   * playing state). togglePlay flips isPlaying before the round-trip, so
+   * an interleaved stopped-state broadcast would otherwise momentarily
+   * stop (then restart) the engine - the stop-echo window of #424. */
+  let playIntentInFlight = false;
+  /** An inbound bpm arrived while a local bpm gesture was open (#424). */
+  let inboundBpmSuppressed = false;
+  /** The open bpm gesture posted at least one outbound bpm intent. */
+  let bpmPostedDuringGesture = false;
   /** Latest inbound playback target, coalesced into one deferred sync.
    * undefined = nothing pending; null = stop. */
   let pendingGrid: SharedGrid | null | undefined;
@@ -173,6 +192,7 @@ function createSessionAdapter(
   // --- Playback alignment (session grid -> engine) ---
 
   function startAlignedToGrid(grid: SharedGrid): void {
+    const attempt = ++startAttempt;
     // During the start lead window the "next bar boundary" is bar 0's
     // downbeat itself, so fresh starts and mid-playback joins share one
     // formula. Drumhaus patterns loop one bar, so starting at a bar
@@ -196,7 +216,12 @@ function createSessionAdapter(
     void engine.play({ atContextTime }).catch(() => {
       // The context could not start (suspended with no usable gesture):
       // stay stopped locally and let a later state or user gesture retry.
-      appliedGrid = null;
+      // Only the live attempt may clear: a superseded start's late
+      // rejection would otherwise wipe the grid a newer start already
+      // applied and force one redundant realign restart (#424).
+      if (attempt === startAttempt) {
+        appliedGrid = null;
+      }
     });
   }
 
@@ -205,8 +230,15 @@ function createSessionAdapter(
 
     if (grid === null) {
       // Follower stop is immediate. Skipped when already idle so a stop
-      // echo can never cancel an in-flight user play().
-      if (useTransportStore.getState().isPlaying || appliedGrid !== null) {
+      // echo can never cancel an in-flight user play(), and skipped while
+      // a local play intent is in flight: isPlaying is already optimistic
+      // then, so a stopped-state broadcast interleaved into the round-trip
+      // would momentarily stop (then restart) the engine (#424). The
+      // intent's ack - or a local stop - resolves the flag either way.
+      if (
+        !playIntentInFlight &&
+        (useTransportStore.getState().isPlaying || appliedGrid !== null)
+      ) {
         engine.stop();
       }
       appliedGrid = null;
@@ -255,13 +287,26 @@ function createSessionAdapter(
     const snapshot = controller.getSnapshot();
     if (!snapshot.linked) return;
 
+    // Playing state (from any peer) acknowledges a local play intent.
+    if (snapshot.state.playing) playIntentInFlight = false;
+
     applying = true;
     try {
       const transport = useTransportStore.getState();
       if (transport.bpm !== snapshot.state.bpm) {
-        // setBpm also pushes engine.setTempo, so a playing transport
-        // glides onto a rebased grid within the same synchronous dispatch.
-        transport.setBpm(snapshot.state.bpm);
+        if (isBpmGestureActive()) {
+          // A local bpm gesture is open: the local value is authoritative
+          // and every move already posts an outbound intent, so applying
+          // the conductor's lagging acks here would snap the knob back on
+          // every broadcast - the follower drag jitter of #424. The
+          // gesture-end handler reconciles.
+          inboundBpmSuppressed = true;
+        } else {
+          // setBpm also pushes engine.setTempo, so a playing transport
+          // glides onto a rebased grid within the same synchronous
+          // dispatch.
+          transport.setBpm(snapshot.state.bpm);
+        }
       }
       const pattern = usePatternStore.getState();
       if (pattern.variation !== snapshot.state.scene) {
@@ -281,7 +326,30 @@ function createSessionAdapter(
   function handleBpmChange(bpm: number): void {
     if (applying || !linked()) return;
     if (controller.getSnapshot().state.bpm === bpm) return;
+    if (isBpmGestureActive()) bpmPostedDuringGesture = true;
     controller.setBpm(bpm);
+  }
+
+  /**
+   * Reconcile after a bpm gesture: a gesture that posted intents converges
+   * through its final ack (resyncing here would snap to a stale value), so
+   * resync from the session only when a foreign bpm change was suppressed
+   * by a gesture that itself sent nothing (a grab that never moved).
+   */
+  function handleBpmGestureEnd(): void {
+    const suppressed = inboundBpmSuppressed;
+    const posted = bpmPostedDuringGesture;
+    inboundBpmSuppressed = false;
+    bpmPostedDuringGesture = false;
+    if (!linked() || !suppressed || posted) return;
+    applying = true;
+    try {
+      const transport = useTransportStore.getState();
+      const bpm = controller.getSnapshot().state.bpm;
+      if (transport.bpm !== bpm) transport.setBpm(bpm);
+    } finally {
+      applying = false;
+    }
   }
 
   function handleVariationChange(variation: number): void {
@@ -305,8 +373,10 @@ function createSessionAdapter(
       return;
     }
     if (isPlaying) {
+      playIntentInFlight = true;
       controller.play();
     } else {
+      playIntentInFlight = false;
       controller.stop();
     }
   }
@@ -331,6 +401,9 @@ function createSessionAdapter(
     // comment at the top of the factory.
     swapInFreshController();
     appliedGrid = null;
+    playIntentInFlight = false;
+    inboundBpmSuppressed = false;
+    bpmPostedDuringGesture = false;
     // Published for the transport store: while linked, togglePlay leaves
     // starting the engine to this adapter's grid-aligned path (#425).
     setSessionLinked(true);
@@ -380,6 +453,7 @@ function createSessionAdapter(
     unsubscribers.push(
       engine.onPlaybackVariationChange(handlePlaybackVariationChange),
     );
+    unsubscribers.push(onBpmGestureEnd(handleBpmGestureEnd));
   }
 
   function unlink(): void {
@@ -393,6 +467,9 @@ function createSessionAdapter(
     unsubscribers = [];
     controller.disconnect();
     appliedGrid = null;
+    playIntentInFlight = false;
+    inboundBpmSuppressed = false;
+    bpmPostedDuringGesture = false;
     setSessionLinked(false);
     // Fully local from here: playback (if any) keeps running untouched.
   }

--- a/apps/drumhaus/src/features/transport/components/tempo-controls-screen.tsx
+++ b/apps/drumhaus/src/features/transport/components/tempo-controls-screen.tsx
@@ -5,6 +5,7 @@ import { historyGestureHandlers } from "@/features/preset/history/history";
 import { VariationBadge } from "@/features/sequencer/components/variation-badge";
 import { usePatternStore } from "@/features/sequencer/store/use-pattern-store";
 import { VARIATION_LABELS } from "@/features/sequencer/types/sequencer";
+import { bpmGestureHandlers } from "@/features/transport/lib/bpm-gesture-handlers";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
 import { ScreenBar } from "@/layout/screen-bar";
 import { cn } from "@/shared/lib/utils";
@@ -34,7 +35,7 @@ function TempoControlsScreen() {
           ch, tabular digits) so neighbors don't shift while dragging. */}
       <div className="flex w-full items-center justify-between gap-1 whitespace-nowrap tabular-nums">
         <ValueField
-          {...historyGestureHandlers}
+          {...bpmGestureHandlers}
           descriptor={transportBpmDescriptor}
           value={bpm}
           onChange={setBpm}

--- a/apps/drumhaus/src/features/transport/components/tempo-controls.tsx
+++ b/apps/drumhaus/src/features/transport/components/tempo-controls.tsx
@@ -11,6 +11,7 @@ import { ArrowDownToDot, Music3, Timer } from "lucide-react";
 
 import { TRANSPORT_BPM_RANGE } from "@/core/audio/engine/constants";
 import { historyGestureHandlers } from "@/features/preset/history/history";
+import { bpmGestureHandlers } from "@/features/transport/lib/bpm-gesture-handlers";
 import { useTransportStore } from "@/features/transport/store/use-transport-store";
 import { buttonActive } from "@/shared/lib/button-active";
 import { clamp, cn } from "@/shared/lib/utils";
@@ -82,7 +83,7 @@ const TempoControls = () => {
     <div className="mx-auto flex w-5/6 flex-col items-center justify-center gap-4 px-4">
       {mode === "bpm" ? (
         <RotaryKnob
-          {...historyGestureHandlers}
+          {...bpmGestureHandlers}
           descriptor={transportBpmDescriptor}
           value={bpm}
           onChange={setBpm}

--- a/apps/drumhaus/src/features/transport/lib/bpm-gesture-handlers.ts
+++ b/apps/drumhaus/src/features/transport/lib/bpm-gesture-handlers.ts
@@ -1,0 +1,24 @@
+import { beginBpmGesture, endBpmGesture } from "@/core/session/bpm-gesture";
+import {
+  beginHistoryGesture,
+  endHistoryGesture,
+} from "@/features/preset/history/history";
+
+/**
+ * Gesture brackets for the bpm controls: one undo unit (history) plus the
+ * session layer's local-bpm-gesture signal, which keeps inbound session
+ * tempo from fighting an open drag on a linked follower (#424). Spread
+ * into a param control exactly like historyGestureHandlers.
+ */
+const bpmGestureHandlers = {
+  onGestureStart: () => {
+    beginHistoryGesture();
+    beginBpmGesture();
+  },
+  onGestureEnd: () => {
+    endHistoryGesture();
+    endBpmGesture();
+  },
+} as const;
+
+export { bpmGestureHandlers };


### PR DESCRIPTION
Closes #424. The three nit-grade session-adapter findings from the #423 review, each reproduced deterministically before fixing.

## 1. Follower knob drag fights intent acks

While a follower drags the bpm knob, every conductor state broadcast carries the last-acked tempo, and applying it inbound snapped the store back per broadcast until the final intent landed.

Reproduced in the adapter's browser suite (real bridge session over memoryHub, real conductor peer): two drag moves before the first ack returns produced store writes `[120, 125, 120, 125]` - the snap back to 120 mid-drag.

Fix: a new leaf module `core/session/bpm-gesture.ts` (same shape as `link-state.ts`) carries the param-control gesture brackets from the two bpm controls to the adapter, which holds inbound bpm while a gesture is open. Reconciliation at gesture end: a gesture that posted intents converges through its final ack; a gesture that posted nothing (a grab that never moved) adopts the suppressed foreign tempo immediately. The knob and value field consume param-control's existing public `onGestureStart`/`onGestureEnd` props - no package internals touched, no styling touched (prop spread swap only).

## 2. Stop-echo window

`togglePlay` flips `isPlaying` synchronously before the play intent round-trips, so a stopped-state broadcast interleaved into that window passed the stop guard and stopped (then restarted) the engine.

Reproduced by holding the conductor lock externally and scripting the conductor by hand on a raw wire (the only way to hold the round-trip open across the adapter's deferred playback sync): the interleaved stopped broadcast produced `engine.stop()` during the round-trip. Fix: the follower stop path is gated while a locally posted play intent is in flight; the flag resolves on any inbound playing state, on a local stop, and across link cycles. A genuine stop after the ack still stops the engine (covered).

## 3. Stale grid marker on late start rejection

`startAlignedToGrid`'s rejection handler cleared `appliedGrid` unconditionally, so a late rejection from grid A after grid B had applied wiped B's marker and the next state broadcast forced one redundant realign restart.

Reproduced with a manual-settle fake engine: grid A start left pending, grid B started and resolved, then A rejected - a subsequent scene-change broadcast restarted playback (3 play calls instead of 2). Fix: a monotonic start-attempt id; only the live attempt's rejection clears the marker. A companion test pins that a rejection of the live attempt still clears it so the next broadcast retries.

## Mid-playback-join pending state (not implemented)

The cosmetic point (isPlaying reads true during the up-to-one-bar pre-boundary silence on a mid-playback join) is left as is: surfacing it needs new adapter -> store -> UI state plumbing, which does not fall out of these fixes naturally, and the UI belongs elsewhere.

## Gates

- `pnpm format:check`, `pnpm lint`, `pnpm test` (all workspace projects; drumhaus 807 passed): green
- drumhaus build, both flavors (default and `VITE_ENABLE_LINK=true`): green
- pulse build: green
- drumhaus e2e (34 passed, `PORT=4544`): green
- family e2e (8 passed, `PORT=4546`; 4446 was busy, config's PORT override used): green

All three regression tests fail on main and pass here.