### PR TITLE
fix(param-control): close gestures on unmount

### DIFF
--- a/packages/param-control/src/__tests__/rotary-knob.browser.test.ts
+++ b/packages/param-control/src/__tests__/rotary-knob.browser.test.ts
@@ -190,6 +190,19 @@ describe("RotaryKnob interactions (canonical-only public API)", () => {
     expect(recorded.gestureEnds).toBe(1);
   });
 
+  it("ends an active gesture when the control unmounts (#438)", async () => {
+    await mount(50);
+    await pointer("pointerdown", 100);
+    await pointer("pointermove", 90);
+    expect(recorded.gestureStarts).toBe(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+
+    expect(recorded.gestureEnds).toBe(1);
+  });
+
   it("ends the drag when the primary button releases mid-chord (#402)", async () => {
     await mount(50);
     await pointer("pointerdown", 100);

--- a/packages/param-control/src/hooks/use-param-control.ts
+++ b/packages/param-control/src/hooks/use-param-control.ts
@@ -386,6 +386,7 @@ function useParamControl<T>({
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onCancel);
       window.removeEventListener("contextmenu", onContextMenu);
+      endGesture(true);
     };
   }, [tracking, handlePointerMove, endGesture]);
 


### PR DESCRIPTION
# fix(param-control): close gestures on unmount

## Summary

Unmounting a parameter control during an active drag removed its window listeners without ending the gesture, leaving downstream gesture brackets open. This change closes the gesture as part of the listener-effect cleanup, and adds browser coverage for unmounting an active rotary-knob drag.

Fixes #438

## Changes

- End an active parameter-control gesture during window-listener cleanup.
- Cover unmounting a live rotary-knob drag in the browser interaction suite.

## Testing

- `sandbox-run "corepack pnpm install --frozen-lockfile && corepack pnpm exec playwright install --with-deps chromium && corepack pnpm --filter @haus/param-control test"` — passed: 5 test files, 67 tests.
- `sandbox-run "corepack pnpm install --frozen-lockfile && corepack pnpm --filter @haus/param-control build"` — passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
